### PR TITLE
BE-321. Updated BE service to only have one call and required filters in the call

### DIFF
--- a/src/Eras.Api/Controllers/EvaluationDetailsController.cs
+++ b/src/Eras.Api/Controllers/EvaluationDetailsController.cs
@@ -1,13 +1,9 @@
-﻿using Eras.Application.Features.EvaluationDetails.Queries.GetEvaluationDetailsByFilters;
+﻿using System.ComponentModel.DataAnnotations;
+
 using Eras.Application.Features.EvaluationDetails.Queries.GetStudentsByFilters;
-using Eras.Application.Features.Evaluations.Commands.DeleteEvaluation;
-using Eras.Application.Features.Evaluations.Queries.GetByDateRange;
-using Eras.Application.Models.Response;
-using Eras.Domain.Entities;
 
 using MediatR;
 
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Eras.Api.Controllers;
@@ -19,32 +15,17 @@ public class EvaluationDetailsController(IMediator Mediator, ILogger<Evaluations
     private readonly IMediator _mediator = Mediator;
     private readonly ILogger<EvaluationsController> _logger = Logger;
 
-    [HttpGet("EvaluationDetailsByFilter")]
-    public async Task<IActionResult> EvaluationDetailsByFilterAsync([FromQuery] int? PollId, [FromQuery] List<int>? ComponentIds, [FromQuery] List<int>? CohortIds, [FromQuery] List<int>? VariableIds)
-    {
-        _logger.LogInformation("Retrieving evaluation details with filters {PollId}, Components ({ComponentIds}), Cohorts ({CohortIds}), Variables ({VariableIds})", PollId, ComponentIds, CohortIds, VariableIds);
-        var query = new GetEvaluationDetailsByFiltersQuery() { 
-            PollId = PollId,
-            ComponentIds = ComponentIds,
-            CohortIds = CohortIds,
-            VariableIds = VariableIds
-        };
-        var response = await _mediator.Send(query);
-
-        _logger.LogInformation("Successfully retrieved Evaluation Details {response}", response);
-        return response == null ? NotFound(response) : Ok(response);
-    }
-
     [HttpGet("StudentsByFilters")]
-    public async Task<IActionResult> StudentsByFilterAsync([FromQuery] int? PollId, [FromQuery] List<int>? ComponentIds, [FromQuery] List<int>? CohortIds, [FromQuery] List<int>? VariableIds)
+    public async Task<IActionResult> StudentsByFilterAsync([FromQuery, Required] string PollUuid, [FromQuery, Required, MinLength(1)] List<string> ComponentNames, [FromQuery, Required, MinLength(1)] List<int> CohortIds, [FromQuery, Required, MinLength(1)] List<int>? VariableIds, [FromQuery] List<int>? RiskLevels)
     {
-        _logger.LogInformation("Retrieving students with filters {PollId}, Components ({ComponentIds}), Cohorts ({CohortIds}), Variables ({VariableIds})", PollId, ComponentIds, CohortIds, VariableIds);
+        _logger.LogInformation("Retrieving students with filters {PollId}, Components ({ComponentIds}), Cohorts ({CohortIds}), Variables ({VariableIds})", PollUuid, ComponentNames, CohortIds, VariableIds);
         var query = new GetStudentsByFiltersQuery()
         {
-            PollId = PollId,
-            ComponentIds = ComponentIds,
+            PollUuid = PollUuid,
+            ComponentNames = ComponentNames,
             CohortIds = CohortIds,
-            VariableIds = VariableIds
+            VariableIds = VariableIds,
+            RiskLevels = RiskLevels
         };
         var response = await _mediator.Send(query);
 

--- a/src/Eras.Application/Contracts/Persistence/IErasEvaluationDetailsViewRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/IErasEvaluationDetailsViewRepository.cs
@@ -12,5 +12,5 @@ namespace Eras.Application.Contracts.Persistence;
 public interface IErasEvaluationDetailsViewRepository : IBaseRepository<ErasEvaluationDetailsView>
 {
     Task<List<ErasEvaluationDetailsView>> GetByFiltersAsync(int? PollId, List<int>? ComponentIds, List<int>? CohortIds, List<int>? VariableIds);
-    Task<List<StudentsByFiltersResponse>> GetStudentsByFilters(int? PollId, List<int>? ComponentIds, List<int>? CohortIds, List<int>? VariableIds);
+    Task<List<StudentsByFiltersResponse>> GetStudentsByFilters(string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<int>? RiskLevel);
 }

--- a/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByFilters/GetStudentsByFiltersQuery.cs
+++ b/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByFilters/GetStudentsByFiltersQuery.cs
@@ -6,9 +6,10 @@ namespace Eras.Application.Features.EvaluationDetails.Queries.GetStudentsByFilte
 
 public class GetStudentsByFiltersQuery : IRequest<List<StudentsByFiltersResponse>>
 {
-    public int? PollId { get; set; }
-    public List<int>? ComponentIds { get; set; }
-    public List<int>? CohortIds { get; set; }
+    public required string PollUuid { get; set; }
+    public required List<string> ComponentNames { get; set; }
+    public required List<int> CohortIds { get; set; }
     public List<int>? VariableIds { get; set; }
+    public List<int>? RiskLevels { get; set; }
 
 }

--- a/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByFilters/GetStudentsByFiltersQueryHandler.cs
+++ b/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByFilters/GetStudentsByFiltersQueryHandler.cs
@@ -29,10 +29,11 @@ public class GetStudentsByFiltersQueryHandler : IRequestHandler<GetStudentsByFil
     public async Task<List<StudentsByFiltersResponse>> Handle(GetStudentsByFiltersQuery Request, CancellationToken CancellationToken)
     {
         var studentsList = await _repository.GetStudentsByFilters(
-            Request.PollId,
-            Request.ComponentIds,
+            Request.PollUuid,
+            Request.ComponentNames,
             Request.CohortIds,
-            Request.VariableIds
+            Request.VariableIds,
+            Request.RiskLevels
         );
 
         return studentsList;


### PR DESCRIPTION
## Description
Updated BE service to only have one call and required filters in the call
Now we have this endpoint, can be tested with the performance poll:
PollUUID: 21ef0700-a7e0-4cf2-a5b2-e7533454dc2f
<img width="1469" height="852" alt="image" src="https://github.com/user-attachments/assets/93745d77-6bc9-49eb-886e-51f5fafc834f" />

Sample Response:
```
[
  {
    "id": 7,
    "name": "Alberto Arandia",
    "email": "a.arandia@jala.university",
    "answerId": 283,
    "answerText": "Interés personal y gusto por la programación.",
    "riskLevel": 1
  },
  {
    "id": 8,
    "name": "Boris Barrientos",
    "email": "bboris@jala.university",
    "answerId": 329,
    "answerText": "Buena oportunidad en el campo laboral.",
    "riskLevel": 3
  }
]
```

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues
[BE-321](https://github.com/JU-DEV-Bootcamps/ERAS-BE/issues/321)

