### PR TITLE
fix/BE-361_Use evaluation finishedAt date as the filter for surveys to import

### DIFF
--- a/src/Eras.Infrastructure/External/CosmicLatteClient/CosmicLatteAPIService.cs
+++ b/src/Eras.Infrastructure/External/CosmicLatteClient/CosmicLatteAPIService.cs
@@ -210,24 +210,12 @@ namespace Eras.Infrastructure.External.CosmicLatteClient
                 string studentName = apiResponse.Data.Answers.ElementAt(0).Value.AnswersList[0];
                 string studentEmail = apiResponse.Data.Answers.ElementAt(1).Value.AnswersList[0];
                 string studentCohort = apiResponse.Data.Answers.ElementAt(2).Value.AnswersList[0];
+                DateTime evaluationFinishedAtDate = apiResponse.Data.Evaluation.FinishedAt;
                 StudentDTO studentDto = CreateStudent(studentName, studentEmail, studentCohort);
                 List<ComponentDTO> clonedListComponents = new List<ComponentDTO>();
+                bool isEvaluationWithinRange = ValidateEvaluationWithinDateRange(StartDate, EndDate, evaluationFinishedAtDate);
 
-                if(string.IsNullOrEmpty(StartDate) &&
-                    string.IsNullOrEmpty(EndDate))
-                {
-                    clonedListComponents = CloneComponentsList(Components);
-                }else if (!string.IsNullOrEmpty(StartDate) && 
-                    !string.IsNullOrEmpty(EndDate) && 
-                    CohortsHelper.CohortInDateRange(studentCohort ,DateTime.Parse(StartDate), DateTime.Parse(EndDate))
-                    )
-                {
-                    clonedListComponents = CloneComponentsList(Components);
-                }
-                else if(!string.IsNullOrEmpty(StartDate) &&
-                    string.IsNullOrEmpty(EndDate) &&
-                    CohortsHelper.GetCohort(DateTime.Parse(StartDate)) == studentCohort
-                    )
+                if (isEvaluationWithinRange)
                 {
                     clonedListComponents = CloneComponentsList(Components);
                 }
@@ -628,6 +616,34 @@ namespace Eras.Infrastructure.External.CosmicLatteClient
             {
                 component.Variables = component.Variables.OrderBy(v => v.Position).ToList();
             }
+        }
+
+        private bool ValidateEvaluationWithinDateRange(string StartDate, string EndDate, DateTime EvaluationFinishedAtDate)
+        {
+            if(string.IsNullOrEmpty(StartDate) &&
+               string.IsNullOrEmpty(EndDate)
+              )
+            {
+                return true;
+            }
+            
+            if(!string.IsNullOrEmpty(StartDate) && 
+               !string.IsNullOrEmpty(EndDate) && 
+               EvaluationFinishedAtDate >= DateTime.Parse(StartDate) &&
+               EvaluationFinishedAtDate <= DateTime.Parse(EndDate)
+              )
+            {
+                return true;
+            }
+            if(!string.IsNullOrEmpty(StartDate) &&
+               string.IsNullOrEmpty(EndDate) &&
+               EvaluationFinishedAtDate >= DateTime.Parse(StartDate)
+              )
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/Eras.Infrastructure/External/CosmicLatteClient/CosmicLatteAPIService.cs
+++ b/src/Eras.Infrastructure/External/CosmicLatteClient/CosmicLatteAPIService.cs
@@ -620,23 +620,25 @@ namespace Eras.Infrastructure.External.CosmicLatteClient
 
         private bool ValidateEvaluationWithinDateRange(string StartDate, string EndDate, DateTime EvaluationFinishedAtDate)
         {
-            if(string.IsNullOrEmpty(StartDate) &&
-               string.IsNullOrEmpty(EndDate)
-              )
+            bool wasStartDateProvided = !string.IsNullOrEmpty(StartDate);
+            bool wasEndDateProvided = !string.IsNullOrEmpty(EndDate);
+
+            if(!wasStartDateProvided && !wasEndDateProvided)
             {
                 return true;
             }
             
-            if(!string.IsNullOrEmpty(StartDate) && 
-               !string.IsNullOrEmpty(EndDate) && 
+            // Add 1 day to EndDate to account for evaluations finished
+            // on the EndDate.
+            if(wasStartDateProvided && wasEndDateProvided && 
                EvaluationFinishedAtDate >= DateTime.Parse(StartDate) &&
-               EvaluationFinishedAtDate <= DateTime.Parse(EndDate)
+               EvaluationFinishedAtDate <= DateTime.Parse(EndDate).AddDays(1)
               )
             {
                 return true;
             }
-            if(!string.IsNullOrEmpty(StartDate) &&
-               string.IsNullOrEmpty(EndDate) &&
+
+            if(wasStartDateProvided && !wasEndDateProvided &&
                EvaluationFinishedAtDate >= DateTime.Parse(StartDate)
               )
             {


### PR DESCRIPTION
## Description
Use finishedAt date as the filter to decide which surveys to import in the "Go to Import" option.

## How to test
- You need an Evaluation process. If you don't have one, create one
- Select the "Go to Import" option for that Evaluation Process.
- Select a Start Date and an End Date
- Before continuing, open the DevTools console and track the network requests
- Import the students
- Now, only the students that finished their Evaluation within the defined time frame should be imported. You can check that by checking the finishedAt property of the response of the import request .

## Type of change

- [ X ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues
BE-361 https://github.com/JU-DEV-Bootcamps/ERAS-BE/issues/361