### PR TITLE
Hotfix/eras be 164/paginator

### DIFF
--- a/src/Eras.Api/Controllers/StudentsController.cs
+++ b/src/Eras.Api/Controllers/StudentsController.cs
@@ -164,7 +164,7 @@ public class StudentsController(IMediator Mediator, ILogger<StudentsController> 
     )
     {
         var getStudentAnswersByPoll =
-            new GetStudentAnswersByPollQuery(Query) { StudentId = Id, PollId = InstanceId };
+            new GetStudentAnswersByPollQuery() { StudentId = Id, PollId = InstanceId, Query = Query };
         try
         {
             return Ok(await _mediator.Send(getStudentAnswersByPoll));

--- a/src/Eras.Api/Controllers/StudentsController.cs
+++ b/src/Eras.Api/Controllers/StudentsController.cs
@@ -159,11 +159,12 @@ public class StudentsController(IMediator Mediator, ILogger<StudentsController> 
     [HttpGet("{Id}/polls/{InstanceId}/answers")]
     public async Task<IActionResult> GetStudentAnswersByPollAsync(
         [FromRoute] int Id,
-        [FromRoute] int InstanceId
+        [FromRoute] int InstanceId,
+        [FromQuery] Pagination Query
     )
     {
         var getStudentAnswersByPoll =
-            new GetStudentAnswersByPollQuery() { StudentId = Id, PollId = InstanceId };
+            new GetStudentAnswersByPollQuery(Query) { StudentId = Id, PollId = InstanceId };
         try
         {
             return Ok(await _mediator.Send(getStudentAnswersByPoll));

--- a/src/Eras.Application/Contracts/Persistence/IStudentAnswersRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/IStudentAnswersRepository.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+﻿using Eras.Application.Utils;
 using Eras.Domain.Entities;
 
 namespace Eras.Application.Contracts.Persistence
@@ -11,5 +6,7 @@ namespace Eras.Application.Contracts.Persistence
     public interface IStudentAnswersRepository
     {
         Task<List<StudentAnswer>> GetStudentAnswersAsync(int StudentId, int PollId);
+
+        Task<PagedResult<StudentAnswer>> GetStudentAnswersPagedAsync(int StudentId, int PollId, int Page, int PageSize);
     }
 }

--- a/src/Eras.Application/Features/Answers/Queries/GetStudentAnswersByPollQuery.cs
+++ b/src/Eras.Application/Features/Answers/Queries/GetStudentAnswersByPollQuery.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Eras.Application.Utils;
 using Eras.Domain.Entities;
 using MediatR;
 
 namespace Eras.Application.Features.Answers.Queries
 {
-    public class GetStudentAnswersByPollQuery : IRequest<List<StudentAnswer>>
+    public class GetStudentAnswersByPollQuery(Pagination Query) : IRequest<PagedResult<StudentAnswer>>
     {
         public int StudentId { get; set; }
         public int PollId { get; set; }

--- a/src/Eras.Application/Features/Answers/Queries/GetStudentAnswersByPollQuery.cs
+++ b/src/Eras.Application/Features/Answers/Queries/GetStudentAnswersByPollQuery.cs
@@ -9,6 +9,6 @@ namespace Eras.Application.Features.Answers.Queries
         public int StudentId { get; set; }
         public int PollId { get; set; }
 
-        public Pagination Query { get; set; } = default!;
+        public Pagination Query { get; set; } = new Pagination();
     }
 }

--- a/src/Eras.Application/Features/Answers/Queries/GetStudentAnswersByPollQuery.cs
+++ b/src/Eras.Application/Features/Answers/Queries/GetStudentAnswersByPollQuery.cs
@@ -4,9 +4,11 @@ using MediatR;
 
 namespace Eras.Application.Features.Answers.Queries
 {
-    public class GetStudentAnswersByPollQuery(Pagination Query) : IRequest<PagedResult<StudentAnswer>>
+    public class GetStudentAnswersByPollQuery() : IRequest<PagedResult<StudentAnswer>>
     {
         public int StudentId { get; set; }
         public int PollId { get; set; }
+
+        public Pagination Query { get; set; } = default!;
     }
 }

--- a/src/Eras.Application/Features/Answers/Queries/GetStudentAnswersByPollQueryHandler.cs
+++ b/src/Eras.Application/Features/Answers/Queries/GetStudentAnswersByPollQueryHandler.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using Eras.Application.Contracts.Persistence;
 using Eras.Application.Features.Components.Queries;
+using Eras.Application.Utils;
 using Eras.Domain.Entities;
 
 using MediatR;
@@ -14,21 +15,22 @@ using Microsoft.Extensions.Logging;
 
 namespace Eras.Application.Features.Answers.Queries
 {
-    public class GetStudentAnswersByPollQueryHandler : IRequestHandler<GetStudentAnswersByPollQuery, List<StudentAnswer>>
+    public class GetStudentAnswersByPollQueryHandler : IRequestHandler<GetStudentAnswersByPollQuery, PagedResult<StudentAnswer>>
     {
         private readonly IStudentAnswersRepository _studentAnswersRepository;
         private readonly ILogger<GetStudentAnswersByPollQueryHandler> _logger;
 
-        public GetStudentAnswersByPollQueryHandler(IStudentAnswersRepository StudentAnswersRepos00itory, ILogger<GetStudentAnswersByPollQueryHandler> Logger)
+        public GetStudentAnswersByPollQueryHandler(IStudentAnswersRepository StudentAnswersRepository, ILogger<GetStudentAnswersByPollQueryHandler> Logger)
         {
-            _studentAnswersRepository = StudentAnswersRepos00itory;
+            _studentAnswersRepository = StudentAnswersRepository;
             _logger = Logger;
         }
 
-        public async Task<List<StudentAnswer>> Handle(GetStudentAnswersByPollQuery Request, CancellationToken CancellationToken)
+        public async Task<PagedResult<StudentAnswer>> Handle(GetStudentAnswersByPollQuery Request, CancellationToken CancellationToken)
         {
-            var listOfAnswers = await _studentAnswersRepository.GetStudentAnswersAsync(Request.StudentId, Request.PollId);
-            return listOfAnswers;
+            var answers = await _studentAnswersRepository.GetStudentAnswersPagedAsync(Request.StudentId, Request.PollId, Request.Query.Page, Request.Query.PageSize);
+            
+            return answers;
         }
     }
 }

--- a/src/Eras.Application/Features/Answers/Queries/GetStudentAnswersByPollQueryHandler.cs
+++ b/src/Eras.Application/Features/Answers/Queries/GetStudentAnswersByPollQueryHandler.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Eras.Application.Contracts.Persistence;
+﻿using Eras.Application.Contracts.Persistence;
+using Eras.Application.Exceptions;
 using Eras.Application.Features.Components.Queries;
 using Eras.Application.Utils;
 using Eras.Domain.Entities;
@@ -25,9 +20,17 @@ namespace Eras.Application.Features.Answers.Queries
             _studentAnswersRepository = StudentAnswersRepository;
             _logger = Logger;
         }
-
         public async Task<PagedResult<StudentAnswer>> Handle(GetStudentAnswersByPollQuery Request, CancellationToken CancellationToken)
         {
+            if (Request == null)
+                throw new ArgumentNullException(nameof(Request));
+
+            if (Request.PollId <= 0 || Request.StudentId <= 0)
+                throw new ArgumentException("PollId and StudentId must be positive integers.");
+
+            if (Request.Query == null)
+                throw new ArgumentNullException("Request must contain pagination");
+
             var answers = await _studentAnswersRepository.GetStudentAnswersPagedAsync(Request.StudentId, Request.PollId, Request.Query.Page, Request.Query.PageSize);
             
             return answers;

--- a/src/Eras.Application/Features/Answers/Queries/GetStudentAnswersByPollQueryHandler.cs
+++ b/src/Eras.Application/Features/Answers/Queries/GetStudentAnswersByPollQueryHandler.cs
@@ -22,8 +22,6 @@ namespace Eras.Application.Features.Answers.Queries
         }
         public async Task<PagedResult<StudentAnswer>> Handle(GetStudentAnswersByPollQuery Request, CancellationToken CancellationToken)
         {
-            if (Request == null)
-                throw new ArgumentNullException(nameof(Request));
 
             if (Request.PollId <= 0 || Request.StudentId <= 0)
                 throw new ArgumentException("PollId and StudentId must be positive integers.");

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/StudentAnswersRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/StudentAnswersRepository.cs
@@ -5,10 +5,12 @@ using System.Text;
 using System.Threading.Tasks;
 
 using Eras.Application.Contracts.Persistence;
+using Eras.Application.Models.Response.Calculations;
 using Eras.Application.Utils;
 using Eras.Domain.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
 
+using Microsoft.AspNetCore.Components;
 using Microsoft.EntityFrameworkCore;
 
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
@@ -21,30 +23,26 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
         {
             _context = Context;
         }
-
         public Task<PagedResult<StudentAnswer>> GetStudentAnswersPagedAsync(int StudentId, int PollId, int Page, int PageSize)
         {
-            var studentAnswers = (from a in _context.Answers
-                                 join pi2 in _context.PollInstances on a.PollInstanceId equals pi2.Id
-                                 join pv in _context.PollVariables on a.PollVariableId equals pv.Id
-                                 join v in _context.Variables on pv.VariableId equals v.Id
-                                 join c in _context.Components on v.ComponentId equals c.Id
-                                 where pv.PollId == PollId && pi2.StudentId == StudentId
-                                 
-                                 select new StudentAnswer
-                                 {
-                                     Variable = v.Name,
-                                     Position = a.PollVariableId,
-                                     Component = c.Name,
-                                     Answer = a.AnswerText,
-                                     Score = a.RiskLevel
-                                 }).Skip((Page - 1) * PageSize).Take(PageSize);
+            var studentAnswers = _context.ErasCalculationsByPoll
+                .Where(e => e.StudentId == StudentId && e.PollId == PollId)
+                .Select(e => new StudentAnswer
+                {
+                    Variable = e.Question,
+                    Position = e.PollVariableId,
+                    Component = e.ComponentName,
+                    Answer = e.AnswerText,
+                    Score = e.AnswerRisk
+                })
+                .Skip((Page - 1) * PageSize)
+                .Take(PageSize);
 
-            var totalCount = studentAnswers.Count();
+            var totalCount = _context.ErasCalculationsByPoll
+                .Count(e => e.StudentId == StudentId && e.PollId == PollId);
 
-            return Task.FromResult(new PagedResult<StudentAnswer>(studentAnswers.Count(), studentAnswers.ToList()));
+            return Task.FromResult(new PagedResult<StudentAnswer>(totalCount, studentAnswers.ToList()));
         }
-
         public Task<List<StudentAnswer>> GetStudentAnswersAsync(int StudentId, int PollId)
         {
             var studentAnswers = from a in _context.Answers

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/StudentAnswersRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/StudentAnswersRepository.cs
@@ -5,7 +5,11 @@ using System.Text;
 using System.Threading.Tasks;
 
 using Eras.Application.Contracts.Persistence;
+using Eras.Application.Utils;
 using Eras.Domain.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
+
+using Microsoft.EntityFrameworkCore;
 
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
 {
@@ -16,6 +20,25 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
         public StudentAnswersRepository(AppDbContext Context)
         {
             _context = Context;
+        }
+
+        public Task<IEnumerable<StudentAnswer>> GetStudentAnswersPagedAsync(int StudentId, int PollId, int Page, int PageSize)
+        {
+            var studentAnswers = from a in _context.Answers
+                                 join pi2 in _context.PollInstances on a.PollInstanceId equals pi2.Id
+                                 join pv in _context.PollVariables on a.PollVariableId equals pv.Id
+                                 join v in _context.Variables on pv.VariableId equals v.Id
+                                 join c in _context.Components on v.ComponentId equals c.Id
+                                 where pv.PollId == PollId && pi2.StudentId == StudentId
+                                 select new StudentAnswer
+                                 {
+                                     Variable = v.Name,
+                                     Position = a.PollVariableId,
+                                     Component = c.Name,
+                                     Answer = a.AnswerText,
+                                     Score = a.RiskLevel
+                                 };
+            return Task.FromResult(studentAnswers.ToList());
         }
 
         public Task<List<StudentAnswer>> GetStudentAnswersAsync(int StudentId, int PollId)
@@ -36,5 +59,7 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
                                  };
             return Task.FromResult(studentAnswers.ToList());
         }
+
+        public Task<StudentAnswer> UpdateAsync(StudentAnswer Entity) => throw new NotImplementedException();
     }
 }

--- a/test/Eras.Application.Tests/Features/Answers/Queries/GetStudentAnswersByPollQueryHandlerTest.cs
+++ b/test/Eras.Application.Tests/Features/Answers/Queries/GetStudentAnswersByPollQueryHandlerTest.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using Eras.Application.Contracts.Persistence;
 using Eras.Application.Features.Answers.Queries;
+using Eras.Application.Utils;
 using Eras.Domain.Entities;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -40,9 +41,15 @@ public class GetStudentAnswersByPollQueryHandlerTest
             }
         };
 
