### PR TITLE
BE275: Fix typo on Evaluations endpoints parameters

### DIFF
--- a/src/Eras.Api/Controllers/EvaluationsController.cs
+++ b/src/Eras.Api/Controllers/EvaluationsController.cs
@@ -23,7 +23,7 @@ public class EvaluationsController(IMediator Mediator, ILogger<EvaluationsContro
     private readonly IMediator _mediator = Mediator;
     private readonly ILogger<EvaluationsController> _logger = Logger;
 
-    [HttpDelete("{id}")]
+    [HttpDelete("{Id}")]
     [Authorize]
     public async Task<IActionResult> DeleteEvaluationAsync(int Id)
     {
@@ -63,7 +63,7 @@ public class EvaluationsController(IMediator Mediator, ILogger<EvaluationsContro
         }
     }
     [Authorize]
-    [HttpPut("{id}")]
+    [HttpPut("{Id}")]
     public async Task<IActionResult> UpdateEvaluationAsync(int Id, [FromBody] EvaluationDTO EvaluationDTO)
     {
         try


### PR DESCRIPTION
## Description
The endpoints had some typos as their signatures are not case sensitive


## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [X] Have the requirements been met?
- [X] Is the code easy to read?
- [ ] Do unit tests pass?
- [X] Is the code formatted correctly?

## C# Checklist

- [X] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [X] Does the code handle exceptions correctly
- [X] Is the code subject to concurrency issues? Are shared objects properly protected?
- [X] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [X] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [X] Are internal vs private vs public classes and methods used the right way?

## Related Issues


