### PR TITLE
fix(variableRepository): update values returned to correct sync with …

### DIFF
--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/VariableRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/VariableRepository.cs
@@ -84,7 +84,7 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
                     ComponentName = X.C.Name,
                     Audit = X.V.Audit,
                     IdComponent = X.C.Id,
-                    PollVariableId = X.V.Id,
+                    PollVariableId = X.Pv.Id,
                     IdPoll = X.P.Id
                 });
 


### PR DESCRIPTION
## Description
Fixed #227. Now HM should appear in whichever order the polls are called.


## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


