### PR TITLE
fix(ERAS-392): updated validator number range in Configuration DTO

### DIFF
--- a/src/Eras.Application/DTOs/ConfigurationsDTO.cs
+++ b/src/Eras.Application/DTOs/ConfigurationsDTO.cs
@@ -11,7 +11,7 @@ namespace Eras.Application.DTOs;
 public class ConfigurationsDTO
 {
     [Required(ErrorMessage = "Configuration Id is required.")]
-    [Range(1, 2147483647, ErrorMessage = "Id must be greater than 0.")]
+    [Range(0, 2147483647, ErrorMessage = "Id must be greater than 0.")]
     public int Id { get; set; }
 
     [Required(ErrorMessage = "UserId is required.")]
@@ -32,7 +32,7 @@ public class ConfigurationsDTO
     public string EncryptedKey { get; set; }
 
     [Required(ErrorMessage = "Service provider Id is required.")]
-    [Range(1, 2147483647, ErrorMessage = "Service Provider Id must be greater than 0.")]
+    [Range(0, 2147483647, ErrorMessage = "Service Provider Id must be greater than 0.")]
     public int ServiceProviderId { get; set; }
 
     public bool IsDeleted { get; set; }


### PR DESCRIPTION
## Description
updated validator number range in Configuration DTO


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [x] Have the requirements been met?
- [x] Is the code easy to read?
- [x] Do unit tests pass?
- [x] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues
[ERAS-392](https://github.com/JU-DEV-Bootcamps/ERAS/issues/392)

