### PR TITLE
355 enhance poll re import logic to properly manage existing and new students

### DIFF
--- a/src/Eras.Application/Contracts/Persistence/IAnswerRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/IAnswerRepository.cs
@@ -6,6 +6,7 @@ namespace Eras.Application.Contracts.Persistence
     {
         Task<List<Answer>> GetByPollInstanceIdAsync(string Uuid);
         Task<List<Answer>> GetByStudentIdAsync(string Uuid);
+        Task<List<Answer>> GetByPollInstanceAnswerAndPollVariableAsync(int PollVariableId, int PollInstanceId, string AnswerText);
         Task SaveManyAnswersAsync(List<Answer> Answers);
     }
 }

--- a/src/Eras.Application/Contracts/Persistence/IAnswerRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/IAnswerRepository.cs
@@ -8,5 +8,7 @@ namespace Eras.Application.Contracts.Persistence
         Task<List<Answer>> GetByStudentIdAsync(string Uuid);
         Task<List<Answer>> GetByPollInstanceAnswerAndPollVariableAsync(int PollVariableId, int PollInstanceId, string AnswerText);
         Task SaveManyAnswersAsync(List<Answer> Answers);
+        Task<Answer?> GetByPollInstanceAndVariableAsync(int PollVariableId, int PollInstanceId);
+        Task UpdateAnswerTextAsync(int Id, string AnswerText, decimal RiskLevel);
     }
 }

--- a/src/Eras.Application/Contracts/Persistence/IPollInstanceRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/IPollInstanceRepository.cs
@@ -8,6 +8,7 @@ public interface IPollInstanceRepository : IBaseRepository<PollInstance>
 {
     Task<PollInstance?> GetByUuidAsync(string Uuid);
     Task<PollInstance?> GetByUuidAndStudentIdAsync(string Uuid, int StudentId);
+    Task<bool> ExistsByPollNameAndStudentEmailAsync(string PollName, string StudentEmail);
 
     Task<IEnumerable<PollInstance>> GetByLastDays(int Days, bool LastVersion, string PollUuid);
 

--- a/src/Eras.Application/Dtos/PollDTO.cs
+++ b/src/Eras.Application/Dtos/PollDTO.cs
@@ -44,5 +44,7 @@ public class PollDTO
     [StringLength(100, MinimumLength = 3, ErrorMessage = "Parent Id Id must be between 3 and 100 characters.")]
     [RegularExpression(@"^[a-zA-Z0-9_\-]+$", ErrorMessage = "Parent Id can only contain letters, numbers, dashes and underscores.")]
     public string ParentId { get; set; } = string.Empty;
+
+    public bool IsAlreadyImported { get; set; } = false;
 }
 

--- a/src/Eras.Application/Features/Answers/Commands/CreateAnswerList/CreateAnswerListCommandHandler.cs
+++ b/src/Eras.Application/Features/Answers/Commands/CreateAnswerList/CreateAnswerListCommandHandler.cs
@@ -32,6 +32,17 @@ namespace Eras.Application.Features.Answers.Commands.CreateAnswerList
             {
                 try
                 {
+                    var existing = await _answerRepository.GetByPollInstanceAnswerAndPollVariableAsync(
+                        answer.PollVariableId,
+                        answer.PollInstanceId,
+                        answer.AnswerText);
+
+                    if (existing.Any())
+                    {
+                        _logger.LogInformation("Answer already exists, skipping duplicate");
+                        continue;
+                    }
+
                     await _answerRepository.AddAsync(answer);
                 }
                 catch (Exception ex)

--- a/src/Eras.Application/Features/Answers/Commands/CreateAnswerList/CreateAnswerListCommandHandler.cs
+++ b/src/Eras.Application/Features/Answers/Commands/CreateAnswerList/CreateAnswerListCommandHandler.cs
@@ -32,26 +32,25 @@ namespace Eras.Application.Features.Answers.Commands.CreateAnswerList
             {
                 try
                 {
-                    var existing = await _answerRepository.GetByPollInstanceAnswerAndPollVariableAsync(
-                        answer.PollVariableId,
-                        answer.PollInstanceId,
-                        answer.AnswerText);
+                    var existing = await _answerRepository
+                        .GetByPollInstanceAndVariableAsync(answer.PollVariableId, answer.PollInstanceId);
 
-                    if (existing.Any())
+                    if (existing != null)
                     {
-                        _logger.LogInformation("Answer already exists, skipping duplicate");
-                        continue;
+                        await _answerRepository.UpdateAnswerTextAsync(existing.Id, answer.AnswerText, answer.RiskLevel);
                     }
 
-                    await _answerRepository.AddAsync(answer);
+                    else
+                    {
+                        await _answerRepository.AddAsync(answer);
+                    }
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "An error occurred creating answers ");
+                    _logger.LogError(ex, "An error occurred creating or updating answers");
                 }
             }
             return new CreateCommandResponse<List<Answer>>(answers, 1, "Success", true);
