### PR TITLE
BE274: apply ParentId filter to get the poll when creating a new eval…

### DIFF
--- a/src/Eras.Api/Controllers/EvaluationsController.cs
+++ b/src/Eras.Api/Controllers/EvaluationsController.cs
@@ -108,13 +108,14 @@ public class EvaluationsController(IMediator Mediator, ILogger<EvaluationsContro
     }
 
     [Authorize]
-    [HttpPost]
-    public async Task<IActionResult> CreateEvaluationAsync([FromBody] EvaluationDTO EvaluationDTO)
+    [HttpPost("{ParentId}")]
+    public async Task<IActionResult> CreateEvaluationAsync(string ParentId, [FromBody] EvaluationDTO EvaluationDTO)
     {
         _logger.LogInformation("Creating evaluation with the name {Name}", EvaluationDTO.Name);
         var command = new CreateEvaluationCommand()
         {
             EvaluationDTO = EvaluationDTO,
+            ParentId = ParentId
         };
         CreateCommandResponse<Evaluation> response = await _mediator.Send(command);
         if (response.Success)

--- a/src/Eras.Application/Contracts/Persistence/IPollRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/IPollRepository.cs
@@ -5,6 +5,7 @@ namespace Eras.Application.Contracts.Persistence
     public interface IPollRepository : IBaseRepository<Poll>
     {
         Task<Poll?> GetByNameAsync(string Name);
+        Task<Poll?> GetByParentIdAsync(string ParentId);
         Task<Poll?> GetByUuidAsync(string Uuid);
     }
 }

--- a/src/Eras.Application/Features/Evaluations/Commands/CreateEvaluation/CreateEvaluationCommand.cs
+++ b/src/Eras.Application/Features/Evaluations/Commands/CreateEvaluation/CreateEvaluationCommand.cs
@@ -8,5 +8,6 @@ namespace Eras.Application.Features.Evaluations.Commands
     public class CreateEvaluationCommand : IRequest<CreateCommandResponse<Evaluation>>
     {
         public EvaluationDTO EvaluationDTO = default!;
+        public string ParentId { get; set; } = string.Empty;
     }
 }

--- a/src/Eras.Application/Features/Evaluations/Commands/CreateEvaluation/CreateEvaluationCommandHandler.cs
+++ b/src/Eras.Application/Features/Evaluations/Commands/CreateEvaluation/CreateEvaluationCommandHandler.cs
@@ -31,12 +31,12 @@ namespace Eras.Application.Features.Evaluations.Commands
                 Evaluation? evaluation=null;
                 Poll? poll = null;
                 evaluation = await _evaluationRepository.GetByNameAsync(Request.EvaluationDTO.Name);
+
                 if (evaluation != null) return new CreateCommandResponse<Evaluation>(null, 0,
                     $"Evaluation with Name {Request.EvaluationDTO.Name} already exists", false);
 
-
                 if (!Request.EvaluationDTO.PollName.Equals(string.Empty))
-                    poll = await _pollRepository.GetByNameAsync(Request.EvaluationDTO.PollName);
+                    poll = await _pollRepository.GetByParentIdAsync(Request.ParentId);
                 evaluation = Request.EvaluationDTO.ToDomain();
                 evaluation.Audit = new AuditInfo()
                 {

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Xml.Linq;
 
 using Eras.Application.Contracts.Persistence;
 using Eras.Domain.Entities;
@@ -19,6 +20,12 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
         {
             var poll = await _context.Polls.FirstOrDefaultAsync(Poll => Poll.Name == Name);
 
+            return poll?.ToDomain();
+        }
+
+        public async Task<Poll?> GetByParentIdAsync(string ParentId)
+        {
+            var poll = await _context.Polls.FirstOrDefaultAsync(Poll => Poll.ParentId.Equals(ParentId));
             return poll?.ToDomain();
         }
 

--- a/test/Eras.Api.Tests/Controllers/EvaluationControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/EvaluationControllerTests.cs
@@ -31,10 +31,11 @@ namespace Eras.Api.Tests.Controllers
         public async Task CreateEvaluationController_Should_Return_SuccessAsync()
         {
             var evaluationDTO = new EvaluationDTO() { Name = "newEvaluation", StartDate = DateTime.UtcNow, EndDate = DateTime.Now };
+            var parentId = "";
             var commandResponse = new CreateCommandResponse<Evaluation>(evaluationDTO.ToDomain(), "Success", true);
             _mockMediator.Setup(M => M.Send(It.IsAny<CreateEvaluationCommand>(), default))
                 .ReturnsAsync(commandResponse);
-            var result = await _controller.CreateEvaluationAsync(evaluationDTO) as OkObjectResult;
+            var result = await _controller.CreateEvaluationAsync(parentId, evaluationDTO) as OkObjectResult;
 
             Assert.NotNull(result);
             Assert.Equal(200, result.StatusCode);


### PR DESCRIPTION
…uation

## Description



## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [x] Have the requirements been met?
- [x] Is the code easy to read?
- [x] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


