### PR TITLE
Fixed Duplicated Answers and double call to import polls

### DIFF
--- a/src/Eras.Application/Features/Answers/Commands/CreateAnswerList/CreateAnswerListCommandHandler.cs
+++ b/src/Eras.Application/Features/Answers/Commands/CreateAnswerList/CreateAnswerListCommandHandler.cs
@@ -1,15 +1,10 @@
 ﻿using Eras.Application.Contracts.Persistence;
-using Eras.Application.Features.Answers.Commands.CreateAnswer;
 using Eras.Application.Mappers;
 using Eras.Application.Models;
 using Eras.Domain.Entities;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Eras.Application.Features.Answers.Commands.CreateAnswerList
 {
@@ -33,6 +28,16 @@ namespace Eras.Application.Features.Answers.Commands.CreateAnswerList
                 await _answerRepository.SaveManyAnswersAsync(answers);
 
                 return new CreateComandResponse<List<Answer>>(answers, 1, "Success", true);
+            }
+            catch (DbUpdateException ex)
+            {
+                if (ex.InnerException!=null)
+                {
+                    _logger.LogError(ex.InnerException.Message, "Create error on Answer");
+                }
+                else
+                    _logger.LogError(ex.Message, "Create error on Answer");
+                return new CreateComandResponse<List<Answer>>(null, 0, "Error", false);
             }
             catch (Exception ex)
             {

--- a/src/Eras.Infrastructure/External/CosmicLatteClient/CosmicLatteAPIService.cs
+++ b/src/Eras.Infrastructure/External/CosmicLatteClient/CosmicLatteAPIService.cs
@@ -58,7 +58,6 @@ namespace Eras.Infrastructure.External.CosmicLatteClient
         {
             try
             {
-                CreateComandResponse<CreatedPollDTO> createdPollResponse = await _pollOrchestratorService.ImportPollInstances(pollsDtos);
                 CreateComandResponse<CreatedPollDTO> createdPoll = await _pollOrchestratorService.ImportPollInstances(pollsDtos);
                 return createdPoll.Entity;
             }

--- a/src/Eras.Infrastructure/External/CosmicLatteClient/CosmicLatteAPIService.cs
+++ b/src/Eras.Infrastructure/External/CosmicLatteClient/CosmicLatteAPIService.cs
@@ -110,7 +110,6 @@ namespace Eras.Infrastructure.External.CosmicLatteClient
                 // At this point we have created a huge json with a lot of duplicate information, it makes no sense.
                 // We should redesign the next layer so that this transfer of duplicate information is not required.
                 CreateComandResponse<Poll> createdPollResponse = await _pollOrchestratorService.ImportPollInstances(pollsDtos);
-                await _pollOrchestratorService.ImportPollInstances(pollsDtos);
                 return pollsDtos;
             }
             catch (Exception e)

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Configurations/AnswerConfiguration.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Configurations/AnswerConfiguration.cs
@@ -12,6 +12,7 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Configurations
 
             ConfigureColumns(builder);
             ConfigureRelationShips(builder);
+            ConfigureConstraints(builder);
             AuditConfiguration.Configure(builder);
         }
 
@@ -42,6 +43,12 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Configurations
                 .WithMany(pollVariable => pollVariable.Answers)
                 .HasForeignKey(answer => answer.PollVariableId)
                 .OnDelete(DeleteBehavior.Cascade);
