### PR TITLE
Fix(be 745) Add pagination for students lists

### DIFF
--- a/src/Eras.Api/Controllers/EvaluationDetailsController.cs
+++ b/src/Eras.Api/Controllers/EvaluationDetailsController.cs
@@ -2,6 +2,7 @@
 
 using Eras.Application.Features.EvaluationDetails.Queries.GetStudentsByEvaluationId;
 using Eras.Application.Features.EvaluationDetails.Queries.GetStudentsByFilters;
+using Eras.Application.Utils;
 
 using MediatR;
 
@@ -17,7 +18,8 @@ public class EvaluationDetailsController(IMediator Mediator, ILogger<Evaluations
     private readonly ILogger<EvaluationsController> _logger = Logger;
 
     [HttpGet("StudentsByFilters")]
-    public async Task<IActionResult> StudentsByFilterAsync([FromQuery, Required] string PollUuid, [FromQuery, Required, MinLength(1)] List<string> ComponentNames, [FromQuery, Required, MinLength(1)] List<int> CohortIds, [FromQuery, Required, MinLength(1)] List<int>? VariableIds, [FromQuery] List<decimal>? RiskLevels)
+    public async Task<IActionResult> StudentsByFilterAsync(
+        [FromQuery, Required] string PollUuid, [FromQuery, Required, MinLength(1)] List<string> ComponentNames, [FromQuery, Required, MinLength(1)] List<int> CohortIds, [FromQuery, Required, MinLength(1)] List<int>? VariableIds, [FromQuery] List<decimal>? RiskLevels, [FromQuery] Pagination Query)
     {
         _logger.LogInformation("Retrieving students with filters {PollId}, Components ({ComponentIds}), Cohorts ({CohortIds}), Variables ({VariableIds})", PollUuid, ComponentNames, CohortIds, VariableIds);
         var query = new GetStudentsByFiltersQuery()
@@ -26,7 +28,8 @@ public class EvaluationDetailsController(IMediator Mediator, ILogger<Evaluations
             ComponentNames = ComponentNames,
             CohortIds = CohortIds,
             VariableIds = VariableIds,
-            RiskLevels = RiskLevels
+            RiskLevels = RiskLevels,
+            PageValues = Query
         };
         var response = await _mediator.Send(query);
 

--- a/src/Eras.Api/Controllers/StudentsController.cs
+++ b/src/Eras.Api/Controllers/StudentsController.cs
@@ -136,16 +136,18 @@ public class StudentsController(IMediator Mediator, ILogger<StudentsController> 
     }
 
     [HttpGet("polls/{Uuid}/top")]
-    public async Task<IActionResult> GetPollTopStudentsAsync([FromRoute] string Uuid, [FromQuery] int CohortId, [FromQuery] bool LastVersion)
+    public async Task<IActionResult> GetPollTopStudentsAsync(
+        [FromRoute] string Uuid, [FromQuery] int CohortId, [FromQuery] bool LastVersion, [FromQuery] Pagination Query)
     {
         var getCohortTopRiskStudentsQuery = new GetCohortTopRiskStudentsQuery()
         {
             PollUuid = Uuid,
             //Todo: Cohort Filter should be optional
             CohortId = CohortId,
-            LastVersion = LastVersion
+            LastVersion = LastVersion,
+            PageValues = Query
         };
-        GetQueryResponse<List<GetCohortTopRiskStudentsByComponentResponse>> queryResponse = await _mediator.Send(getCohortTopRiskStudentsQuery);
+        GetQueryResponse<PagedResult<GetCohortTopRiskStudentsByComponentResponse>> queryResponse = await _mediator.Send(getCohortTopRiskStudentsQuery);
 
         return Ok(queryResponse.Body);
     }

--- a/src/Eras.Api/Controllers/StudentsController.cs
+++ b/src/Eras.Api/Controllers/StudentsController.cs
@@ -153,7 +153,8 @@ public class StudentsController(IMediator Mediator, ILogger<StudentsController> 
     }
 
     [HttpGet("polls/{Uuid}/components/top")]
-    public async Task<IActionResult> GetComponentTopStudentsAsync([FromRoute] string Uuid, [FromQuery] string ComponentName, [FromQuery] int CohortId, [FromQuery] bool LastVersion)
+    public async Task<IActionResult> GetComponentTopStudentsAsync(
+        [FromRoute] string Uuid, [FromQuery] string ComponentName, [FromQuery] int CohortId, [FromQuery] bool LastVersion, [FromQuery] Pagination Query)
     {
         var getCohortTopRiskStudentsByComponentQuery = new GetCohortTopRiskStudentsByComponentQuery()
         {
@@ -161,8 +162,9 @@ public class StudentsController(IMediator Mediator, ILogger<StudentsController> 
             ComponentName = ComponentName,
             CohortId = CohortId,
             LastVersion = LastVersion,
+            PageValues = Query
         };
-        GetQueryResponse<List<GetCohortTopRiskStudentsByComponentResponse>> queryResponse = await _mediator.Send(getCohortTopRiskStudentsByComponentQuery);
+        GetQueryResponse<PagedResult<GetCohortTopRiskStudentsByComponentResponse>> queryResponse = await _mediator.Send(getCohortTopRiskStudentsByComponentQuery);
 
         return Ok(queryResponse.Body);
     }

--- a/src/Eras.Application/Contracts/Persistence/ICohortRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/ICohortRepository.cs
@@ -8,9 +8,9 @@ public interface ICohortRepository : IBaseRepository<Cohort>
     Task<Cohort?> GetByNameAsync(string Name);
     Task<Cohort?> GetByCourseCodeAsync(string Name);
     Task<List<Cohort>> GetCohortsAsync();
-    Task<List<GetCohortTopRiskStudentsByComponentResponse>> GetCohortTopRiskStudentsByComponentAsync(string PollUuid, string ComponentName, int CohortId, bool LastVersion);
+    Task<IEnumerable<GetCohortTopRiskStudentsByComponentResponse>> GetCohortTopRiskStudentsByComponentAsync(string PollUuid, string ComponentName, int CohortId, bool LastVersion, int Page, int PageSize);
     Task<IEnumerable<GetCohortTopRiskStudentsByComponentResponse>> GetCohortTopRiskStudentsAsync(string PollUuid, int CohortId, bool LastVersion, int Page, int PageSize);
     Task<List<Cohort>> GetCohortsByPollUuidAsync(string PollUuid, bool LastVersion);
     Task<List<Cohort>> GetCohortsByPollIdAsync(int PollId);
-    Task<int> CountStudentsAsync(string PollUuid, int CohortId, bool LastVersion);
+    Task<int> CountStudentsAsync(string PollUuid, int CohortId, bool LastVersion, string? ComponentName = null);
 }

--- a/src/Eras.Application/Contracts/Persistence/ICohortRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/ICohortRepository.cs
@@ -9,7 +9,8 @@ public interface ICohortRepository : IBaseRepository<Cohort>
     Task<Cohort?> GetByCourseCodeAsync(string Name);
     Task<List<Cohort>> GetCohortsAsync();
     Task<List<GetCohortTopRiskStudentsByComponentResponse>> GetCohortTopRiskStudentsByComponentAsync(string PollUuid, string ComponentName, int CohortId, bool LastVersion);
-    Task<List<GetCohortTopRiskStudentsByComponentResponse>> GetCohortTopRiskStudentsAsync(string PollUuid, int CohortId, bool LastVersion);
+    Task<IEnumerable<GetCohortTopRiskStudentsByComponentResponse>> GetCohortTopRiskStudentsAsync(string PollUuid, int CohortId, bool LastVersion, int Page, int PageSize);
     Task<List<Cohort>> GetCohortsByPollUuidAsync(string PollUuid, bool LastVersion);
     Task<List<Cohort>> GetCohortsByPollIdAsync(int PollId);
+    Task<int> CountStudentsAsync(string PollUuid, int CohortId, bool LastVersion);
 }

--- a/src/Eras.Application/Contracts/Persistence/IErasEvaluationDetailsViewRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/IErasEvaluationDetailsViewRepository.cs
@@ -12,6 +12,8 @@ namespace Eras.Application.Contracts.Persistence;
 public interface IErasEvaluationDetailsViewRepository : IBaseRepository<ErasEvaluationDetailsView>
 {
     Task<List<ErasEvaluationDetailsView>> GetByFiltersAsync(int? PollId, List<int>? ComponentIds, List<int>? CohortIds, List<int>? VariableIds);
-    Task<List<StudentsByFiltersResponse>> GetStudentsByFilters(string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevel);
+    Task<(IEnumerable<ErasEvaluationDetailsView> Items, int Total)> GetStudentsByFilters(string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevel, int Page, int PageSize);
     Task<List<StudentsByFiltersResponse>> GetStudentsByEvaluationIdFilters(int EvaluationId, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevel);
+    new Task<int> CountAsync();
+
 }

--- a/src/Eras.Application/Contracts/Persistence/IErasEvaluationDetailsViewRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/IErasEvaluationDetailsViewRepository.cs
@@ -12,8 +12,8 @@ namespace Eras.Application.Contracts.Persistence;
 public interface IErasEvaluationDetailsViewRepository : IBaseRepository<ErasEvaluationDetailsView>
 {
     Task<List<ErasEvaluationDetailsView>> GetByFiltersAsync(int? PollId, List<int>? ComponentIds, List<int>? CohortIds, List<int>? VariableIds);
-    Task<(IEnumerable<ErasEvaluationDetailsView> Items, int Total)> GetStudentsByFilters(string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevel, int Page, int PageSize);
+    Task<IEnumerable<ErasEvaluationDetailsView>> GetStudentsByFilters(string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevel, int Page, int PageSize);
     Task<List<StudentsByFiltersResponse>> GetStudentsByEvaluationIdFilters(int EvaluationId, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevel);
-    new Task<int> CountAsync();
+    Task<int> CountStudentsByFilters(string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevel);
 
 }

--- a/src/Eras.Application/Features/Cohort/Queries/GetCohortTopRiskStudents/GetCohortTopRiskStudentsQuery.cs
+++ b/src/Eras.Application/Features/Cohort/Queries/GetCohortTopRiskStudents/GetCohortTopRiskStudentsQuery.cs
@@ -1,12 +1,14 @@
 ﻿using Eras.Application.Models.Response.Calculations;
 using Eras.Application.Models.Response.Common;
+using Eras.Application.Utils;
 
 using MediatR;
 
 namespace Eras.Application.Features.Cohorts.Queries.GetCohortTopRiskStudents;
-public class GetCohortTopRiskStudentsQuery : IRequest<GetQueryResponse<List<GetCohortTopRiskStudentsByComponentResponse>>>
+public class GetCohortTopRiskStudentsQuery : IRequest<GetQueryResponse<PagedResult<GetCohortTopRiskStudentsByComponentResponse>>>
 {
     public required string PollUuid { get; set; }
     public int CohortId { get; set; }
     public bool LastVersion { get; set; }
+    public required Pagination PageValues { get; set; }
 }

--- a/src/Eras.Application/Features/Cohort/Queries/GetCohortTopRiskStudents/GetCohortTopRiskStudentsQueryHandler.cs
+++ b/src/Eras.Application/Features/Cohort/Queries/GetCohortTopRiskStudents/GetCohortTopRiskStudentsQueryHandler.cs
@@ -1,13 +1,15 @@
 ﻿using Eras.Application.Contracts.Persistence;
 using Eras.Application.Models.Response.Calculations;
 using Eras.Application.Models.Response.Common;
+using Eras.Application.Models.Response.Controllers.EvaluationDetailsController;
+using Eras.Application.Utils;
 
 using MediatR;
 
 using Microsoft.Extensions.Logging;
 
 namespace Eras.Application.Features.Cohorts.Queries.GetCohortTopRiskStudents;
-public class GetCohortTopRiskStudentsQueryHandler : IRequestHandler<GetCohortTopRiskStudentsQuery, GetQueryResponse<List<GetCohortTopRiskStudentsByComponentResponse>>>
+public class GetCohortTopRiskStudentsQueryHandler : IRequestHandler<GetCohortTopRiskStudentsQuery, GetQueryResponse<PagedResult<GetCohortTopRiskStudentsByComponentResponse>>>
 {
     private readonly ICohortRepository _cohortRepository;
     private readonly ILogger<GetCohortTopRiskStudentsQueryHandler> _logger;
@@ -17,9 +19,26 @@ public class GetCohortTopRiskStudentsQueryHandler : IRequestHandler<GetCohortTop
         _logger = Logger;
     }
 
-    public async Task<GetQueryResponse<List<GetCohortTopRiskStudentsByComponentResponse>>> Handle(GetCohortTopRiskStudentsQuery Request, CancellationToken CancellationToken)
+    public async Task<GetQueryResponse<PagedResult<GetCohortTopRiskStudentsByComponentResponse>>> Handle(GetCohortTopRiskStudentsQuery Request, CancellationToken CancellationToken)
     {
-        var studentsList = await _cohortRepository.GetCohortTopRiskStudentsAsync(Request.PollUuid, Request.CohortId, Request.LastVersion);
-        return new GetQueryResponse<List<GetCohortTopRiskStudentsByComponentResponse>>(studentsList);
+        try
+        {
+            var studentsList = await _cohortRepository.GetCohortTopRiskStudentsAsync(
+                Request.PollUuid,
+                Request.CohortId,
+                Request.LastVersion,
+                Request.PageValues.Page,
+                Request.PageValues.PageSize
+            );
+
+            var totalCount = await _cohortRepository.CountStudentsAsync(Request.PollUuid, Request.CohortId, Request.LastVersion);
+            var pagedResult = new PagedResult<GetCohortTopRiskStudentsByComponentResponse>(totalCount, studentsList.ToList());
+            return new GetQueryResponse<PagedResult<GetCohortTopRiskStudentsByComponentResponse>>(pagedResult);
+        }
+        catch (Exception ex) {
+            _logger.LogError(ex, "An error occurred while getting cohort top risk: " + ex.Message);
+            return new GetQueryResponse<PagedResult<GetCohortTopRiskStudentsByComponentResponse>>(
+                new PagedResult<GetCohortTopRiskStudentsByComponentResponse>(0, []));
+        }
     }
 }