-
         }
     }
 }

--- a/src/Eras.Application/Services/PollOrchestratorService.cs
+++ b/src/Eras.Application/Services/PollOrchestratorService.cs
@@ -113,7 +113,14 @@ namespace Eras.Application.Services
                             // Create asnswers
                             if (createdPollInstance.Success)
                             {
-                                await CreateAnswersAsync(pollToCreate, createdComponents, createdPollInstance);
+                                bool isNewPollInstance = createdPollInstance.SuccessfullImports == 1;
+                                bool isExistingWithNewVersion = createdPollInstance.SuccessfullImports == 0 && IsNewVersion;
+
+                                if (isNewPollInstance || isExistingWithNewVersion)
+                                {
+                                    await CreateAnswersAsync(pollToCreate, createdComponents, createdPollInstance);
+                                }
+                                createdPollsInstances++;
                             }
                             createdPollsInstances++;
                         }
@@ -147,7 +154,8 @@ namespace Eras.Application.Services
                         return responseUpdate;
                     }
                     else
-                        return new CreateCommandResponse<PollInstance>(responseQuery.Body, responseQuery.Message, responseQuery.Success);
+                        return new CreateCommandResponse<PollInstance>(responseQuery.Body, 0, "Already exists", true);
+
                 }
                 else
                 {

--- a/src/Eras.Application/Services/PollOrchestratorService.cs
+++ b/src/Eras.Application/Services/PollOrchestratorService.cs
@@ -113,16 +113,9 @@ namespace Eras.Application.Services
                             // Create asnswers
                             if (createdPollInstance.Success)
                             {
-                                bool isNewPollInstance = createdPollInstance.SuccessfullImports == 1;
-                                bool isExistingWithNewVersion = createdPollInstance.SuccessfullImports == 0 && IsNewVersion;
-
-                                if (isNewPollInstance || isExistingWithNewVersion)
-                                {
-                                    await CreateAnswersAsync(pollToCreate, createdComponents, createdPollInstance);
-                                }
+                                await CreateAnswersAsync(pollToCreate, createdComponents, createdPollInstance);
                                 createdPollsInstances++;
                             }
-                            createdPollsInstances++;
                         }
                     }
                 }

--- a/src/Eras.Infrastructure/External/CosmicLatteClient/CosmicLatteAPIService.cs
+++ b/src/Eras.Infrastructure/External/CosmicLatteClient/CosmicLatteAPIService.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using System.Text.Json;
 
+using Eras.Application.Contracts.Persistence;
 using Eras.Application.Dtos;
 using Eras.Application.DTOs;
 using Eras.Application.DTOs.CL;
@@ -28,18 +29,21 @@ namespace Eras.Infrastructure.External.CosmicLatteClient
         private readonly ILogger<CosmicLatteAPIService> _logger;
         private readonly PollOrchestratorService _pollOrchestratorService;
         private readonly IApiKeyEncryptor _encryptor;