+        }
+
+        private void ConfigureConstraints(EntityTypeBuilder<AnswerEntity> builder)
+        {
+            builder.HasAlternateKey(answer => new { answer.PollInstanceId, answer.PollVariableId, answer.AnswerText })
+                .HasName("Unique_PollInstanceId_PollVariableId_AnswerText");
         }
     }
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20250306135843_unique-anwers.Designer.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20250306135843_unique-anwers.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Eras.Infrastructure.Persistence.PostgreSQL;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250306135843_unique-anwers")]
+    partial class uniqueanwers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20250306135843_unique-anwers.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20250306135843_unique-anwers.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Eras.Infrastructure.Persistence.PostgreSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class uniqueanwers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_answers_poll_instance_id",
+                table: "answers");
+
+            migrationBuilder.AddUniqueConstraint(
+                name: "Unique_PollInstanceId_PollVariableId_AnswerText",
+                table: "answers",
+                columns: new[] { "poll_instance_id", "poll_variable_id", "answer_text" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropUniqueConstraint(
+                name: "Unique_PollInstanceId_PollVariableId_AnswerText",
+                table: "answers");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_answers_poll_instance_id",
+                table: "answers",
+                column: "poll_instance_id");
+        }
+    }
+}

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AnswerRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AnswerRepository.cs
@@ -56,7 +56,7 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
             }
             catch (DbUpdateException ex)
             {
-                Console.WriteLine($"Error al guardar los registros: {ex.Message}");
+                Console.WriteLine($"Error storing answer: {ex.Message}");
             }
         }
     }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AnswerRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AnswerRepository.cs
@@ -6,7 +6,8 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
 {
-    public class AnswerRepository(AppDbContext context) : BaseRepository<Answer, AnswerEntity>(context, AnswerMapper.ToDomain, AnswerMapper.ToPersistence), IAnswerRepository
+    public class AnswerRepository(AppDbContext context) : BaseRepository<Answer, AnswerEntity>
+        (context, AnswerMapper.ToDomain, AnswerMapper.ToPersistence), IAnswerRepository
     {
         public async Task<List<Answer>?> GetByStudentIdAsync(string uuid)
         {
@@ -42,8 +43,21 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
         }
         public async Task SaveManyAnswersAsync(List<Answer> answers)
         {
-            await _context.Answers.AddRangeAsync(answers.Select(ans => ans.ToPersistence()));
-            var result =  await _context.SaveChangesAsync();
+            using var transaction = await _context.Database.BeginTransactionAsync();
+            try
+            {
+                foreach (var ans in answers)
+                {
+                    await _context.Answers.AddAsync(ans.ToPersistence());
+                }
+
+                await _context.SaveChangesAsync();
+                await transaction.CommitAsync();
+            }
+            catch (DbUpdateException ex)
+            {
+                Console.WriteLine($"Error al guardar los registros: {ex.Message}");
+            }
         }
     }
 }

--- a/test/Eras.Application.Tests/Features/Components/Commands/CreateComponentCommandHandlerTests.cs
+++ b/test/Eras.Application.Tests/Features/Components/Commands/CreateComponentCommandHandlerTests.cs
@@ -16,13 +16,13 @@ using Moq;
 
 namespace Eras.Application.Tests.Features.Answers.Commands
 {
-    public class CreateAnswerCommandHandlerTests
+    public class CreateComponentCommandHandlerTests
     {
         private readonly Mock<IComponentRepository> _mockComponentRepository;
         private readonly Mock<ILogger<CreateComponentCommandHandler>> _mockLogger;
         private readonly CreateComponentCommandHandler _handler;
 
-        public CreateAnswerCommandHandlerTests()
+        public CreateComponentCommandHandlerTests()
         {
             _mockComponentRepository = new Mock<IComponentRepository>();
             _mockLogger = new Mock<ILogger<CreateComponentCommandHandler>>();
@@ -34,10 +34,10 @@ namespace Eras.Application.Tests.Features.Answers.Commands
         {
             var newComponentDto = new ComponentDTO() { Name= "newComponent" };
             var command = new CreateComponentCommand { Component = newComponentDto };
-            var newPoll = newComponentDto.ToDomain;
+            var newComponent = newComponentDto.ToDomain;
 
             _mockComponentRepository.Setup(repo => repo.AddAsync(It.IsAny<Component>()))
-                .ReturnsAsync(newPoll);
+                .ReturnsAsync(newComponent);
 
             var result = await _handler.Handle(command, CancellationToken.None);
 


### PR DESCRIPTION
## Description

- Added constraint on answers and created new migration with this change
- Change repository answer save method

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues

https://github.com/JU-DEV-Bootcamps/ERAS-BE/issues/75