--- a/src/Eras.Application/Features/Cohort/Queries/GetCohortTopRiskStudentsByComponent/GetCohortTopRiskStudentsByComponentQuery.cs
+++ b/src/Eras.Application/Features/Cohort/Queries/GetCohortTopRiskStudentsByComponent/GetCohortTopRiskStudentsByComponentQuery.cs
@@ -1,13 +1,15 @@
 ﻿using Eras.Application.Models.Response.Calculations;
 using Eras.Application.Models.Response.Common;
+using Eras.Application.Utils;
 
 using MediatR;
 
 namespace Eras.Application.Features.Cohorts.Queries.GetCohortTopRiskStudentsByComponent;
-public class GetCohortTopRiskStudentsByComponentQuery : IRequest<GetQueryResponse<List<GetCohortTopRiskStudentsByComponentResponse>>>
+public class GetCohortTopRiskStudentsByComponentQuery : IRequest<GetQueryResponse<PagedResult<GetCohortTopRiskStudentsByComponentResponse>>>
 {
     public required string PollUuid { get; set; }
     public required string ComponentName { get; set; }
     public int CohortId { get; set; }
     public bool LastVersion { get; set; }
+    public required Pagination PageValues { get; set; }
 }

--- a/src/Eras.Application/Features/Cohort/Queries/GetCohortTopRiskStudentsByComponent/GetCohortTopRiskStudentsByComponentQueryHandler.cs
+++ b/src/Eras.Application/Features/Cohort/Queries/GetCohortTopRiskStudentsByComponent/GetCohortTopRiskStudentsByComponentQueryHandler.cs
@@ -1,20 +1,40 @@
 ﻿using Eras.Application.Contracts.Persistence;
 using Eras.Application.Models.Response.Calculations;
 using Eras.Application.Models.Response.Common;
