### PR TITLE
BE-505. Added new env variable __ENABLE_SWAGGER__ to decide to show or not swagger

### DIFF
--- a/src/Eras.Api/Program.cs
+++ b/src/Eras.Api/Program.cs
@@ -100,7 +100,8 @@ using (var scope = app.Services.CreateScope())
 app.UseCors("CORSPolicy");
 
 // Enable Swagger just for development environments.
-if (app.Environment.IsDevelopment())
+bool isSwaggerEnabled = builder.Configuration["EnableSwagger"] == "true";
+if (isSwaggerEnabled)
 {
     app.UseSwagger();
     app.UseSwaggerUI(_ =>

--- a/src/Eras.Api/appsettings.Production.json
+++ b/src/Eras.Api/appsettings.Production.json
@@ -1,35 +1,36 @@
 {
-    "CosmicLatte": {
-        "BaseUrl": "__COSMIC_API_URL__",
-        "ApiKey": "__COSMIC_LATTE_API_KEY__"
-    },
-    "Encryption": {
-        "Key": "__ENCRYPTION_KEY__",
-        "IV": "__ENCRYPTION_IV__"
-    },
-    "Logging": {
-        "LogLevel": {
-            "Default": "Information",
-            "Microsoft.AspNetCore": "Warning"
-        }
-    },
-    "AllowedHosts": "*",
-    "Keycloak": {
-        "BaseUrl": "__KEYCLOAK_URL__",
-        "Realm": "__KEYCLOAK_REALM__",
-        "ClientId": "__CLIENT_ID__",
-        "ClientSecret": "__KEYCLOAK_CLIENT_SECRET__",
-        "Audience": "__KEYCLOAK_CLIENT_AUDIENCE__"
-    },
-    "Kestrel": {
-        "Endpoints": {
-            "Https": {
-                "Url": "https://*:443",
-                "Certificate": {
-                    "Path": "/https/aspnetapp.pfx",
-                    "Password": "eras"
-                }
-            }
-        }
+  "EnableSwagger": "__ENABLE_SWAGGER__",
+  "CosmicLatte": {
+    "BaseUrl": "__COSMIC_API_URL__",
+    "ApiKey": "__COSMIC_LATTE_API_KEY__"
+  },
+  "Encryption": {
+    "Key": "__ENCRYPTION_KEY__",
+    "IV": "__ENCRYPTION_IV__"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "AllowedHosts": "*",
+  "Keycloak": {
+    "BaseUrl": "__KEYCLOAK_URL__",
+    "Realm": "__KEYCLOAK_REALM__",
+    "ClientId": "__CLIENT_ID__",
+    "ClientSecret": "__KEYCLOAK_CLIENT_SECRET__",
+    "Audience": "__KEYCLOAK_CLIENT_AUDIENCE__"
+  },
+  "Kestrel": {
+    "Endpoints": {
+      "Https": {
+        "Url": "https://*:443",
+        "Certificate": {
+          "Path": "/https/aspnetapp.pfx",
+          "Password": "eras"
+        }
+      }
+    }
+  }
 }

--- a/src/Eras.Api/appsettings.json
+++ b/src/Eras.Api/appsettings.json
@@ -1,24 +1,25 @@
 {
-    "CosmicLatte": {
-        "BaseUrl": "https://staging.cosmic-latte.com/api/1.0/",
-        "ApiKey": "cosmic-latte-api-key"
-    },
-    "Encryption": {
-        "Key": "c0427fcd4880380275616fbb3019c339584defa39cbb0f7185a29dabe9befa9d",
-        "IV": "4d59d9b834ccbf185d29922fbeec2f4c"
-    },
-    "Logging": {
-        "LogLevel": {
-            "Default": "Information",
-            "Microsoft.AspNetCore": "Warning"
-        }
-    },
-    "AllowedHosts": "*",
-    "Keycloak": {
-        "BaseUrl": "http://localhost:18080",
-        "Realm": "ERAS",
-        "ClientId": "api-client",
-        "ClientSecret": "keycloak-client-secret",
-        "Audience": "__KEYCLOAK_CLIENT_AUDIENCE__"
+  "EnableSwagger": "true",
+  "CosmicLatte": {
+    "BaseUrl": "https://staging.cosmic-latte.com/api/1.0/",
+    "ApiKey": "cosmic-latte-api-key"
+  },
+  "Encryption": {
+    "Key": "c0427fcd4880380275616fbb3019c339584defa39cbb0f7185a29dabe9befa9d",
+    "IV": "4d59d9b834ccbf185d29922fbeec2f4c"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "AllowedHosts": "*",
+  "Keycloak": {
+    "BaseUrl": "http://localhost:18080",
+    "Realm": "ERAS",
+    "ClientId": "api-client",
+    "ClientSecret": "keycloak-client-secret",
+    "Audience": "__KEYCLOAK_CLIENT_AUDIENCE__"
+  }
 }


### PR DESCRIPTION
## Description
BE-505. Added new env variable __ENABLE_SWAGGER__ to decide to show or not swagger


## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues
[BE-505](https://github.com/JU-DEV-Bootcamps/ERAS/issues/505)

