### PR TITLE
fix(CLResponseModel): delete unnecesary 'required' flags

### DIFF
--- a/src/Eras.Application/DTOs/CosmicLatte/CLResponseModelForAllPollsDTO.cs
+++ b/src/Eras.Application/DTOs/CosmicLatte/CLResponseModelForAllPollsDTO.cs
@@ -90,7 +90,7 @@ namespace Eras.Application.DTOs.CL
         public DateTime finishedAt { get; set; }
 
         [JsonPropertyName("score")]
-        public required Score score { get; set; }
+        public Score score { get; set; }
     }
 
     // level 2
@@ -136,7 +136,7 @@ namespace Eras.Application.DTOs.CL
     public class ByTrait
     {
         [JsonExtensionData]
-        public required Dictionary<string, JsonElement> traits { get; set; }
+        public Dictionary<string, JsonElement> traits { get; set; }
 
 
         private static Dictionary<string, TraitData> DeserializeTraits(Dictionary<string, JsonElement> Traits)


### PR DESCRIPTION
## Description



## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