+using Eras.Application.Utils;
 
 using MediatR;
 
 using Microsoft.Extensions.Logging;
 
 namespace Eras.Application.Features.Cohorts.Queries.GetCohortTopRiskStudentsByComponent;
-public class GetCohortTopRiskStudentsByComponentQueryHandler(ICohortRepository CohortRepository, ILogger<GetCohortTopRiskStudentsByComponentQueryHandler> Logger) : IRequestHandler<GetCohortTopRiskStudentsByComponentQuery, GetQueryResponse<List<GetCohortTopRiskStudentsByComponentResponse>>>
+public class GetCohortTopRiskStudentsByComponentQueryHandler(ICohortRepository CohortRepository, ILogger<GetCohortTopRiskStudentsByComponentQueryHandler> Logger) : IRequestHandler<GetCohortTopRiskStudentsByComponentQuery, GetQueryResponse<PagedResult<GetCohortTopRiskStudentsByComponentResponse>>>
 {
     private readonly ICohortRepository _cohortRepository = CohortRepository;
     private readonly ILogger<GetCohortTopRiskStudentsByComponentQueryHandler> _logger = Logger;
 
-    public async Task<GetQueryResponse<List<GetCohortTopRiskStudentsByComponentResponse>>> Handle(GetCohortTopRiskStudentsByComponentQuery Request, CancellationToken CancellationToken)
+    public async Task<GetQueryResponse<PagedResult<GetCohortTopRiskStudentsByComponentResponse>>> Handle(GetCohortTopRiskStudentsByComponentQuery Request, CancellationToken CancellationToken)
     {
-        List<GetCohortTopRiskStudentsByComponentResponse> listStudents = await _cohortRepository.GetCohortTopRiskStudentsByComponentAsync(Request.PollUuid, Request.ComponentName, Request.CohortId, Request.LastVersion);
-        return new GetQueryResponse<List<GetCohortTopRiskStudentsByComponentResponse>>(listStudents);
+        try
+        {
+            var listStudents = await _cohortRepository.GetCohortTopRiskStudentsByComponentAsync(
+                Request.PollUuid,
+                Request.ComponentName,
+                Request.CohortId,
+                Request.LastVersion,
+                Request.PageValues.Page,
+                Request.PageValues.PageSize
+            );
+
+            var totalCount = await _cohortRepository.CountStudentsAsync(Request.PollUuid, Request.CohortId, Request.LastVersion, Request.ComponentName);
+            var pagedResult = new PagedResult<GetCohortTopRiskStudentsByComponentResponse>(totalCount, listStudents.ToList());
+            return new GetQueryResponse<PagedResult<GetCohortTopRiskStudentsByComponentResponse>>(pagedResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An error occurred while getting cohort top risk: " + ex.Message);
+            return new GetQueryResponse<PagedResult<GetCohortTopRiskStudentsByComponentResponse>>(
+                new PagedResult<GetCohortTopRiskStudentsByComponentResponse>(0, []));
+        }
     }
 }

--- a/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByFilters/GetStudentsByFiltersQuery.cs
+++ b/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByFilters/GetStudentsByFiltersQuery.cs
@@ -1,15 +1,17 @@
 ﻿using Eras.Application.Models.Response.Controllers.EvaluationDetailsController;
+using Eras.Application.Utils;
 
 using MediatR;
 
 namespace Eras.Application.Features.EvaluationDetails.Queries.GetStudentsByFilters;
 
-public class GetStudentsByFiltersQuery : IRequest<List<StudentsByFiltersResponse>>
+public class GetStudentsByFiltersQuery : IRequest<PagedResult<StudentsByFiltersResponse>>
 {
     public required string PollUuid { get; set; }
     public required List<string> ComponentNames { get; set; }
     public required List<int> CohortIds { get; set; }
     public List<int>? VariableIds { get; set; }
     public List<decimal>? RiskLevels { get; set; }
+    public required Pagination PageValues { get; set; } 
 
 }

--- a/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByFilters/GetStudentsByFiltersQueryHandler.cs
+++ b/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByFilters/GetStudentsByFiltersQueryHandler.cs
@@ -27,21 +27,26 @@ public class GetStudentsByFiltersQueryHandler :
         _repository = Repository;
         _logger = Logger;
     }
