### PR TITLE
Fix/eras 211/update country data

### DIFF
--- a/src/Eras.Application/Features/Evaluations/Commands/UpdateEvaluation/UpdateEvaluationCommandHandler.cs
+++ b/src/Eras.Application/Features/Evaluations/Commands/UpdateEvaluation/UpdateEvaluationCommandHandler.cs
@@ -39,15 +39,16 @@ namespace Eras.Application.Features.Evaluations.Commands.UpdateEvaluation
                 evaluationDB.EndDate = Request.EvaluationDTO.EndDate;
                 evaluationDB.Audit.ModifiedAt = DateTime.UtcNow;
                 evaluationDB.Audit.ModifiedBy = "Controller";
+                evaluationDB.Country = Request.EvaluationDTO.Country;
 
                 // Only updatable if they were never set
                 if (string.IsNullOrEmpty(evaluationDB.PollName) || evaluationDB.Status == "Incomplete")
                 {
-                    if (! string.IsNullOrEmpty(Request.EvaluationDTO.PollName))
+                    if (!string.IsNullOrEmpty(Request.EvaluationDTO.PollName))
                     {
-                        Poll?  poll = await _PollRepository.GetByNameAsync(Request.EvaluationDTO.PollName);
+                        Poll? poll = await _PollRepository.GetByNameAsync(Request.EvaluationDTO.PollName);
 
-                        evaluationDB.PollName = Request.EvaluationDTO.PollName; 
+                        evaluationDB.PollName = Request.EvaluationDTO.PollName;
                         if (poll != null)
                         {
                             try


### PR DESCRIPTION
## Description
Now on /evaluation-process is possible to update Evaluation Process data, including the country


## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


