### PR TITLE
refactor(GetCohortsList): add LastVersion option to query

### DIFF
--- a/src/Eras.Api/Controllers/CohortsController.cs
+++ b/src/Eras.Api/Controllers/CohortsController.cs
@@ -22,9 +22,11 @@ public class CohortsController(IMediator Mediator, ILogger<CohortsController> Lo
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> GetCohortsAsync([FromQuery] string? PollUuid)
+    public async Task<IActionResult> GetCohortsAsync([FromQuery] string? PollUuid, [FromQuery] bool LastVersion)
     {
         GetCohortsListQuery getCohortsListQuery = new();
+
+        getCohortsListQuery.LastVersion = LastVersion;
         if (!string.IsNullOrEmpty(PollUuid))
         {
             getCohortsListQuery.PollUuid = PollUuid;

--- a/src/Eras.Application/Contracts/Persistence/ICohortRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/ICohortRepository.cs
@@ -10,6 +10,6 @@ public interface ICohortRepository : IBaseRepository<Cohort>
     Task<List<Cohort>> GetCohortsAsync();
     Task<List<GetCohortTopRiskStudentsByComponentResponse>> GetCohortTopRiskStudentsByComponentAsync(string PollUuid, string ComponentName, int CohortId, bool LastVersion);
     Task<List<GetCohortTopRiskStudentsByComponentResponse>> GetCohortTopRiskStudentsAsync(string PollUuid, int CohortId, bool LastVersion);
-    Task<List<Cohort>> GetCohortsByPollUuidAsync(string PollUuid);
+    Task<List<Cohort>> GetCohortsByPollUuidAsync(string PollUuid, bool LastVersion);
     Task<List<Cohort>> GetCohortsByPollIdAsync(int PollId);
 }

--- a/src/Eras.Application/Features/Cohort/Queries/GetCohortsList/GetCohortsListQuery.cs
+++ b/src/Eras.Application/Features/Cohort/Queries/GetCohortsList/GetCohortsListQuery.cs
@@ -8,5 +8,6 @@ namespace Eras.Application.Features.Cohorts.Queries
     public class GetCohortsListQuery : IRequest<GetQueryResponse<List<Cohort>>>
     {
         public string PollUuid { get; set; } = string.Empty;
+        public bool LastVersion { get; set; } = true;
     }
 }

--- a/src/Eras.Application/Features/Cohort/Queries/GetCohortsList/GetCohortsListQueryHandler.cs
+++ b/src/Eras.Application/Features/Cohort/Queries/GetCohortsList/GetCohortsListQueryHandler.cs
@@ -20,7 +20,7 @@ public class GetCohortsListQueryHandler(ICohortRepository Repository, ILogger<Ge
             var res = await _repository.GetCohortsAsync();
             return new GetQueryResponse<List<Domain.Entities.Cohort>>(res, $"All {res.Count} Cohorts retrieved successfully", true);
         }
-        List<Domain.Entities.Cohort> listOfCohorts = await _repository.GetCohortsByPollUuidAsync(Request.PollUuid);
+        List<Domain.Entities.Cohort> listOfCohorts = await _repository.GetCohortsByPollUuidAsync(Request.PollUuid, Request.LastVersion);
         return new GetQueryResponse<List<Domain.Entities.Cohort>>(listOfCohorts, $"{listOfCohorts} cohorts retrieved from poll {Request.PollUuid} successfully", true);
     }
 }

--- a/test/Eras.Api.Tests/Controllers/CohortsControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/CohortsControllerTests.cs
@@ -27,7 +27,7 @@ public class CohortsControllerTests
     public async Task GetCohorts_ReturnsOkResultAsync()
     {
         // Act
-        IActionResult result = await _controller.GetCohortsAsync(null);
+        IActionResult result = await _controller.GetCohortsAsync(null, false);
 
         // Assert
         OkObjectResult okResult = Assert.IsType<OkObjectResult>(result);


### PR DESCRIPTION
## Description
Now, Cohorts selection on /reports should hide whenever there are no cohorts on any given Poll and Version


## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


