### PR TITLE
fix(ERAS-263): applied filtering for poll variables

### DIFF
--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollVariableRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollVariableRepository.cs
@@ -25,8 +25,18 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
 
         public async Task<PagedResult<ErasCalculationsByPollDTO>?> GetByPollUuidVariableIdAsync(string PollUuid, List<int> VariableIds, Pagination Pagination)
         {
+            var pollId = await _context.Polls
+                .Where(P => P.Uuid == PollUuid)
+                .Select(P => P.Id)
+                .FirstOrDefaultAsync();
+
+            var filteredVariableIds = await _context.PollVariables
+                .Where(V => VariableIds.Contains(V.VariableId) && V.PollId == pollId)
+                .Select(V => V.Id)
+                .ToListAsync();
+
             var topRiskQuery = _context.ErasCalculationsByPoll
-                .Where(Calculation => Calculation.PollUuid == PollUuid && VariableIds.Contains(Calculation.PollVariableId))
+                .Where(Calculation => Calculation.PollUuid == PollUuid && filteredVariableIds.Contains(Calculation.PollVariableId))
                 .Select(Result => new ErasCalculationsByPollDTO
                 {
                     PollUuid = Result.PollUuid,


### PR DESCRIPTION
## Description
To fix this issue I have changed the repository, even that the ID passed through the FE was correct the filtering through the view is not correct because the variableID it's different for all polls

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [x] Have the requirements been met?
- [x] Is the code easy to read?
- [x] Do unit tests pass?
- [x] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues

[ERAS-263](https://github.com/JU-DEV-Bootcamps/ERAS/issues/263)
