### PR TITLE
Example enabling authorization with keycloak by bearer token

### DIFF
--- a/src/Eras.Api/Controllers/CohortsController.cs
+++ b/src/Eras.Api/Controllers/CohortsController.cs
@@ -1,10 +1,13 @@
 ﻿﻿using Eras.Application.Features.Cohort.Queries;
 using MediatR;
+
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Eras.Api.Controllers
 {
     [ApiController]
+    [Authorize]
     [Route("api/v1/[controller]")]
     public class CohortsController : ControllerBase
     {

--- a/src/Eras.Api/Controllers/CosmicLatteController.cs
+++ b/src/Eras.Api/Controllers/CosmicLatteController.cs
@@ -1,17 +1,14 @@
-﻿using Eras.Application.Contracts.Infrastructure;
-using Eras.Application.Dtos;
-using Eras.Application.DTOs;
+﻿using Eras.Application.Dtos;
 using Eras.Application.DTOs.CosmicLatte;
 using Eras.Application.Services;
-using Eras.Domain.Entities;
-using MediatR;
+
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using System.Diagnostics.CodeAnalysis;
-using System.Xml.Linq;
 
 namespace Eras.Api.Controllers
 {
     [ApiController]
+    [Authorize]
     [Route("api/v1/CosmicLatte/")]
     public class CosmicLatteController : ControllerBase
     {
@@ -33,6 +30,7 @@ namespace Eras.Api.Controllers
         }
 
         [HttpPost("polls/")]
+        [Authorize(Roles = "Administrator")]
         public async Task<IActionResult> SavePreviewPollsAsync([FromBody] List<PollDTO> PollsInstances)
         {
             return Ok(await _cosmicLatteService.SavePreviewPolls(PollsInstances));

--- a/src/Eras.Api/Controllers/HeatMapController.cs
+++ b/src/Eras.Api/Controllers/HeatMapController.cs
@@ -7,11 +7,14 @@ using Eras.Application.Models.Response;
 using Eras.Application.Models.Response.Common;
 
 using MediatR;
+
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Eras.Api.Controllers;
 
 [ApiController]
+[Authorize]
 [Route("api/v1/[controller]")]
 public class HeatMapController(IMediator Mediator, ILogger<HeatMapController> Logger) : ControllerBase
 {

--- a/src/Eras.Api/Controllers/PollInstanceController.cs
+++ b/src/Eras.Api/Controllers/PollInstanceController.cs
@@ -4,11 +4,14 @@ using Eras.Application.Features.PollInstances.Queries.GetPollInstancesByCohortAn
 using Eras.Application.Models.Response.Common;
 using Eras.Domain.Entities;
 using MediatR;
+
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Eras.Api.Controllers
 {
     [Route("api/v1/[controller]")]
+    [Authorize]
     [ApiController]
     [ExcludeFromCodeCoverage]
     public class PollInstanceController : ControllerBase

--- a/src/Eras.Api/Controllers/PollsController.cs
+++ b/src/Eras.Api/Controllers/PollsController.cs
@@ -4,9 +4,12 @@ using Eras.Application.Features.Polls.Queries.GetAllPollsQuery;
 using Eras.Application.Features.Polls.Queries.GetPollsByCohort;
 using Eras.Application.Features.Polls.Queries.GetPollsByStudent;
 using MediatR;
+
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 [ApiController]
+[Authorize]
 [Route("api/v1/[controller]")]
 [ExcludeFromCodeCoverage]
 public class PollsController : ControllerBase

--- a/src/Eras.Api/Controllers/ReportsController.cs
+++ b/src/Eras.Api/Controllers/ReportsController.cs
@@ -7,10 +7,12 @@ using Eras.Domain.Entities;
 
 using MediatR;
 
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 namespace Eras.Api.Controllers;
 
 [ApiController]
+[Authorize]
 [Route("api/[controller]")]
 [ExcludeFromCodeCoverage]
 public class ReportsController(IMediator Mediator) : ControllerBase


### PR DESCRIPTION
## Description

Example of how to enable route authorization for all controllers. And one example to enable role based authorization for cosmic latter post polls resource.

## Related Issues


