### PR TITLE
BE-505. Enable swagger just for development environments

### DIFF
--- a/src/Eras.Api/Program.cs
+++ b/src/Eras.Api/Program.cs
@@ -99,15 +99,18 @@ using (var scope = app.Services.CreateScope())
 // Enable CORS
 app.UseCors("CORSPolicy");
 
-// Configure the HTTP request pipeline.
-app.UseSwagger();
-app.UseSwaggerUI(_ =>
-        {
-            _.EnableDeepLinking();
-            _.OAuthClientId("api-client");
-            _.OAuthAppName("Swagger new ");
-        }
-        );
+// Enable Swagger just for development environments.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI(_ =>
+            {
+                _.EnableDeepLinking();
+                _.OAuthClientId("api-client");
+                _.OAuthAppName("Swagger new ");
+            }
+            );
+}
 
 app.UseHsts();
 app.UseHttpsRedirection();


### PR DESCRIPTION
## Description
Enable swagger just for development environments


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [x] Have the requirements been met?
- [x] Is the code easy to read?
- [x] Do unit tests pass?
- [x] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues
[ERAS-505](https://github.com/JU-DEV-Bootcamps/ERAS/issues/505)