-
     public async Task<PagedResult<StudentsByFiltersResponse>> Handle(GetStudentsByFiltersQuery Request, CancellationToken CancellationToken)
     {
         try
         {
-            var (items, total) = await _repository.GetStudentsByFilters(
+            var studentsList = await _repository.GetStudentsByFilters(
                 Request.PollUuid,
-                Request.ComponentNames,
+                Request.ComponentNames, 
                 Request.CohortIds,
                 Request.VariableIds,
                 Request.RiskLevels,
-                Request.PageValues.Page,
+                Request.PageValues.Page, 
                 Request.PageValues.PageSize
             );
-            var studentsResponses = items.Select(Student => new StudentsByFiltersResponse
+
+            var totalCount = await _repository.CountStudentsByFilters(
+                Request.PollUuid, Request.ComponentNames, Request.CohortIds,
+                Request.VariableIds, Request.RiskLevels
+            );
+
+            var studentsResponses = studentsList.Select(Student => new StudentsByFiltersResponse
             {
                 Id = Student.StudentId,
                 Name = Student.StudentName,
@@ -51,16 +56,11 @@ public class GetStudentsByFiltersQueryHandler :
                 RiskLevel = Student.RiskLevel
             }).ToList();
 
-            PagedResult<StudentsByFiltersResponse> pagedResult = new PagedResult<StudentsByFiltersResponse>(
-                total,
-                studentsResponses
-            );
-
-            return pagedResult;
+            return new PagedResult<StudentsByFiltersResponse>(totalCount, studentsResponses);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "An error occured while filter students: " + ex.Message);
+            _logger.LogError(ex, "An error occurred while filtering students: " + ex.Message);
             return new PagedResult<StudentsByFiltersResponse>(0, []);
         }
     }

--- a/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByFilters/GetStudentsByFiltersQueryHandler.cs
+++ b/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByFilters/GetStudentsByFiltersQueryHandler.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Eras.Application.Contracts.Persistence;
 using Eras.Application.Features.EvaluationDetails.Queries.GetEvaluationDetailsByFilters;
 using Eras.Application.Models.Response.Controllers.EvaluationDetailsController;
+using Eras.Application.Utils;
 using Eras.Domain.Entities;
 
 using MediatR;
@@ -15,7 +16,8 @@ using Microsoft.Extensions.Logging;
 
 namespace Eras.Application.Features.EvaluationDetails.Queries.GetStudentsByFilters;
 
-public class GetStudentsByFiltersQueryHandler : IRequestHandler<GetStudentsByFiltersQuery, List<StudentsByFiltersResponse>>
+public class GetStudentsByFiltersQueryHandler : 
+    IRequestHandler<GetStudentsByFiltersQuery, PagedResult<StudentsByFiltersResponse>>
 {
     private readonly IErasEvaluationDetailsViewRepository _repository;
     private readonly ILogger<GetStudentsByFiltersQueryHandler> _logger;
@@ -26,16 +28,40 @@ public class GetStudentsByFiltersQueryHandler : IRequestHandler<GetStudentsByFil
         _logger = Logger;
     }
 
-    public async Task<List<StudentsByFiltersResponse>> Handle(GetStudentsByFiltersQuery Request, CancellationToken CancellationToken)
+    public async Task<PagedResult<StudentsByFiltersResponse>> Handle(GetStudentsByFiltersQuery Request, CancellationToken CancellationToken)
     {
-        var studentsList = await _repository.GetStudentsByFilters(
-            Request.PollUuid,
-            Request.ComponentNames,
-            Request.CohortIds,
-            Request.VariableIds,
-            Request.RiskLevels
-        );
+        try
+        {
+            var (items, total) = await _repository.GetStudentsByFilters(
+                Request.PollUuid,
+                Request.ComponentNames,
+                Request.CohortIds,
+                Request.VariableIds,
+                Request.RiskLevels,
+                Request.PageValues.Page,
+                Request.PageValues.PageSize
+            );
+            var studentsResponses = items.Select(Student => new StudentsByFiltersResponse
+            {
+                Id = Student.StudentId,
+                Name = Student.StudentName,
+                Email = Student.StudentEmail,
+                AnswerId = Student.AnswerId,
+                AnswerText = Student.AnswerText,
+                RiskLevel = Student.RiskLevel
+            }).ToList();
 
-        return studentsList;
+            PagedResult<StudentsByFiltersResponse> pagedResult = new PagedResult<StudentsByFiltersResponse>(
+                total,
+                studentsResponses
+            );
+
+            return pagedResult;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An error occured while filter students: " + ex.Message);
+            return new PagedResult<StudentsByFiltersResponse>(0, []);
+        }
     }
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/CohortRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/CohortRepository.cs
@@ -33,57 +33,33 @@ public class CohortRepository(AppDbContext Context) : BaseRepository<Cohort, Coh
             .ToListAsync();
         return [.. cohorts.Select(P => P.ToDomain())];
     }
