### PR TITLE
fix(ERAS-228): fix component average calculation

### DIFF
--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Views/vErasCalculationByPoll.sql
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Views/vErasCalculationByPoll.sql
@@ -16,6 +16,7 @@ WITH PercentageCalc AS (
 ),
 RiskAverageByComponent AS (
     SELECT
+        pv.poll_id,
         c."name" AS component_name,
         ROUND(AVG(a.risk_level),2) AS average_risk
     FROM
@@ -24,7 +25,7 @@ RiskAverageByComponent AS (
     JOIN variables v ON pv.variable_id = v."Id"
     JOIN components c ON v.component_id = c."Id"
     GROUP BY
-        c."name" /*, pv.poll_id Repeating result by some reason*/
+        pv.poll_id, c."name"
 ),
 RiskAverageByVariable AS (
     SELECT
@@ -100,7 +101,8 @@ JOIN poll_instances pi ON a.poll_instance_id = pi."Id"
 JOIN student_cohort sc ON sc.student_id = pi."StudentId"
 JOIN cohorts coh ON coh."Id" = sc.cohort_id
 JOIN PercentageCalc pc ON a.poll_variable_id = pc.poll_variable_id AND a.answer_text = pc.answer_text
-JOIN RiskAverageByComponent rac ON c."name" = rac.component_name
+JOIN RiskAverageByComponent rac 
+  ON c."name" = rac.component_name AND p."Id" = rac.poll_id
 JOIN RiskAverageByVariable rav ON v."Id" = rav.variable_id
 JOIN RiskCountByPollInstance rcbi ON a.poll_instance_id = rcbi.poll_instance_id
 JOIN RiskAvgByCohortComponent racbc ON racbc.cohort_id = sc.cohort_id AND racbc.component_id = c."Id"


### PR DESCRIPTION
## Description
Added a filter to take into account the poll Id in the average calculation of components

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [x] Have the requirements been met?
- [x] Is the code easy to read?
- [x] Do unit tests pass?
- [x] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues
[ERAS-228](https://github.com/JU-DEV-Bootcamps/ERAS/issues/228)