+        private readonly IPollInstanceRepository _pollInstanceRepository;
 
         public CosmicLatteAPIService(
             IConfiguration Configuration,
             IHttpClientFactory HttpClientFactory,
             ILogger<CosmicLatteAPIService> Logger,
             PollOrchestratorService PollOrchestratorService,
-            IApiKeyEncryptor Encryptor)
+            IApiKeyEncryptor Encryptor,
+            IPollInstanceRepository PollInstanceRepository)
         {
             _httpClient = HttpClientFactory.CreateClient();
             _logger = Logger;
             _pollOrchestratorService = PollOrchestratorService;
             _encryptor = Encryptor;
+            _pollInstanceRepository = PollInstanceRepository;
         }
 
         public async Task<CosmicLatteStatus> CosmicApiIsHealthy(string ApiKey, string ApiUrl)
@@ -150,6 +154,17 @@ namespace Eras.Infrastructure.External.CosmicLatteClient
                             Components = SanitizeComponents(populatedComponents),
                             ParentId = responseToPollInstance.parent.Split(':')[1]
                         };
+                        
+                        var studentEmail = pollDto.Components?
+                            .FirstOrDefault()?.Variables?
+                            .FirstOrDefault()?.Answer?.Student?.Email;
+
+
+                        if (!string.IsNullOrEmpty(studentEmail))
+                        {
+                            pollDto.IsAlreadyImported = await _pollInstanceRepository
+                                .ExistsByPollNameAndStudentEmailAsync(pollDto.Name, studentEmail);
+                        }
                         pollsDtos.Add(pollDto);
                     }
                 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AnswerRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AnswerRepository.cs
@@ -69,4 +69,21 @@ public class AnswerRepository(AppDbContext Context) : BaseRepository<Answer, Ans
             Answ.AnswerText.Equals(AnswerText) && Answ.PollVariableId == PollVariableId).ToListAsync();
         return answers.Select(Answ => Answ.ToDomain()).ToList();
     }
+
+    public async Task<Answer?> GetByPollInstanceAndVariableAsync(int PollVariableId, int PollInstanceId)
+    {
+        AnswerEntity? answer = await _context.Answers
+            .FirstOrDefaultAsync(a => a.PollVariableId == PollVariableId && 
+                                    a.PollInstanceId == PollInstanceId);
+        return answer?.ToDomain();
+    }
+
+    public async Task UpdateAnswerTextAsync(int Id, string AnswerText, decimal RiskLevel)
+    {
+        await _context.Answers
+            .Where(a => a.Id == Id)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(a => a.AnswerText, AnswerText)
+                .SetProperty(a => a.RiskLevel, RiskLevel));
+    }
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
@@ -26,6 +26,14 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
         return results?.ToDomain();
     }
 
+    public async Task<bool> ExistsByPollNameAndStudentEmailAsync(string PollName, string StudentEmail)
+    {
+        return await _context.PollInstances
+            .Include(p => p.Student)
+            .AnyAsync(p => _context.Polls
+                .Any(poll => poll.Uuid == p.Uuid && poll.Name == PollName) &&
+                p.Student.Email == StudentEmail);
+    }
 
     public async Task<IEnumerable<PollInstance>> GetByLastDays(int Days, bool LastVersion, string PollUuid)
     {


### PR DESCRIPTION
## Description

Implements detection of previously imported students during poll preview by querying existing poll instances before returning the preview data. When a student is re-imported with the toggle manually activated, their existing answers are overwritten with the new values using an upsert strategy that avoids EF Core change tracker conflicts.

### Changes:

- Added ExistsByPollNameAndStudentEmailAsync to IPollInstanceRepository and PollInstanceRepository
- Added IsAlreadyImported field to PollDTO
- CosmicLatteAPIService now checks existing poll instances per student during preview
- Added GetByPollInstanceAndVariableAsync and UpdateAnswerTextAsync to AnswerRepository
- CreateAnswerListCommandHandler now upserts answers: updates existing ones, creates new ones
- PollOrchestratorService now always calls CreateAnswersAsync, letting the handler decide whether to insert or update
- Fixed UpdateAsync conflict by replacing it with ExecuteUpdateAsync to bypass EF Core tracking issues



## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