-
-    public async Task<List<GetCohortTopRiskStudentsByComponentResponse>> GetCohortTopRiskStudentsByComponentAsync(string PollUuid, string ComponentName, int CohortId, bool LastVersion)
+   
+    public async Task<IEnumerable<GetCohortTopRiskStudentsByComponentResponse>> GetCohortTopRiskStudentsByComponentAsync(
+    string PollUuid, string ComponentName, int CohortId, bool LastVersion, int Page, int PageSize)
     {
-
-        int pollVersion = _context.Polls
-            .Where(A => A.Uuid == PollUuid)
-            .Select(A => A.LastVersion)
-            .FirstOrDefault();
-
-        if (LastVersion)
-        {
-            List<GetCohortTopRiskStudentsByComponentResponse> result = await _context.ErasCalculationsByPoll
-                        .Where(View => View.PollUuid == PollUuid && View.ComponentName == ComponentName && View.CohortId == CohortId && View.PollVersion == pollVersion)
-                        .GroupBy(V => new { V.PollInstanceId, V.StudentName, V.StudentId })
-                        .Select(Group => new GetCohortTopRiskStudentsByComponentResponse
-                        {
-                            StudentId = Group.Key.StudentId,
-                            StudentName = Group.Key.StudentName,
-                            AnswerAverage = Math.Round((decimal)Group.Average(V => V.AnswerRisk), 2),
-                            RiskSum = Group.Sum(V => V.AnswerRisk)
-                        })
-                        .OrderByDescending(G => G.RiskSum)
-                        .ToListAsync();
-            return result;
-        }
-        else
-        {
-            List<GetCohortTopRiskStudentsByComponentResponse> result = await _context.ErasCalculationsByPoll
-                        .Where(View => View.PollUuid == PollUuid && View.ComponentName == ComponentName && View.CohortId == CohortId && View.PollVersion != pollVersion)
-                        .GroupBy(V => new { V.PollInstanceId, V.StudentName, V.StudentId })
-                        .Select(Group => new GetCohortTopRiskStudentsByComponentResponse
-                        {
-                            StudentId = Group.Key.StudentId,
-                            StudentName = Group.Key.StudentName,
-                            AnswerAverage = Math.Round((decimal)Group.Average(V => V.AnswerRisk), 2),
-                            RiskSum = Group.Sum(V => V.AnswerRisk)
-                        })
-                        .OrderByDescending(G => G.RiskSum)
-                        .ToListAsync();
-            return result;
-        }
-
-
-
+        var query = BuildCohort(PollUuid, CohortId, LastVersion, ComponentName);
+        return await ProjectAndPaginate(query, Page, PageSize).ToListAsync();
     }
 
