### PR TITLE
fix: apply Math.Floor rounding on RiskLevel filter to match decimal v…

### DIFF
--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
@@ -56,17 +56,9 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
         query = query.Where(v => CohortIds.Contains(v.CohortId));
         query = query.Where(v => ComponentNames.Contains(v.ComponentName));
 
-        if (VariableIds != null && VariableIds.Any())
-        {
-            query = query.Where(v => VariableIds.Contains(v.VariableId));
-        }
+        var entitiesEval = await query.ToListAsync();
 
-        if (RiskLevels != null && RiskLevels.Any())
-        {
-            query = query.Where(v => RiskLevels.Contains(v.RiskLevel));
-        }
-
-        return await query
+        var resultEval = entitiesEval
             .Select(v => new StudentsByFiltersResponse
             {
                 Id = v.StudentId,
@@ -76,8 +68,14 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
                 AnswerText = v.AnswerText,
                 RiskLevel = v.RiskLevel
             })
-            .Distinct()
-            .ToListAsync();
+            .Distinct();
+
+        if (RiskLevels != null && RiskLevels.Any())
+        {
+            resultEval = resultEval.Where(v => RiskLevels.Contains(Math.Floor(v.RiskLevel)));
+        }
+
+        return resultEval.ToList();
     }
 
     public async Task<List<StudentsByFiltersResponse>> GetStudentsByFilters(string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevels)
@@ -93,12 +91,9 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
             query = query.Where(v => VariableIds.Contains(v.VariableId));
         }
 
-        if (RiskLevels != null && RiskLevels.Any())
-        {
-            query = query.Where(v => RiskLevels.Contains(v.RiskLevel));
-        }
+        var entities = await query.ToListAsync();
 
-        return await query
+        var result = entities
             .Select(v => new StudentsByFiltersResponse
             {
                 Id = v.StudentId,
@@ -108,7 +103,13 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
                 AnswerText = v.AnswerText,
                 RiskLevel = v.RiskLevel
             })
-            .Distinct()
-            .ToListAsync();
+            .Distinct();
+
+        if (RiskLevels != null && RiskLevels.Any())
+        {
+            result = result.Where(v => RiskLevels.Contains(Math.Floor(v.RiskLevel)));
+        }
+
+        return result.ToList();
     }
 }


### PR DESCRIPTION
## Description
### Problem
The student detail list in the heatmap modal was returning empty 
when the selected risk level had decimal values in the database 
(e.g. 2.5, 4.3). The filter was doing an exact match between 
the integer sent from the frontend and the decimal stored in the DB.

### Root Cause
`GetStudentsByFilters` and `GetStudentsByEvaluationIdFilters` were 
filtering with `RiskLevels.Contains(v.RiskLevel)` directly in SQL, 
so [3].Contains(2.5) always returned false.

### Fix
Moved the RiskLevels filter to in-memory after `ToListAsync()` and 
applied `Math.Floor` before comparing, so decimal values correctly 
match their integer group.

### Files changed
- `ERAS-BE/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs`


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


