### PR TITLE
fix(db): fixed decimals scale in fields

### DIFF
--- a/src/Eras.Api/Program.cs
+++ b/src/Eras.Api/Program.cs
@@ -47,27 +47,54 @@ app.UseSerilogRequestLogging();
 // Apply database migrations
 using (var scope = app.Services.CreateScope())
 {
-    var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-    dbContext.Database.Migrate();
-
+    var dbContextDrop = scope.ServiceProvider.GetRequiredService<AppDbContext>();
     // Read the view definition
-    var sqlFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory,
-                                   "Persistence/PostgreSQL/Views/vErasCalculationByPoll.sql");
+    var sqlFilePathDrop = Path.Combine(AppDomain.CurrentDomain.BaseDirectory,
+                                   "Persistence/PostgreSQL/Views/vErasCalculationByPollDrop.sql");
 
-    if (!File.Exists(sqlFilePath))
+    if (!File.Exists(sqlFilePathDrop))
     {
-        throw new FileNotFoundException($"SQL File not found: {sqlFilePath}");
+        throw new FileNotFoundException($"SQL File not found: {sqlFilePathDrop}");
     }
 
-    var sqlScript = File.ReadAllText(sqlFilePath);
+    var sqlScriptDrop = File.ReadAllText(sqlFilePathDrop);
     // Execute the SQL query
-    using (var connection = dbContext.Database.GetDbConnection())
+    using (var connection = dbContextDrop.Database.GetDbConnection())
     {
         connection.Open();
         using (var command = connection.CreateCommand())
         {
-            command.CommandText = sqlScript;
+            command.CommandText = sqlScriptDrop;
             command.ExecuteNonQuery();
+        }
+    }
+}
+using (var scope = app.Services.CreateScope())
+{
+    using (var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>())
+    {
+        dbContext.Database.Migrate();
+    
+
+        // Read the view definition
+        var sqlFilePathUp = Path.Combine(AppDomain.CurrentDomain.BaseDirectory,
+                                       "Persistence/PostgreSQL/Views/vErasCalculationByPoll.sql");
+
+        if (!File.Exists(sqlFilePathUp))
+        {
+            throw new FileNotFoundException($"SQL File not found: {sqlFilePathUp}");
+        }
+
+        var sqlScript = File.ReadAllText(sqlFilePathUp);
+        // Execute the SQL query
+        using (var connection = dbContext.Database.GetDbConnection())
+        {
+            connection.Open();
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = sqlScript;
+                command.ExecuteNonQuery();
+            }
         }
     }
 

--- a/src/Eras.Infrastructure/Eras.Infrastructure.csproj
+++ b/src/Eras.Infrastructure/Eras.Infrastructure.csproj
@@ -33,6 +33,9 @@
 		<None Update="Persistence/PostgreSQL/Views/vErasCalculationByPoll.sql">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
+		<None Update="Persistence\PostgreSQL\Views\vErasCalculationByPollDrop.sql">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
 	</ItemGroup>
 
 

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Configurations/AnswerConfiguration.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Configurations/AnswerConfiguration.cs
@@ -27,7 +27,7 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Configurations
                 .IsRequired();
             Builder.Property(Answer => Answer.RiskLevel)
                 .HasColumnName("risk_level")
-                .HasPrecision(3,4)
+                .HasPrecision(7,4)
                 .IsRequired();
             Builder.Property(Answer => Answer.PollInstanceId)
                 .HasColumnName("poll_instance_id")

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Configurations/StudentDetailConfiguration.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Configurations/StudentDetailConfiguration.cs
@@ -33,19 +33,19 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Configurations
                 .IsRequired();
             Builder.Property(Detail => Detail.AvgScore)
                 .HasColumnName("avg_score")
-                .HasPrecision(10,4)
+                .HasPrecision(14,4)
                 .IsRequired();
             Builder.Property(Detail => Detail.CoursesUnderAvg)
                 .HasColumnName("courses_under_avg")
