### PR TITLE
Change runner to self-hosted and update action versions

### DIFF
--- a/.github/workflows/push_workflow.yaml
+++ b/.github/workflows/push_workflow.yaml
@@ -51,13 +51,14 @@ jobs:
           path: CoverletReport
 
   package:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: coverage
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          clean: true
       - name: Set variables
         id: set-vars
         run: |
@@ -86,9 +87,16 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./src/Eras.Api/Dockerfile
           push: true
+          no-cache: true
           tags: ${{ vars.DOCKERHUB_USERNAME }}/${{ env.REPO_NAME }}:${{ env.LAST_TAG }}-${{ env.SHORT_SHA }}-dev
+      - name: Snapshot_Assemblies
+        if: always()
+        run: |
+          AUDIT_PATH="/home/ubuntu/audit/push"
+          mkdir -p "$AUDIT_PATH"
+          find . -name "*.dll" -not -path "*/obj/*" -exec cp --parents {} "$AUDIT_PATH" \;


### PR DESCRIPTION
Updated the workflow to use a self-hosted runner and upgraded action versions.

## Description
Change runner to self-hosted and update action versions


## Type of change

- [x ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues
#345 

