### PR TITLE
Fix syntax error in find command for DLLs

### DIFF
--- a/.github/workflows/Package-BE-CICD-Test.yml
+++ b/.github/workflows/Package-BE-CICD-Test.yml
@@ -97,7 +97,7 @@ jobs:
       - name: snapshot_before_build
         run: |
           mkdir -p /home/ubuntu/audit/before_build
-          find . -name "Eras*.dll" -not -path "*/obj/*" exec cp --parents {} "$AUDIT_PATH" \;
+          find . -name "Eras*.dll" -not -path "*/obj/*" -exec cp --parents {} "$AUDIT_PATH" \;
           echo "Audit completed $AUDIT_PATH"
           pdw
       - name: Clean previous builds
@@ -184,7 +184,7 @@ jobs:
       - name: snapshot_after_build
         run: |
           mkdir -p /home/ubuntu/audit/after_build
-          find . -name "Eras*.dll" -not -path "*/obj/*" exec cp --parents {} "$AUDIT_PATH" \;
+          find . -name "Eras*.dll" -not -path "*/obj/*" -exec cp --parents {} "$AUDIT_PATH" \;
           echo "Audit completed $AUDIT_PATH"
           - name: Save BE tag as JSON
       


### PR DESCRIPTION
## Description
Fix syntax error in find command for DLLs


## Type of change

- [x ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues

#345
