### PR TITLE
fix: apply GetRiskGroup to match decimal risk levels with correct ran…

### DIFF
--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
@@ -75,7 +75,7 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
 
         if (RiskLevels != null && RiskLevels.Any())
         {
-            resultEval = resultEval.Where(v => RiskLevels.Contains(Math.Floor(v.RiskLevel)));
+            resultEval = resultEval.Where(v => RiskLevels.Contains((decimal)GetRiskGroup((double)v.RiskLevel)));
         }
 
         return resultEval.ToList();
@@ -89,11 +89,16 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
         var entities = await query
             .OrderBy(v => v.StudentName)
             .Distinct()
-            .Skip((Page - 1) * PageSize)
-            .Take(PageSize)
             .ToListAsync();
 
-        return entities.Select(ErasEvaluationDetailsViewMapper.ToDomain);
+        var filtered = (RiskLevels != null && RiskLevels.Any())
+            ? entities.Where(v => RiskLevels.Contains((decimal)GetRiskGroup((double)v.RiskLevel)))
+            : entities;
+
+        return filtered
+            .Skip((Page - 1) * PageSize)
+            .Take(PageSize)
+            .Select(ErasEvaluationDetailsViewMapper.ToDomain);
     }
 
     public async Task<int> CountStudentsByFilters(
@@ -115,9 +120,16 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
         if (VariableIds != null && VariableIds.Any())
             query = query.Where(v => VariableIds.Contains(v.VariableId));
 
-        if (RiskLevels != null && RiskLevels.Any())
-            query = query.Where(v => RiskLevels.Contains((Math.Floor(v.RiskLevel))));
-
         return query;
+    }
+
+    private static int GetRiskGroup(double risk)
+    {
+        if (risk < 1) return 0;
+        if (risk < 1.5) return 1;
+        if (risk < 2.5) return 2;
+        if (risk < 3.5) return 3;
+        if (risk < 4.5) return 4;
+        return 5;
     }
 }


### PR DESCRIPTION
## Description

This MR addresses an issue identified as a side effect of the previous fix related to the Column Chart.

After applying that correction, the Heat Map component was unintentionally affected and stopped displaying data correctly. This update resolves the Heat Map issue and ensures it works as expected without impacting the previously fixed Column Chart functionality.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


