### PR TITLE
Round fields in eras calculation view

### DIFF
--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Views/vErasCalculationByPoll.sql
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Views/vErasCalculationByPoll.sql
@@ -17,7 +17,7 @@ WITH PercentageCalc AS (
 RiskAverageByComponent AS (
     SELECT
         c."name" AS component_name,
-        AVG(a.risk_level) AS average_risk
+        ROUND(AVG(a.risk_level),2) AS average_risk
     FROM
         answers a
     JOIN poll_variable pv ON a.poll_variable_id = pv."Id"
@@ -30,7 +30,7 @@ RiskAverageByVariable AS (
     SELECT
         v."Id" AS variable_id,
         v."name" AS variable_name,
-        AVG(a.risk_level) AS average_risk
+        ROUND(AVG(a.risk_level),2) AS average_risk
     FROM
         answers a
     JOIN poll_variable pv ON a.poll_variable_id = pv."Id"
@@ -56,7 +56,7 @@ RiskAvgByCohortComponent AS (
     SELECT
         sc.cohort_id,
         c."Id" AS component_id,
-        AVG(a.risk_level) AS average_risk_by_cohort_component
+        ROUND(AVG(a.risk_level),2) AS average_risk_by_cohort_component
     FROM
         answers a
     JOIN poll_variable pv ON pv."Id" = a.poll_variable_id


### PR DESCRIPTION
## Description

Fix Eras calculation view having many decimals by adding a ROUND operator to sql view script

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues
https://github.com/JU-DEV-Bootcamps/ERAS/issues/144

