### PR TITLE
fix: avoid override data student by post without optional headers

### DIFF
--- a/src/Eras.Application/Features/Students/Commands/CreateStudent/CreateStudentsCommandHandler.cs
+++ b/src/Eras.Application/Features/Students/Commands/CreateStudent/CreateStudentsCommandHandler.cs
@@ -73,8 +73,15 @@ namespace Eras.Application.Features.Students.Commands.CreateStudent
                             if (studentCreatedOrChanged.SuccessfullImports == 0)
                                 updatedStudents.Add(studentCreatedOrChanged.Entity!);
 
-                            CreateCommandResponse<StudentDetail> createdStudentDetail = await CreateStudentDetailAsync(studentCreatedOrChanged.Entity!, dto);
-                            studentCreatedOrChanged.Entity!.StudentDetail = createdStudentDetail.Entity!;
+                            bool studentAlreadyHasDetail = studentCreatedOrChanged.Entity!.StudentDetail?.Id != 0;
+                            
+                            if (!HasDefaultDetailData(dto) && !studentAlreadyHasDetail)
+                            {
+                                CreateCommandResponse<StudentDetail> createdStudentDetail =
+                                    await CreateStudentDetailAsync(studentCreatedOrChanged.Entity!, dto);
+                                studentCreatedOrChanged.Entity!.StudentDetail = createdStudentDetail.Entity!;
+                            }
+
                             createdStudents.Add(studentCreatedOrChanged.Entity);
                         }
                     } else
@@ -117,6 +124,12 @@ namespace Eras.Application.Features.Students.Commands.CreateStudent
             };
             CreateStudentDetailCommand createStudentDetailCommand = new CreateStudentDetailCommand() { StudentDetailDto = studentDetailDTO };
             return await _mediator.Send(createStudentDetailCommand);
+        }
+
+        private bool HasDefaultDetailData(StudentImportDto Dto)
+        {
+            return Dto.EnrolledCourses == 0 && Dto.TimelySubmissions == 0 && Dto.AverageScore == 0 && Dto.CoursesBelowAverage == 0 
+                && Dto.RawScoreDifference == 0 && Dto.StandardScoreDifference == 0 && Dto.DaysSinceLastAccess == 0;
         }
     }
 }

--- a/src/Eras.Application/Mappers/StudentMapper.cs
+++ b/src/Eras.Application/Mappers/StudentMapper.cs
@@ -71,12 +71,12 @@ public static class StudentMapper
             Uuid = StudentImportDto.SISId,
             Name = StudentImportDto.Name,
             Email = StudentImportDto.Email,
-            StudentDetail = ExctractStudentDetailDto(StudentImportDto),
+            StudentDetail = ExtractStudentDetailDto(StudentImportDto),
             Cohort = new CohortDTO()
         };
     }
 
-    public static StudentDetailDTO ExctractStudentDetailDto(StudentImportDto Dto)
+    public static StudentDetailDTO ExtractStudentDetailDto(StudentImportDto Dto)
     {
         return new StudentDetailDTO()
         {


### PR DESCRIPTION
## Description

The fix avoids override data if a new csv has the same information about a student without non-required headers.

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues

#342 