+        var pagedResult = new PagedResult<StudentAnswer>(studentAnswers.Count, studentAnswers);
+
         _mockAnswerRepository
-            .Setup(Repo => Repo.GetStudentAnswersAsync(It.Is<int>(Id => Id == 1),It.Is<int>(Id => Id == 1)))
-            .ReturnsAsync(studentAnswers);
+            .Setup(r => r.GetStudentAnswersPagedAsync(
+                It.Is<int>(StudentId => StudentId == 1),
+                It.Is<int>(PollId => PollId == 1),
+                1,
+                10))
+            .ReturnsAsync(pagedResult);
 
         // Act
         var result = await _handler.Handle(query, CancellationToken.None);

--- a/test/Eras.Application.Tests/Features/Answers/Queries/GetStudentAnswersByPollQueryHandlerTest.cs
+++ b/test/Eras.Application.Tests/Features/Answers/Queries/GetStudentAnswersByPollQueryHandlerTest.cs
@@ -48,6 +48,7 @@ public class GetStudentAnswersByPollQueryHandlerTest
         var result = await _handler.Handle(query, CancellationToken.None);
 
         // Assert
+        Assert.NotNull(result);
         Assert.Equal(2, result.Count);
     }
 }


### PR DESCRIPTION
## Description
Added proper communication between FE and BE for pagination. Now, components using ListComponent can communicate with BE to get PagedResult.

An example can be seen opening a modal on /reports/summary-heatmap


## Type of change

- [X] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


