### PR TITLE
Update RW-test-package-BE-Runner.yml

### DIFF
--- a/.github/workflows/RW-test-package-BE-Runner.yml
+++ b/.github/workflows/RW-test-package-BE-Runner.yml
@@ -161,7 +161,7 @@ jobs:
          
       - name: Save BE tag as JSON
         run: |
-          TAG="${{ env.LAST_TAG }}-${{ env.SHORT_SHA }}-${{ inputs.environment_tag }}"
+          TAG="${{ env.SHORT_SHA }}-${{ inputs.environment_tag }}"
           echo "{\"ERAS-BE\": \"$TAG\"}" > be_tag.json
 
       - name: Build project


### PR DESCRIPTION
The sh file in ERAS project has hardcoded this first part, to avoid conflicts is required to remove the first part of the tag.

## Description
I recovered from the Docker hub tags the following information "ERAS-FE": "0.1.0-86094a5-testing", "ERAS-BE": "0.1.0-b06c2b0-testing" but the sh file setVersion.sh has already hardcoded the "0.1.0-" so I need to recover only the part EX "86094a5"


## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


