### PR TITLE
Update RW-test-package-BE-Runner.yml

### DIFF
--- a/.github/workflows/RW-test-package-BE-Runner.yml
+++ b/.github/workflows/RW-test-package-BE-Runner.yml
@@ -157,12 +157,15 @@ jobs:
           case "$client_id" in
           eras-dev-api)
             echo "target_secret=KEYCLOAK_CLIENT_SECRET" >> "$GITHUB_OUTPUT"
+            echo "swagger_status=true" >> "$GITHUB_OUTPUT" 
             ;;
           eras-dev)
             echo "target_secret=KEYCLOAK_CLIENT_SECRET_STAGE" >> "$GITHUB_OUTPUT"
+            echo "swagger_status=true" >> "$GITHUB_OUTPUT" 
             ;;
           eras-prod-api)
             echo "target_secret=KEYCLOAK_CLIENT_SECRET_PROD" >> "$GITHUB_OUTPUT"
+            echo "swagger_status=false" >> "$GITHUB_OUTPUT" 
             ;;
           *)
             echo "Invalid keycloak_client_id: ${client_id}" >&2
@@ -183,8 +186,8 @@ jobs:
 
           # Dynamic secret
           sed -i "s|__KEYCLOAK_CLIENT_SECRET__|${{ secrets[steps.select_secret.outputs.target_secret] }}|g" src/Eras.Api/appsettings.Production.json
-
-    
+          sed -i "s|__ENABLE_SWAGGER__|${{ steps.select_secret.outputs.swagger_status }}|g" src/Eras.Api/appsettings.Production.json
+          
           sed -i "s|__KEYCLOAK_CLIENT_AUDIENCE__|account|g" src/Eras.Api/appsettings.Production.json
 
           sed -i "s|__CLIENT_ID__|${{ inputs.keycloak_client_id }}|g" src/Eras.Api/appsettings.Production.json


### PR DESCRIPTION
Added a new variable to know the status of the swagger according the keycloak user for development and testing the user should be eras_api_dev and the status should be true for swagger, for stage the user is eras_dev and the status should be true, and for production environment the user should be eras_prod_api and the status should be false

(cherry picked from commit 3f36b7a21f1b6129e84fdced6fb9e472463416fd)

## Description



## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


