### PR TITLE
fix: fixing query to return the correct poll list

### DIFF
--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
@@ -35,7 +35,6 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
             .Where(A => A.Uuid == PollUuid)
             .Select(A => (int?)A.LastVersion)
             .FirstOrDefault() ?? throw new InvalidOperationException($"No se encontró una encuesta con UUID {PollUuid}");
-        
         List<PollInstanceEntity> pollInstanceCounts;
 
         if (LastVersion)
@@ -70,7 +69,7 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
                 PollInstance => PollInstance.StudentId,
                 StudentCohort => StudentCohort.StudentId,
                 (PollInstance, StudentCohort) => new { pollInstance = PollInstance, studentCohort = StudentCohort })
-            .Where(Joined => CohortId.Contains(Joined.studentCohort.CohortId));
+            .Where(Joined => CohortId.Contains(Joined.studentCohort.CohortId) && Joined.pollInstance.Uuid == PollUuid);
 
         int pollVersion = _context.Polls
             .Where(A => A.Uuid == PollUuid)
@@ -84,7 +83,7 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
         }
         else
         {
-            DateTime dateLimit = DateTime.UtcNow.AddDays(Days.HasValue? - Days.Value : 0);
+            DateTime dateLimit = DateTime.UtcNow.AddDays(Days.HasValue ? -Days.Value : 0);
             query = query.Where(PI => PI.pollInstance.FinishedAt >= dateLimit && PI.pollInstance.LastVersion != pollVersion);
         }
 


### PR DESCRIPTION
## Description
Fixing query


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