-    public async Task<IEnumerable<GetCohortTopRiskStudentsByComponentResponse>> GetCohortTopRiskStudentsAsync(string PollUuid, int CohortId, bool LastVersion, int Page, int PageSize)
+    public async Task<IEnumerable<GetCohortTopRiskStudentsByComponentResponse>> GetCohortTopRiskStudentsAsync(
+        string PollUuid, int CohortId, bool LastVersion, int Page, int PageSize)
     {
         var query = BuildCohort(PollUuid, CohortId, LastVersion);
+        return await ProjectAndPaginate(query, Page, PageSize).ToListAsync();
+    }
 
+    public async Task<int> CountStudentsAsync(string PollUuid, int CohortId, bool LastVersion, string? ComponentName = null)
+    {
+        var query = BuildCohort(PollUuid, CohortId, LastVersion, ComponentName);
         return await query
+            .GroupBy(V => new { V.PollInstanceId, V.StudentName, V.StudentId })
+            .CountAsync();
+    }
+
+    private IQueryable<GetCohortTopRiskStudentsByComponentResponse> ProjectAndPaginate(
+        IQueryable<ErasCalculationsByPollEntity> Query, int Page, int PageSize)
+    {
+        return Query
             .GroupBy(V => new { V.PollInstanceId, V.StudentName, V.StudentId })
             .Select(G => new GetCohortTopRiskStudentsByComponentResponse
             {
@@ -94,20 +70,11 @@ public class CohortRepository(AppDbContext Context) : BaseRepository<Cohort, Coh
             })
             .OrderByDescending(G => G.RiskSum)
             .Skip((Page - 1) * PageSize)
-            .Take(PageSize)
-            .ToListAsync();
+            .Take(PageSize);
     }
 
-    public async Task<int> CountStudentsAsync(string PollUuid, int CohortId, bool LastVersion)
-    {
-        var query = BuildCohort(PollUuid, CohortId, LastVersion);
-
-        return await query
-            .GroupBy(V => new { V.PollInstanceId, V.StudentName, V.StudentId })
-            .CountAsync();
-    }
-
-    private IQueryable<ErasCalculationsByPollEntity> BuildCohort(string PollUuid, int CohortId, bool LastVersion)
+    private IQueryable<ErasCalculationsByPollEntity> BuildCohort(
+        string PollUuid, int CohortId, bool LastVersion, string? ComponentName = null)
     {
         int pollVersion = _context.Polls
             .Where(A => A.Uuid == PollUuid)
@@ -116,11 +83,14 @@ public class CohortRepository(AppDbContext Context) : BaseRepository<Cohort, Coh
 
         var query = _context.ErasCalculationsByPoll
             .Where(V => V.PollUuid == PollUuid && V.CohortId == CohortId);
-        
+
         query = LastVersion
             ? query.Where(v => v.PollVersion == pollVersion)
             : query.Where(v => v.PollVersion != pollVersion);
-        
+
+        if (!string.IsNullOrEmpty(ComponentName))
+            query = query.Where(v => v.ComponentName == ComponentName);
+
         return query;
     }
 

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/CohortRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/CohortRepository.cs
@@ -75,49 +75,53 @@ public class CohortRepository(AppDbContext Context) : BaseRepository<Cohort, Coh
             return result;
         }
 
