### PR TITLE
Update RW-test-package-BE-Runner.yml

### DIFF
--- a/.github/workflows/RW-test-package-BE-Runner.yml
+++ b/.github/workflows/RW-test-package-BE-Runner.yml
@@ -163,11 +163,14 @@ jobs:
         run: |
           TAG="${{ env.LAST_TAG }}-${{ env.SHORT_SHA }}-${{ inputs.environment_tag }}"
           echo "{\"ERAS-BE\": \"$TAG\"}" > be_tag.json
-  
-      - name: Upload BE tag artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: eras-be-tag
-          path: be_tag.json
 
+      - name: Verify files before zipping
+        run: |
+          test -f be_tag.json || (echo "be_tag.json not found" && exit 1)
+          test -d build-output || (echo "build-output directory not found" && exit 1)
+
+      - name: Save artifact locally
+        run: |
+          mkdir -p /home/ubuntu/Eras_versions/
+          zip -r /home/ubuntu/Eras_versions/eras-be-tag.zip ./build-output be_tag.json
 


### PR DESCRIPTION
Workflow doesn't accept the artifact files between submodules and main project, I changed the strategy to create a local file in the runner machine using the last 2 steps

## Description
The following PR allows to the runner of Back end to create a new file shared by the other runners to read the new tag created and avoid the limitation to use external services to save the TAG.


## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