-                .HasPrecision(10, 4)
+                .HasPrecision(14, 4)
                 .IsRequired();
             Builder.Property(Detail => Detail.PureScoreDiff)
                 .HasColumnName("pure_score_diff")
-                .HasPrecision(10, 4)
+                .HasPrecision(14, 4)
                 .IsRequired();
             Builder.Property(Detail => Detail.StandardScoreDiff)
                 .HasColumnName("standard_score_diff")
-                .HasPrecision(10, 4)
+                .HasPrecision(14, 4)
                 .IsRequired();
             Builder.Property(Detail => Detail.LastAccessDays)
                 .HasColumnName("last_access_days")

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20250606212553_fix_decimals_scale.Designer.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20250606212553_fix_decimals_scale.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Eras.Infrastructure.Persistence.PostgreSQL;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250606212553_fix_decimals_scale")]
+    partial class fix_decimals_scale
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20250606212553_fix_decimals_scale.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20250606212553_fix_decimals_scale.cs
@@ -1,0 +1,138 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Eras.Infrastructure.Persistence.PostgreSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class fix_decimals_scale : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<decimal>(
+                name: "standard_score_diff",
+                table: "student_details",
+                type: "numeric(14,4)",
+                precision: 14,
+                scale: 4,
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(10,4)",
+                oldPrecision: 10,
+                oldScale: 4);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "pure_score_diff",
+                table: "student_details",
+                type: "numeric(14,4)",
+                precision: 14,
+                scale: 4,
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(10,4)",
+                oldPrecision: 10,
+                oldScale: 4);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "courses_under_avg",
+                table: "student_details",
+                type: "numeric(14,4)",
+                precision: 14,
+                scale: 4,
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(10,4)",
+                oldPrecision: 10,
+                oldScale: 4);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "avg_score",
+                table: "student_details",
+                type: "numeric(14,4)",
+                precision: 14,
+                scale: 4,
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(10,4)",
+                oldPrecision: 10,
+                oldScale: 4);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "risk_level",
+                table: "answers",
+                type: "numeric(7,4)",
+                precision: 7,
+                scale: 4,
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(3,4)",
+                oldPrecision: 3,
+                oldScale: 4);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<decimal>(
+                name: "standard_score_diff",
+                table: "student_details",
+                type: "numeric(10,4)",
+                precision: 10,
+                scale: 4,
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(14,4)",
+                oldPrecision: 14,
+                oldScale: 4);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "pure_score_diff",
+                table: "student_details",
+                type: "numeric(10,4)",
+                precision: 10,
+                scale: 4,
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(14,4)",
+                oldPrecision: 14,
+                oldScale: 4);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "courses_under_avg",
+                table: "student_details",
+                type: "numeric(10,4)",
+                precision: 10,
+                scale: 4,
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(14,4)",
+                oldPrecision: 14,
+                oldScale: 4);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "avg_score",
+                table: "student_details",
+                type: "numeric(10,4)",
+                precision: 10,
+                scale: 4,
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(14,4)",
+                oldPrecision: 14,
+                oldScale: 4);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "risk_level",
+                table: "answers",
+                type: "numeric(3,4)",
+                precision: 3,
+                scale: 4,
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(7,4)",
+                oldPrecision: 7,
+                oldScale: 4);
+        }
+    }
+}

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Views/vErasCalculationByPoll.sql
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Views/vErasCalculationByPoll.sql
@@ -1,5 +1,4 @@
-DROP VIEW IF EXISTS vErasCalculationByPoll;
-CREATE OR REPLACE VIEW vErasCalculationByPoll AS
+CREATE VIEW vErasCalculationByPoll AS
 WITH PercentageCalc AS (
     SELECT
         a.poll_variable_id,

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Views/vErasCalculationByPollDrop.sql
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Views/vErasCalculationByPollDrop.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS vErasCalculationByPoll;


### PR DESCRIPTION
## Description
Additional Fix to decimals limitator

Added view removal before migrations since migrations can't alter fields that created view are using


## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues

https://github.com/JU-DEV-Bootcamps/ERAS/issues/98