-        
+
 
     }
 
-    public async Task<List<GetCohortTopRiskStudentsByComponentResponse>> GetCohortTopRiskStudentsAsync(string PollUuid, int CohortId, bool LastVersion)
+    public async Task<IEnumerable<GetCohortTopRiskStudentsByComponentResponse>> GetCohortTopRiskStudentsAsync(string PollUuid, int CohortId, bool LastVersion, int Page, int PageSize)
+    {
+        var query = BuildCohort(PollUuid, CohortId, LastVersion);
+
+        return await query
+            .GroupBy(V => new { V.PollInstanceId, V.StudentName, V.StudentId })
+            .Select(G => new GetCohortTopRiskStudentsByComponentResponse
+            {
+                StudentId = G.Key.StudentId,
+                StudentName = G.Key.StudentName,
+                AnswerAverage = Math.Round((decimal)G.Average(V => V.AnswerRisk), 2),
+                RiskSum = G.Sum(V => V.AnswerRisk)
+            })
+            .OrderByDescending(G => G.RiskSum)
+            .Skip((Page - 1) * PageSize)
+            .Take(PageSize)
+            .ToListAsync();
+    }
+
+    public async Task<int> CountStudentsAsync(string PollUuid, int CohortId, bool LastVersion)
+    {
+        var query = BuildCohort(PollUuid, CohortId, LastVersion);
+
+        return await query
+            .GroupBy(V => new { V.PollInstanceId, V.StudentName, V.StudentId })
+            .CountAsync();
+    }
+
+    private IQueryable<ErasCalculationsByPollEntity> BuildCohort(string PollUuid, int CohortId, bool LastVersion)
     {
         int pollVersion = _context.Polls
             .Where(A => A.Uuid == PollUuid)
             .Select(A => A.LastVersion)
             .FirstOrDefault();
 
-        if (LastVersion)
-        {
-            List<GetCohortTopRiskStudentsByComponentResponse> result = await _context.ErasCalculationsByPoll
-                            .Where(V => V.PollUuid == PollUuid && V.CohortId == CohortId && V.PollVersion == pollVersion)
-                            .GroupBy(V => new { V.PollInstanceId, V.StudentName, V.StudentId })
-                            .Select(G => new GetCohortTopRiskStudentsByComponentResponse
-                            {
-                                StudentId = G.Key.StudentId,
-                                StudentName = G.Key.StudentName,
-                                AnswerAverage = Math.Round((decimal)G.Average(V => V.AnswerRisk), 2),
-                                RiskSum = G.Sum(V => V.AnswerRisk)
-                            })
-                            .OrderByDescending(G => G.RiskSum)
-                            .ToListAsync();
-            return result;
-        }
-        else
-        {
-            List<GetCohortTopRiskStudentsByComponentResponse> result = await _context.ErasCalculationsByPoll
-                            .Where(V => V.PollUuid == PollUuid && V.CohortId == CohortId && V.PollVersion != pollVersion)
-                            .GroupBy(V => new { V.PollInstanceId, V.StudentName, V.StudentId })
-                            .Select(G => new GetCohortTopRiskStudentsByComponentResponse
-                            {
-                                StudentId = G.Key.StudentId,
-                                StudentName = G.Key.StudentName,
-                                AnswerAverage = Math.Round((decimal)G.Average(V => V.AnswerRisk), 2),
-                                RiskSum = G.Sum(V => V.AnswerRisk)
-                            })
-                            .OrderByDescending(G => G.RiskSum)
-                            .ToListAsync();
-            return result;
-        }
+        var query = _context.ErasCalculationsByPoll
+            .Where(V => V.PollUuid == PollUuid && V.CohortId == CohortId);
+        
+        query = LastVersion
+            ? query.Where(v => v.PollVersion == pollVersion)
+            : query.Where(v => v.PollVersion != pollVersion);
+        
+        return query;
     }
 
     public async Task<List<Cohort>> GetCohortsByPollUuidAsync(string PollUuid, bool LastVersion)

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
@@ -82,8 +82,30 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
         return resultEval.ToList();
     }
 
-    public async Task<(IEnumerable<ErasEvaluationDetailsView> Items, int Total)> GetStudentsByFilters(
+    public async Task<IEnumerable<ErasEvaluationDetailsView>> GetStudentsByFilters(
         string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevels, int Page, int PageSize)
+    {
+        var query = BuildStudentsByFiltersQuery(PollUuid, ComponentNames, CohortIds, VariableIds, RiskLevels);
+
+        var entities = await query
+            .OrderBy(v => v.StudentName)
+            .Distinct()
+            .Skip((Page - 1) * PageSize)
+            .Take(PageSize)
+            .ToListAsync();
+
+        return entities.Select(ErasEvaluationDetailsViewMapper.ToDomain);
+    }
+
+    public async Task<int> CountStudentsByFilters(
+        string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevels)
+    {
+        var query = BuildStudentsByFiltersQuery(PollUuid, ComponentNames, CohortIds, VariableIds, RiskLevels);
+        return await query.Select(v => v.StudentId).Distinct().CountAsync();
+    }
+
+    private IQueryable<ErasEvaluationDetailsViewEntity> BuildStudentsByFiltersQuery(
+        string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevels)
     {
         var query = _context.Set<ErasEvaluationDetailsViewEntity>()
             .AsNoTracking()
@@ -92,27 +114,11 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
             .Where(v => ComponentNames.Contains(v.ComponentName));
 
         if (VariableIds != null && VariableIds.Any())
-        {
             query = query.Where(v => VariableIds.Contains(v.VariableId));
-        }
 
         if (RiskLevels != null && RiskLevels.Any())
-        {
-            result = result.Where(v => RiskLevels.Contains(Math.Floor(v.RiskLevel)));
-        }
-        
-        var entities = await query.ToListAsync();
+            query = query.Where(v => RiskLevels.Contains((Math.Floor(v.RiskLevel))));
 
-        int total = await query.Select(v => v.StudentId).CountAsync();
-
-        var persistenceEntities = await query
-            .OrderBy(Eval => Eval.StudentName)
-            .Skip((Page - 1) * PageSize)
-            .Take(PageSize)
-            .Distinct()
-            .ToListAsync(); 
-        var items = persistenceEntities.Select(Eval => ErasEvaluationDetailsViewMapper.ToDomain(Eval)); 
-        
-        return (items, total);
+        return query;
     }
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
@@ -6,11 +6,15 @@ using System.Threading.Tasks;
 
 using Eras.Application.Contracts.Persistence;
 using Eras.Application.Models.Response.Controllers.EvaluationDetailsController;
+using Eras.Application.Utils;
 using Eras.Domain.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Mappers;
 
+using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
+
+using static Microsoft.EntityFrameworkCore.DbLoggerCategory;
 
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
 
@@ -78,38 +82,37 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
         return resultEval.ToList();
     }
 
-    public async Task<List<StudentsByFiltersResponse>> GetStudentsByFilters(string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevels)
+    public async Task<(IEnumerable<ErasEvaluationDetailsView> Items, int Total)> GetStudentsByFilters(
+        string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevels, int Page, int PageSize)
     {
-        var query = _context.Set<ErasEvaluationDetailsViewEntity>().AsNoTracking();
-
-        query = query.Where(v => v.PollUuid == PollUuid);
-        query = query.Where(v => CohortIds.Contains(v.CohortId));
-        query = query.Where(v => ComponentNames.Contains(v.ComponentName));
+        var query = _context.Set<ErasEvaluationDetailsViewEntity>()
+            .AsNoTracking()
+            .Where(v => v.PollUuid == PollUuid)
+            .Where(v => CohortIds.Contains(v.CohortId))
+            .Where(v => ComponentNames.Contains(v.ComponentName));
 
         if (VariableIds != null && VariableIds.Any())
         {
             query = query.Where(v => VariableIds.Contains(v.VariableId));
         }
 
-        var entities = await query.ToListAsync();
-
-        var result = entities
-            .Select(v => new StudentsByFiltersResponse
-            {
-                Id = v.StudentId,
-                Name = v.StudentName,
-                Email = v.StudentEmail,
-                AnswerId = v.AnswerId,
-                AnswerText = v.AnswerText,
-                RiskLevel = v.RiskLevel
-            })
-            .Distinct();
-
         if (RiskLevels != null && RiskLevels.Any())
         {
             result = result.Where(v => RiskLevels.Contains(Math.Floor(v.RiskLevel)));
         }
+        
+        var entities = await query.ToListAsync();
 
-        return result.ToList();
+        int total = await query.Select(v => v.StudentId).CountAsync();
+
+        var persistenceEntities = await query
+            .OrderBy(Eval => Eval.StudentName)
+            .Skip((Page - 1) * PageSize)
+            .Take(PageSize)
+            .Distinct()
+            .ToListAsync(); 
+        var items = persistenceEntities.Select(Eval => ErasEvaluationDetailsViewMapper.ToDomain(Eval)); 
+        
+        return (items, total);
     }
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
@@ -11,7 +11,6 @@ using Eras.Domain.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Mappers;
 
-using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 
 using static Microsoft.EntityFrameworkCore.DbLoggerCategory;

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollVariableRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollVariableRepository.cs
@@ -7,7 +7,6 @@ using Eras.Domain.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Joins;
 using Eras.Infrastructure.Persistence.PostgreSQL.Mappers;
 
-using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories


### PR DESCRIPTION
## Description

### Problem
The pagination to watch and manipulate the list of students in monitoring students, dynamic heatmap chart, dynamic column chart and summary column chart did not work correctly, always it displayed all values in the list.

### Root Cause
GetStudentsByFilters,  GetCohortTopRiskStudents and GetCohortTopRiskStudentsByComponent did not return PagedResult, instead they used Lists. Lack of pagination in those endpoints.

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?



