### PR TITLE
360 use the finishedat date of every poll instance to be used as a filter the graphic report using the date range of the evaluation process

### DIFF
--- a/src/Eras.Api/Controllers/EvaluationDetailsController.cs
+++ b/src/Eras.Api/Controllers/EvaluationDetailsController.cs
@@ -19,12 +19,13 @@ public class EvaluationDetailsController(IMediator Mediator, ILogger<Evaluations
 
     [HttpGet("StudentsByFilters")]
     public async Task<IActionResult> StudentsByFilterAsync(
-        [FromQuery, Required] string PollUuid, [FromQuery, Required, MinLength(1)] List<string> ComponentNames, [FromQuery, Required, MinLength(1)] List<int> CohortIds, [FromQuery, Required, MinLength(1)] List<int>? VariableIds, [FromQuery] List<decimal>? RiskLevels, [FromQuery] Pagination Query)
+        [FromQuery, Required] string PollUuid, [FromQuery, Required] int evaluationId, [FromQuery, Required, MinLength(1)] List<string> ComponentNames, [FromQuery, Required, MinLength(1)] List<int> CohortIds, [FromQuery, Required, MinLength(1)] List<int>? VariableIds, [FromQuery] List<decimal>? RiskLevels, [FromQuery] Pagination Query)
     {
         _logger.LogInformation("Retrieving students with filters {PollId}, Components ({ComponentIds}), Cohorts ({CohortIds}), Variables ({VariableIds})", PollUuid, ComponentNames, CohortIds, VariableIds);
         var query = new GetStudentsByFiltersQuery()
         {
             PollUuid = PollUuid,
+            EvaluationId = evaluationId,
             ComponentNames = ComponentNames,
             CohortIds = CohortIds,
             VariableIds = VariableIds,

--- a/src/Eras.Api/Controllers/PollInstancesController.cs
+++ b/src/Eras.Api/Controllers/PollInstancesController.cs
@@ -26,10 +26,11 @@ public class PollInstancesController(IMediator Mediator, ILogger<StudentsControl
             [FromQuery] int Days,
             [FromQuery] Pagination Query,
             [FromQuery] bool LastVersion = true,
-            [FromRoute] string PollUuid = ""
+            [FromRoute] string PollUuid = "",
+            [FromQuery] int? EvaluationId = null 
     )
     {
-        return Ok(await _mediator.Send(new GetPollInstanceByCohortAndDaysQuery(Query, CohortId, Days, LastVersion, PollUuid)));
+        return Ok(await _mediator.Send(new GetPollInstanceByCohortAndDaysQuery(Query, CohortId, Days, LastVersion, PollUuid, EvaluationId)));
     }
 
     [HttpGet("{Uuid}/cohorts/avg")]

--- a/src/Eras.Api/Controllers/ReportsController.cs
+++ b/src/Eras.Api/Controllers/ReportsController.cs
@@ -98,7 +98,7 @@ public class ReportsController(IMediator Mediator) : ControllerBase
     }
 
     [HttpGet("polls/{Uuid}/avg")]
-    public async Task<IActionResult> GetAvgRiskByPollAsync([FromRoute] string Uuid, [FromQuery] string CohortIds, [FromQuery] bool LastVersion)
+    public async Task<IActionResult> GetAvgRiskByPollAsync([FromRoute] string Uuid, [FromQuery] string CohortIds, [FromQuery] bool LastVersion, [FromQuery] int evaluationId)
     {
         try
         {
@@ -109,7 +109,7 @@ public class ReportsController(IMediator Mediator) : ControllerBase
             {
                 return BadRequest(new { status = "error", message = "Wrong format for cohortIds" });
             }
-            var query = new PollAvgQuery() { PollUuid = pollGuid, CohortIds = CohortIdsAsInts, LastVersion = LastVersion };
+            var query = new PollAvgQuery() { PollUuid = pollGuid, EvaluationId = evaluationId, CohortIds = CohortIdsAsInts, LastVersion = LastVersion };
             GetQueryResponse<AvgReportResponseVm> avgRisk = await _mediator.Send(query);
             return avgRisk.Success
             ? Ok(new
@@ -127,6 +127,7 @@ public class ReportsController(IMediator Mediator) : ControllerBase
 
     [HttpGet("polls/{Uuid}/count")]
     public async Task<IActionResult> GetPollResultsCountAsync([FromRoute] string Uuid,
+        [FromQuery] int evaluationId,
         [FromQuery] string CohortIds,
         [FromQuery] string VariableIds,
         [FromQuery] bool LastVersion)
@@ -135,7 +136,7 @@ public class ReportsController(IMediator Mediator) : ControllerBase
         {
             var VariableIdsAsInts = VariableIds.Split(',').Select(int.Parse).ToList();
             var CohortIdsAsInts = QueryParameterFilter.GetCohortIdsAsInts(CohortIds);
-            var query = new PollCountQuery() { PollUuid = Uuid, CohortIds = CohortIdsAsInts, VariableIds = VariableIdsAsInts, LastVersion = LastVersion };
+            var query = new PollCountQuery() { PollUuid = Uuid, EvaluationId = evaluationId, CohortIds = CohortIdsAsInts, VariableIds = VariableIdsAsInts, LastVersion = LastVersion };
             var count = await _mediator.Send(query);
             return count.Success
             ? Ok(new

--- a/src/Eras.Api/Controllers/StudentsController.cs
+++ b/src/Eras.Api/Controllers/StudentsController.cs
@@ -110,12 +110,13 @@ public class StudentsController(IMediator Mediator, ILogger<StudentsController> 
         [FromQuery] string CohortIds,
         [FromQuery] string PollUuid,
         [FromQuery] Pagination Query,
-        [FromQuery] bool LastVersion
+        [FromQuery] bool LastVersion,
+        [FromQuery] int? evaluationId 
     )
     {
         List<int> Ids = QueryParameterFilter.GetCohortIdsAsInts(CohortIds);
         PagedResult<StudentAverageRiskDto> result = await _mediator.Send(
-            new GetAllAverageRiskByCohortAndPollQuery(Query, Ids, PollUuid, LastVersion)
+            new GetAllAverageRiskByCohortAndPollQuery(Query, Ids, PollUuid, LastVersion, evaluationId)
         );
         return Ok(result);
     }

--- a/src/Eras.Application/Contracts/Persistence/IErasEvaluationDetailsViewRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/IErasEvaluationDetailsViewRepository.cs
@@ -12,8 +12,8 @@ namespace Eras.Application.Contracts.Persistence;
 public interface IErasEvaluationDetailsViewRepository : IBaseRepository<ErasEvaluationDetailsView>
 {
     Task<List<ErasEvaluationDetailsView>> GetByFiltersAsync(int? PollId, List<int>? ComponentIds, List<int>? CohortIds, List<int>? VariableIds);
-    Task<IEnumerable<ErasEvaluationDetailsView>> GetStudentsByFilters(string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevel, int Page, int PageSize);
+    Task<IEnumerable<ErasEvaluationDetailsView>> GetStudentsByFilters(string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevel, int Page, int PageSize, DateTime startDate, DateTime endDate);
     Task<List<StudentsByFiltersResponse>> GetStudentsByEvaluationIdFilters(int EvaluationId, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevel);
-    Task<int> CountStudentsByFilters(string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevel);
+    Task<int> CountStudentsByFilters(string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevel, DateTime startDate, DateTime endDate);
 
 }

--- a/src/Eras.Application/Contracts/Persistence/IErasEvaluationDetailsViewRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/IErasEvaluationDetailsViewRepository.cs
@@ -13,7 +13,7 @@ public interface IErasEvaluationDetailsViewRepository : IBaseRepository<ErasEval
 {
     Task<List<ErasEvaluationDetailsView>> GetByFiltersAsync(int? PollId, List<int>? ComponentIds, List<int>? CohortIds, List<int>? VariableIds);
     Task<IEnumerable<ErasEvaluationDetailsView>> GetStudentsByFilters(string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevel, int Page, int PageSize, DateTime startDate, DateTime endDate);
-    Task<List<StudentsByFiltersResponse>> GetStudentsByEvaluationIdFilters(int EvaluationId, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevel);
+    Task<List<StudentsByFiltersResponse>> GetStudentsByEvaluationIdFilters(int EvaluationId, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevel, DateTime startDate, DateTime endDate);
     Task<int> CountStudentsByFilters(string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevel, DateTime startDate, DateTime endDate);
 
 }

--- a/src/Eras.Application/Contracts/Persistence/IPollInstanceRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/IPollInstanceRepository.cs
@@ -18,11 +18,13 @@ public interface IPollInstanceRepository : IBaseRepository<PollInstance>
             int[] CohortId,
             int? Days,
             bool LastVersion,
-            string PollUuid
+            string PollUuid,
+            DateTime? StartDate,
+            DateTime? EndDate
     );
 
-    Task<AvgReportResponseVm> GetReportByPollCohortAsync(string PollUuid, List<int> CohortIds, bool LastVersion);
+    Task<AvgReportResponseVm> GetReportByPollCohortAsync(string PollUuid, List<int> CohortIds, bool LastVersion, DateTime StartDate, DateTime EndDate);
 
     new Task<PollInstance> UpdateAsync(PollInstance Entity);
-    Task<CountReportResponseVm> GetCountReportByVariablesAsync(string PollUuid, List<int> CohortIds, List<int> VariableIds, bool LastVersion);
+    Task<CountReportResponseVm> GetCountReportByVariablesAsync(string PollUuid, List<int> CohortIds, List<int> VariableIds, bool LastVersion, DateTime startDate, DateTime endDate);
 }

--- a/src/Eras.Application/Contracts/Persistence/IStudentRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/IStudentRepository.cs
@@ -33,7 +33,8 @@ namespace Eras.Application.Contracts.Persistence
             Pagination Pagination,
             List<int> CohortIds,
             string PollUuid,
-            bool LastVersion
+            bool LastVersion,
+            int? evaluationId
         );
 
         Task<IEnumerable<Student>> GetPagedAsyncWithJoins(int Page, int PageSize);

--- a/src/Eras.Application/Features/Consolidator/Queries/Polls/GetPollAvgQuery.cs
+++ b/src/Eras.Application/Features/Consolidator/Queries/Polls/GetPollAvgQuery.cs
@@ -10,4 +10,5 @@ public class PollAvgQuery : IRequest<GetQueryResponse<AvgReportResponseVm>>
     public required Guid PollUuid { get; set; }
     public required List<int> CohortIds { get; set; }
     public bool LastVersion { get; set; }
+    public int EvaluationId { get; set; }
 }

--- a/src/Eras.Application/Features/Consolidator/Queries/Polls/GetPollAvgQueryHandler.cs
+++ b/src/Eras.Application/Features/Consolidator/Queries/Polls/GetPollAvgQueryHandler.cs
@@ -24,6 +24,12 @@ public class PollAvgHandler(
         try
         {
             var evaluation = await _evaluationRepository.GetByIdAsync(Request.EvaluationId);
+
+            if (evaluation == null)
+            {
+                return new GetQueryResponse<AvgReportResponseVm>(new AvgReportResponseVm(), $"Failed: Evaluation with ID {Request.EvaluationId} not found.", false);
+            }
+
             var startDate = DateTime.SpecifyKind(evaluation.StartDate, DateTimeKind.Utc);
             var endDate = DateTime.SpecifyKind(evaluation.EndDate, DateTimeKind.Utc);
 

--- a/src/Eras.Application/Features/Consolidator/Queries/Polls/GetPollAvgQueryHandler.cs
+++ b/src/Eras.Application/Features/Consolidator/Queries/Polls/GetPollAvgQueryHandler.cs
@@ -11,17 +11,23 @@ namespace Eras.Application.Features.Consolidator.Queries.Polls;
 
 public class PollAvgHandler(
     ILogger<PollAvgHandler> Logger,
-    IPollInstanceRepository PollInstanceRepository
+    IPollInstanceRepository PollInstanceRepository,
+    IEvaluationRepository EvaluationRepository 
     ) : IRequestHandler<PollAvgQuery, GetQueryResponse<AvgReportResponseVm>>
 {
     private readonly IPollInstanceRepository _pollInstanceRepository = PollInstanceRepository;
+    private readonly IEvaluationRepository _evaluationRepository = EvaluationRepository; 
     private readonly ILogger<PollAvgHandler> _logger = Logger;
 
     public async Task<GetQueryResponse<AvgReportResponseVm>> Handle(PollAvgQuery Request, CancellationToken CancellationToken)
     {
         try
         {
-            var answersByFilters = await _pollInstanceRepository.GetReportByPollCohortAsync(Request.PollUuid.ToString(), Request.CohortIds, Request.LastVersion)
+            var evaluation = await _evaluationRepository.GetByIdAsync(Request.EvaluationId);
+            var startDate = DateTime.SpecifyKind(evaluation.StartDate, DateTimeKind.Utc);
+            var endDate = DateTime.SpecifyKind(evaluation.EndDate, DateTimeKind.Utc);
+
+            var answersByFilters = await _pollInstanceRepository.GetReportByPollCohortAsync(Request.PollUuid.ToString(), Request.CohortIds, Request.LastVersion, startDate, endDate)
                 ?? throw new NotFoundException($"Error in query for filters: {Request.PollUuid}; {Request.CohortIds}");
 
             if (answersByFilters == null) // Returns empty response

--- a/src/Eras.Application/Features/Consolidator/Queries/Polls/GetPollCountQuery.cs
+++ b/src/Eras.Application/Features/Consolidator/Queries/Polls/GetPollCountQuery.cs
@@ -11,4 +11,5 @@ public class PollCountQuery : IRequest<GetQueryResponse<CountReportResponseVm>>
     public required List<int> CohortIds { get; set; }
     public required List<int> VariableIds { get; set; }
     public bool LastVersion { get; set; }
+    public int EvaluationId { get; set; } 
 }

--- a/src/Eras.Application/Features/Consolidator/Queries/Polls/GetPollCountQueryHandler.cs
+++ b/src/Eras.Application/Features/Consolidator/Queries/Polls/GetPollCountQueryHandler.cs
@@ -11,18 +11,23 @@ namespace Eras.Application.Features.Consolidator.Queries.Polls;
 
 public class PollCountQueryHandler(
     ILogger<PollCountQueryHandler> Logger,
-    IPollInstanceRepository PollInstanceRepository
+    IPollInstanceRepository PollInstanceRepository,
+    IEvaluationRepository EvaluationRepository 
     ) : IRequestHandler<PollCountQuery, GetQueryResponse<CountReportResponseVm>>
 {
     private readonly IPollInstanceRepository _pollInstanceRepository = PollInstanceRepository;
+    private readonly IEvaluationRepository _evaluationRepository = EvaluationRepository;
     private readonly ILogger<PollCountQueryHandler> _logger = Logger;
 
     public async Task<GetQueryResponse<CountReportResponseVm>> Handle(PollCountQuery Req, CancellationToken CancToken)
     {
         try
         {
+            var evaluation = await _evaluationRepository.GetByIdAsync(Req.EvaluationId);
+            var startDate = DateTime.SpecifyKind(evaluation.StartDate, DateTimeKind.Utc);
+            var endDate = DateTime.SpecifyKind(evaluation.EndDate, DateTimeKind.Utc);
 
-            var answersByFilters = await _pollInstanceRepository.GetCountReportByVariablesAsync(Req.PollUuid, Req.CohortIds, Req.VariableIds, Req.LastVersion)
+            var answersByFilters = await _pollInstanceRepository.GetCountReportByVariablesAsync(Req.PollUuid, Req.CohortIds, Req.VariableIds, Req.LastVersion, startDate, endDate)
                 ?? throw new NotFoundException($"Error in query for filters: {Req.PollUuid}; {Req.CohortIds}");
 
             if (answersByFilters == null) // Returns empty response

--- a/src/Eras.Application/Features/Consolidator/Queries/Polls/GetPollCountQueryHandler.cs
+++ b/src/Eras.Application/Features/Consolidator/Queries/Polls/GetPollCountQueryHandler.cs
@@ -24,13 +24,19 @@ public class PollCountQueryHandler(
         try
         {
             var evaluation = await _evaluationRepository.GetByIdAsync(Req.EvaluationId);
+
+            if (evaluation == null)
+            {
+                return new GetQueryResponse<CountReportResponseVm>(new CountReportResponseVm(), "Failed: Evaluation not found", false);
+            }
+
             var startDate = DateTime.SpecifyKind(evaluation.StartDate, DateTimeKind.Utc);
             var endDate = DateTime.SpecifyKind(evaluation.EndDate, DateTimeKind.Utc);
 
             var answersByFilters = await _pollInstanceRepository.GetCountReportByVariablesAsync(Req.PollUuid, Req.CohortIds, Req.VariableIds, Req.LastVersion, startDate, endDate)
                 ?? throw new NotFoundException($"Error in query for filters: {Req.PollUuid}; {Req.CohortIds}");
 
-            if (answersByFilters == null) // Returns empty response
+            if (answersByFilters == null) 
                 return new GetQueryResponse<CountReportResponseVm>(new CountReportResponseVm(), "Success: No answered polls with that Uuid", true);
             return new GetQueryResponse<CountReportResponseVm>(answersByFilters, "Success", true);
         }

--- a/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByEvaluationId/GetStudentsByEvaluationIdQueryHandler.cs
+++ b/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByEvaluationId/GetStudentsByEvaluationIdQueryHandler.cs
@@ -10,24 +10,41 @@ namespace Eras.Application.Features.EvaluationDetails.Queries.GetStudentsByEvalu
 public class GetStudentsByEvaluationIdQueryHandler : IRequestHandler<GetStudentsByEvaluationIdQuery, List<StudentsByFiltersResponse>>
 {
     private readonly IErasEvaluationDetailsViewRepository _repository;
+    private readonly IEvaluationRepository _evaluationRepository;
     private readonly ILogger<GetStudentsByEvaluationIdQueryHandler> _logger;
 
-    public GetStudentsByEvaluationIdQueryHandler(IErasEvaluationDetailsViewRepository Repository, ILogger<GetStudentsByEvaluationIdQueryHandler> Logger)
+    public GetStudentsByEvaluationIdQueryHandler(IErasEvaluationDetailsViewRepository Repository, IEvaluationRepository EvaluationRepository, ILogger<GetStudentsByEvaluationIdQueryHandler> Logger)
     {
         _repository = Repository;
+        _evaluationRepository = EvaluationRepository;
         _logger = Logger;
     }
 
     public async Task<List<StudentsByFiltersResponse>> Handle(GetStudentsByEvaluationIdQuery Request, CancellationToken CancellationToken)
     {
-        var studentsList = await _repository.GetStudentsByEvaluationIdFilters(
-            Request.EvaluationId,
-            Request.ComponentNames,
-            Request.CohortIds,
-            Request.VariableIds,
-            Request.RiskLevels
-        );
+        try
+        {
+            var evaluation = await _evaluationRepository.GetByIdAsync(Request.EvaluationId);
+            var startDate = DateTime.SpecifyKind(evaluation.StartDate, DateTimeKind.Utc);
+            var endDate = DateTime.SpecifyKind(evaluation.EndDate, DateTimeKind.Utc);
 
-        return studentsList;
+            var studentsList = await _repository.GetStudentsByEvaluationIdFilters(
+                Request.EvaluationId,
+                Request.ComponentNames,
+                Request.CohortIds,
+                Request.VariableIds,
+                Request.RiskLevels,
+                startDate,
+                endDate
+            );
+
+            return studentsList;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An error occurred while filtering students by evaluation id: {Message}", ex.Message);
+            return [];
+        }
     }
 }
+

--- a/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByFilters/GetStudentsByFiltersQuery.cs
+++ b/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByFilters/GetStudentsByFiltersQuery.cs
@@ -13,5 +13,5 @@ public class GetStudentsByFiltersQuery : IRequest<PagedResult<StudentsByFiltersR
     public List<int>? VariableIds { get; set; }
     public List<decimal>? RiskLevels { get; set; }
     public required Pagination PageValues { get; set; } 
-
+    public int EvaluationId { get; set; }
 }

--- a/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByFilters/GetStudentsByFiltersQueryHandler.cs
+++ b/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByFilters/GetStudentsByFiltersQueryHandler.cs
@@ -12,17 +12,23 @@ public class GetStudentsByFiltersQueryHandler :
     IRequestHandler<GetStudentsByFiltersQuery, PagedResult<StudentsByFiltersResponse>>
 {
     private readonly IErasEvaluationDetailsViewRepository _repository;
+    private readonly IEvaluationRepository _evaluationRepository;
     private readonly ILogger<GetStudentsByFiltersQueryHandler> _logger;
 
-    public GetStudentsByFiltersQueryHandler(IErasEvaluationDetailsViewRepository Repository, ILogger<GetStudentsByFiltersQueryHandler> Logger)
+    public GetStudentsByFiltersQueryHandler(IErasEvaluationDetailsViewRepository Repository, IEvaluationRepository EvaluationRepository, ILogger<GetStudentsByFiltersQueryHandler> Logger)
     {
         _repository = Repository;
+        _evaluationRepository = EvaluationRepository;
         _logger = Logger;
     }
     public async Task<PagedResult<StudentsByFiltersResponse>> Handle(GetStudentsByFiltersQuery Request, CancellationToken CancellationToken)
     {
         try
         {
+            var evaluation = await _evaluationRepository.GetByIdAsync(Request.EvaluationId); 
+            var startDate = DateTime.SpecifyKind(evaluation.StartDate, DateTimeKind.Utc);
+            var endDate = DateTime.SpecifyKind(evaluation.EndDate, DateTimeKind.Utc);
+
             var studentsList = await _repository.GetStudentsByFilters(
                 Request.PollUuid,
                 Request.ComponentNames, 
@@ -30,12 +36,14 @@ public class GetStudentsByFiltersQueryHandler :
                 Request.VariableIds,
                 Request.RiskLevels,
                 Request.PageValues.Page, 
-                Request.PageValues.PageSize
+                Request.PageValues.PageSize,
+                startDate,
+                endDate
             );
 
             var totalCount = await _repository.CountStudentsByFilters(
                 Request.PollUuid, Request.ComponentNames, Request.CohortIds,
-                Request.VariableIds, Request.RiskLevels
+                Request.VariableIds, Request.RiskLevels, startDate, endDate
             );
 
             var studentsResponses = studentsList.Select(Student => new StudentsByFiltersResponse

--- a/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByFilters/GetStudentsByFiltersQueryHandler.cs
+++ b/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByFilters/GetStudentsByFiltersQueryHandler.cs
@@ -35,8 +35,8 @@ public class GetStudentsByFiltersQueryHandler :
                 Request.CohortIds,
                 Request.VariableIds,
                 Request.RiskLevels,
-                Request.PageValues.Page, 
-                Request.PageValues.PageSize,
+                1,
+                int.MaxValue,
                 startDate,
                 endDate
             );
@@ -46,7 +46,10 @@ public class GetStudentsByFiltersQueryHandler :
                 Request.VariableIds, Request.RiskLevels, startDate, endDate
             );
 
-            var studentsResponses = studentsList.Select(Student => new StudentsByFiltersResponse
+            var studentsResponses = studentsList
+            .GroupBy(Student => new { Student.StudentId, Student.AnswerId })
+            .Select(g => g.First())
+            .Select(Student => new StudentsByFiltersResponse
             {
                 Id = Student.StudentId,
                 Name = Student.StudentName,

--- a/src/Eras.Application/Features/PollInstances/Queries/GetPollInstancesByCohortAndDays/GetPollInstanceByCohortAndDaysQuery.cs
+++ b/src/Eras.Application/Features/PollInstances/Queries/GetPollInstancesByCohortAndDays/GetPollInstanceByCohortAndDaysQuery.cs
@@ -12,7 +12,8 @@ namespace Eras.Application.Features.PollInstances.Queries.GetPollInstancesByCoho
             int[] CohortId,
             int Days,
             bool LastVersion,
-            string PollUuid
+            string PollUuid,
+            int? EvaluationId = null  
         ) : IRequest<GetQueryResponse<PagedResult<PollInstanceDTO>>>
     {
         public int[] CohortId { get; set; } = CohortId;
@@ -21,5 +22,6 @@ namespace Eras.Application.Features.PollInstances.Queries.GetPollInstancesByCoho
         public Pagination Pagination { get; set; } = Pagination;
         public bool LastVersion { get; set; } = LastVersion;
         public string PollUuid { get; set; } = PollUuid;
+        public int? EvaluationId { get; set; } = EvaluationId; 
     }
 }

--- a/src/Eras.Application/Features/PollInstances/Queries/GetPollInstancesByCohortAndDays/GetPollInstanceByCohortAndDaysQueryHandler.cs
+++ b/src/Eras.Application/Features/PollInstances/Queries/GetPollInstancesByCohortAndDays/GetPollInstanceByCohortAndDaysQueryHandler.cs
@@ -13,18 +13,30 @@ namespace Eras.Application.Features.PollInstances.Queries.GetPollInstancesByCoho
     {
 
         private readonly IPollInstanceRepository _pollInstanceRepository;
+        private readonly IEvaluationRepository _evaluationRepository; 
         private readonly ILogger<GetPollInstanceByCohortAndDaysQueryHandler> _logger;
 
-        public GetPollInstanceByCohortAndDaysQueryHandler(IPollInstanceRepository PollInstanceRepository, ILogger<GetPollInstanceByCohortAndDaysQueryHandler> Logger)
+        public GetPollInstanceByCohortAndDaysQueryHandler(IPollInstanceRepository PollInstanceRepository, IEvaluationRepository EvaluationRepository, ILogger<GetPollInstanceByCohortAndDaysQueryHandler> Logger)
         {
             _pollInstanceRepository = PollInstanceRepository;
+            _evaluationRepository = EvaluationRepository;
             _logger = Logger;
         }
         public async Task<GetQueryResponse<PagedResult<PollInstanceDTO>>> Handle(GetPollInstanceByCohortAndDaysQuery Request, CancellationToken CancellationToken)
         {
             try
             {
-                var pollInstances = await _pollInstanceRepository.GetByCohortIdAndLastDays(Request.Pagination.Page, Request.Pagination.PageSize, Request.CohortId, Request.Days, Request.LastVersion, Request.PollUuid, null, null);
+                DateTime? startDate = null;  
+                DateTime? endDate = null;
+
+            if (Request.EvaluationId.HasValue)
+            {
+                var evaluation = await _evaluationRepository.GetByIdAsync(Request.EvaluationId.Value);
+                startDate = DateTime.SpecifyKind(evaluation.StartDate, DateTimeKind.Utc);
+                endDate = DateTime.SpecifyKind(evaluation.EndDate, DateTimeKind.Utc);
+            }
+
+                var pollInstances = await _pollInstanceRepository.GetByCohortIdAndLastDays(Request.Pagination.Page, Request.Pagination.PageSize, Request.CohortId, Request.Days, Request.LastVersion, Request.PollUuid, startDate, endDate);
                 var pollInstanceDTOs =
                     pollInstances.Items
                     .Select(PollInstance => PollInstanceMapper.ToDTO(PollInstance)).ToList();

--- a/src/Eras.Application/Features/PollInstances/Queries/GetPollInstancesByCohortAndDays/GetPollInstanceByCohortAndDaysQueryHandler.cs
+++ b/src/Eras.Application/Features/PollInstances/Queries/GetPollInstancesByCohortAndDays/GetPollInstanceByCohortAndDaysQueryHandler.cs
@@ -24,7 +24,7 @@ namespace Eras.Application.Features.PollInstances.Queries.GetPollInstancesByCoho
         {
             try
             {
-                var pollInstances = await _pollInstanceRepository.GetByCohortIdAndLastDays(Request.Pagination.Page, Request.Pagination.PageSize, Request.CohortId, Request.Days, Request.LastVersion, Request.PollUuid);
+                var pollInstances = await _pollInstanceRepository.GetByCohortIdAndLastDays(Request.Pagination.Page, Request.Pagination.PageSize, Request.CohortId, Request.Days, Request.LastVersion, Request.PollUuid, null, null);
                 var pollInstanceDTOs =
                     pollInstances.Items
                     .Select(PollInstance => PollInstanceMapper.ToDTO(PollInstance)).ToList();

--- a/src/Eras.Application/Features/Students/Queries/GetAllAverageRiskByCohorAndPoll/GetAllAverageRiskByCohortAndPollQuery.cs
+++ b/src/Eras.Application/Features/Students/Queries/GetAllAverageRiskByCohorAndPoll/GetAllAverageRiskByCohortAndPollQuery.cs
@@ -4,6 +4,6 @@ using Eras.Application.Utils;
 
 namespace Eras.Application.Features.Students.Queries.GetAllAverageRiskByCohorAndPoll
 {
-    public sealed record GetAllAverageRiskByCohortAndPollQuery(Pagination Pagination, List<int> CohortIds, string PollUuid, bool LastVersion)
+    public sealed record GetAllAverageRiskByCohortAndPollQuery(Pagination Pagination, List<int> CohortIds, string PollUuid, bool LastVersion, int? evaluationId)
         : IRequest<PagedResult<StudentAverageRiskDto>>;
 }

--- a/src/Eras.Application/Features/Students/Queries/GetAllAverageRiskByCohorAndPoll/GetAllAverageRiskByCohortAndPollQueryHandler.cs
+++ b/src/Eras.Application/Features/Students/Queries/GetAllAverageRiskByCohorAndPoll/GetAllAverageRiskByCohortAndPollQueryHandler.cs
@@ -30,7 +30,8 @@ namespace Eras.Application.Features.Students.Queries.GetAllAverageRiskByCohorAnd
                Request.Pagination,
                Request.CohortIds,
                Request.PollUuid,
-               Request.LastVersion
+               Request.LastVersion,
+               Request.evaluationId
            );
 
             return result;

--- a/src/Eras.Application/Features/Students/Queries/GetAllAverageRiskByCohortsAndPollQuery/GetAllAverageRiskByCohortsAndPollQuery.cs
+++ b/src/Eras.Application/Features/Students/Queries/GetAllAverageRiskByCohortsAndPollQuery/GetAllAverageRiskByCohortsAndPollQuery.cs
@@ -5,6 +5,6 @@ using MediatR;
 
 namespace Eras.Application.Features.Students.Queries.GetAllAverageRiskByCohorAndPoll
 {
-    public sealed record GetAllAverageRiskByCohortsAndPollQuery(Pagination Pagination, List<int> cohortIds, string PollUuid, bool LastVersion)
+    public sealed record GetAllAverageRiskByCohortsAndPollQuery(Pagination Pagination, List<int> cohortIds, string PollUuid, bool LastVersion, int? EvaluationId = null)
         : IRequest<PagedResult<StudentAverageRiskDto>>;
 }

--- a/src/Eras.Application/Features/Students/Queries/GetAllAverageRiskByCohortsAndPollQuery/GetAllAverageRiskByCohortsAndPollQueryHandler.cs
+++ b/src/Eras.Application/Features/Students/Queries/GetAllAverageRiskByCohortsAndPollQuery/GetAllAverageRiskByCohortsAndPollQueryHandler.cs
@@ -33,7 +33,8 @@ namespace Eras.Application.Features.Students.Queries.GetAllAverageRiskByCohorAnd
                 Request.Pagination,
                 Request.cohortIds,
                 Request.PollUuid,
-                Request.LastVersion
+                Request.LastVersion,
+                Request.EvaluationId 
             );
         }
     }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
@@ -51,13 +51,14 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
         return entities.Select(e => e.ToDomain()).ToList();
     }
 
-    public async Task<List<StudentsByFiltersResponse>> GetStudentsByEvaluationIdFilters(int EvaluationId, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevels)
+    public async Task<List<StudentsByFiltersResponse>> GetStudentsByEvaluationIdFilters(int EvaluationId, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevels, DateTime startDate, DateTime endDate)
     {
         var query = _context.Set<ErasEvaluationDetailsViewEntity>().AsNoTracking();
 
         query = query.Where(v => v.EvaluationId == EvaluationId);
         query = query.Where(v => CohortIds.Contains(v.CohortId));
         query = query.Where(v => ComponentNames.Contains(v.ComponentName));
+        query = query.Where(v => v.FinishedAt >= startDate && v.FinishedAt <= endDate);
 
         var entitiesEval = await query.ToListAsync();
 
@@ -74,9 +75,7 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
             .Distinct();
 
         if (RiskLevels != null && RiskLevels.Any())
-        {
             resultEval = resultEval.Where(v => RiskLevels.Contains((decimal)GetRiskGroup((double)v.RiskLevel)));
-        }
 
         return resultEval.ToList();
     }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
@@ -82,10 +82,15 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
     }
 
     public async Task<IEnumerable<ErasEvaluationDetailsView>> GetStudentsByFilters(
-        string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevels, int Page, int PageSize)
+        string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevels, int Page, int PageSize, DateTime startDate, DateTime endDate)
     {
-        var query = BuildStudentsByFiltersQuery(PollUuid, ComponentNames, CohortIds, VariableIds, RiskLevels);
-        var entities = await query.OrderBy(v => v.StudentName).Distinct().ToListAsync();
+        var query = BuildStudentsByFiltersQuery(
+        PollUuid, ComponentNames, CohortIds, VariableIds, startDate, endDate);
+
+        var entities = await query
+            .OrderBy(v => v.StudentName)
+            .Distinct()
+            .ToListAsync();
 
         return ApplyRiskFilter(entities, RiskLevels)
             .Skip((Page - 1) * PageSize)
@@ -94,9 +99,9 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
     }
 
     public async Task<int> CountStudentsByFilters(
-        string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevels)
+        string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevels, DateTime startDate, DateTime endDate)
     {
-        var query = BuildStudentsByFiltersQuery(PollUuid, ComponentNames, CohortIds, VariableIds, RiskLevels);
+        var query = BuildStudentsByFiltersQuery(PollUuid, ComponentNames, CohortIds, VariableIds, startDate, endDate);
         var entities = await query.ToListAsync();
         return ApplyRiskFilter(entities, RiskLevels)
             .Select(v => v.StudentId)
@@ -105,13 +110,14 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
     }
 
     private IQueryable<ErasEvaluationDetailsViewEntity> BuildStudentsByFiltersQuery(
-        string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevels)
+        string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, DateTime startDate, DateTime endDate)
     {
         var query = _context.Set<ErasEvaluationDetailsViewEntity>()
             .AsNoTracking()
             .Where(v => v.PollUuid == PollUuid)
             .Where(v => CohortIds.Contains(v.CohortId))
-            .Where(v => ComponentNames.Contains(v.ComponentName));
+            .Where(v => ComponentNames.Contains(v.ComponentName))
+            .Where(v => v.FinishedAt >= startDate && v.FinishedAt <= endDate); 
 
         if (VariableIds != null && VariableIds.Any())
             query = query.Where(v => VariableIds.Contains(v.VariableId));

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
@@ -81,7 +81,9 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
     }
 
     public async Task<IEnumerable<ErasEvaluationDetailsView>> GetStudentsByFilters(
-        string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevels, int Page, int PageSize, DateTime startDate, DateTime endDate)
+    string PollUuid, List<string> ComponentNames, List<int> CohortIds,
+    List<int>? VariableIds, List<decimal>? RiskLevels,
+    int Page, int PageSize, DateTime startDate, DateTime endDate)
     {
         var query = BuildStudentsByFiltersQuery(
         PollUuid, ComponentNames, CohortIds, VariableIds, startDate, endDate);
@@ -91,10 +93,14 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
             .Distinct()
             .ToListAsync();
 
-        return ApplyRiskFilter(entities, RiskLevels)
+        var filtered = ApplyRiskFilter(entities, RiskLevels).ToList();
+
+        var paged = filtered
             .Skip((Page - 1) * PageSize)
             .Take(PageSize)
-            .Select(ErasEvaluationDetailsViewMapper.ToDomain);
+            .ToList();
+
+        return paged.Select(ErasEvaluationDetailsViewMapper.ToDomain);
     }
 
     public async Task<int> CountStudentsByFilters(

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
@@ -69,7 +69,9 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
             int[] CohortId,
             int? Days,
             bool LastVersion,
-            string PollUuid
+            string PollUuid,
+            DateTime? StartDate,
+            DateTime? EndDate 
     )
     {
         var query = _context.PollInstances.Include(PI => PI.Student)
@@ -84,15 +86,25 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
             .Select(A => A.LastVersion)
             .FirstOrDefault();
 
-        if (Days.HasValue && Days != 0 && LastVersion)
+        if (StartDate.HasValue && EndDate.HasValue)
+        {
+            query = query.Where(PI =>
+                PI.pollInstance.FinishedAt >= StartDate.Value &&
+                PI.pollInstance.FinishedAt <= EndDate.Value);
+        }
+        else if (Days.HasValue && Days != 0 && LastVersion)
         {
             DateTime dateLimit = DateTime.UtcNow.AddDays(-Days.Value);
-            query = query.Where(PI => PI.pollInstance.FinishedAt >= dateLimit && PI.pollInstance.LastVersion == pollVersion);
+            query = query.Where(PI =>
+                PI.pollInstance.FinishedAt >= dateLimit &&
+                PI.pollInstance.LastVersion == pollVersion);
         }
         else
         {
             DateTime dateLimit = DateTime.UtcNow.AddDays(Days.HasValue ? -Days.Value : 0);
-            query = query.Where(PI => PI.pollInstance.FinishedAt >= dateLimit && PI.pollInstance.LastVersion != pollVersion);
+            query = query.Where(PI =>
+                PI.pollInstance.FinishedAt >= dateLimit &&
+                PI.pollInstance.LastVersion != pollVersion);
         }
 
         var totalCount = await query.Distinct().CountAsync();
@@ -116,7 +128,8 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
     }
 
     public async Task<AvgReportResponseVm> GetReportByPollCohortAsync(
-    string PollUuid, List<int> CohortIds, bool LastVersion)
+    string PollUuid, List<int> CohortIds, bool LastVersion,
+    DateTime startDate, DateTime endDate)
     {
         List<string> emailsInCohort = await _context.StudentCohorts
             .Where(SC => CohortIds.Contains(SC.CohortId))
@@ -126,6 +139,7 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
                 (SC, S) => new { SC, S })
             .Select(SC => SC.S.Email)
             .ToListAsync();
+
         IQueryable<ErasCalculationsByPollDTO> reportQuery;
 
         int pollVersion = _context.Polls
@@ -137,8 +151,9 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
         {
             reportQuery =
             from A in _context.ErasCalculationsByPoll
+            join PI in _context.PollInstances on A.PollInstanceId equals PI.Id
             where A.PollUuid == PollUuid
-            where A.PollVersion == pollVersion
+            where PI.FinishedAt >= startDate && PI.FinishedAt <= endDate
             where emailsInCohort.Contains(A.StudentEmail)
             select new ErasCalculationsByPollDTO
             {
@@ -156,8 +171,9 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
         {
             reportQuery =
             from A in _context.ErasCalculationsByPoll
+            join PI in _context.PollInstances on A.PollInstanceId equals PI.Id 
             where A.PollUuid == PollUuid
-            where A.PollVersion != pollVersion
+            where PI.FinishedAt >= startDate && PI.FinishedAt <= endDate 
             where emailsInCohort.Contains(A.StudentEmail)
             select new ErasCalculationsByPollDTO
             {
@@ -217,22 +233,20 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
         return Entity;
     }
 
-    public async Task<CountReportResponseVm> GetCountReportByVariablesAsync(string PollUuid, List<int> CohortIds, List<int> VariableIds, bool LastVersion)
+    public async Task<CountReportResponseVm> GetCountReportByVariablesAsync(string PollUuid, List<int> CohortIds, List<int> VariableIds, bool LastVersion, DateTime startDate, DateTime endDate)
     {
 
         int pollVersion = _context.Polls
             .Where(A => A.Uuid == PollUuid)
             .Select(A => A.LastVersion)
             .FirstOrDefault();
-        IQueryable<ErasCalculationsByPollDTO> reportQuery;
-        if (LastVersion)
-        {
-            reportQuery =
+        IQueryable<ErasCalculationsByPollDTO> reportQuery=
             from A in _context.ErasCalculationsByPoll
+            join PI in _context.PollInstances on A.PollInstanceId equals PI.Id
             where A.PollUuid == PollUuid
-            where A.PollVersion == pollVersion
             where CohortIds.Contains(A.CohortId)
             where VariableIds.Contains(A.PollVariableId)
+            where PI.FinishedAt >= startDate && PI.FinishedAt <= endDate 
             select new ErasCalculationsByPollDTO
             {
                 ComponentName = A.ComponentName,
@@ -247,31 +261,7 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
                 CohortName = A.CohortName,
                 PollVersion = A.PollVersion
             };
-        }
-        else
-        {
-            reportQuery =
-            from A in _context.ErasCalculationsByPoll
-            where A.PollUuid == PollUuid
-            where A.PollVersion != pollVersion
-            where CohortIds.Contains(A.CohortId)
-            where VariableIds.Contains(A.PollVariableId)
-            select new ErasCalculationsByPollDTO
-            {
-                ComponentName = A.ComponentName,
-                ComponentAverageRisk = A.ComponentAverageRisk,
-                AnswerText = A.AnswerText,
-                AnswerRisk = A.AnswerRisk,
-                Question = A.Question,
-                Position = A.Position,
-                StudentName = A.StudentName,
-                StudentEmail = A.StudentEmail,
-                CohortId = A.CohortId,
-                CohortName = A.CohortName,
-                PollVersion = A.PollVersion
-            };
-        }
-
+        
         List<ErasCalculationsByPollDTO> results = await reportQuery.ToListAsync();
 
         List<CountReportComponent> report = [.. results

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/StudentRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/StudentRepository.cs
@@ -158,21 +158,61 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
             Pagination pagination,
             List<int> cohortIds,
             string pollUuid,
-            bool lastVersion)
+            bool lastVersion,
+            int? evaluationId)
         {
             int pollVersion = await _context.Polls
                 .Where(a => a.Uuid == pollUuid)
                 .Select(a => a.LastVersion)
                 .FirstOrDefaultAsync();
 
-            var query = _context.ErasCalculationsByPoll
+            if (evaluationId.HasValue)
+            {
+                var evaluation = await _context.Set<EvaluationEntity>()
+                    .Where(e => e.Id == evaluationId.Value)
+                    .FirstOrDefaultAsync();
+
+                if (evaluation != null)
+                {
+                    var startDate = DateTime.SpecifyKind(evaluation.StartDate, DateTimeKind.Utc);
+                    var endDate = DateTime.SpecifyKind(evaluation.EndDate, DateTimeKind.Utc);
+
+                    var query = from A in _context.ErasCalculationsByPoll
+                                join PI in _context.PollInstances on A.PollInstanceId equals PI.Id
+                                where cohortIds.Contains(A.CohortId)
+                                where A.PollUuid == pollUuid
+                                where PI.FinishedAt >= startDate && PI.FinishedAt <= endDate
+                                select A;
+
+                    var groupedQuery = query
+                        .GroupBy(x => new { x.StudentEmail, x.StudentId, x.StudentName })
+                        .Select(g => new StudentAverageRiskDto
+                        {
+                            StudentId = g.Key.StudentId,
+                            StudentName = g.Key.StudentName,
+                            Email = g.Key.StudentEmail,
+                            AvgRiskLevel = g.Average(x => x.AnswerRisk)
+                        });
+
+                    var count = await groupedQuery.CountAsync();
+                    var data = await groupedQuery
+                        .OrderByDescending(x => x.AvgRiskLevel)
+                        .Skip((pagination.Page - 1) * pagination.PageSize)
+                        .Take(pagination.PageSize)
+                        .ToListAsync();
+
+                    return new PagedResult<StudentAverageRiskDto>(count, data);
+                }
+            }
+
+            var defaultQuery = _context.ErasCalculationsByPoll
                 .Where(x => cohortIds.Contains(x.CohortId) && x.PollUuid == pollUuid);
 
-            query = lastVersion
-                ? query.Where(x => x.PollVersion == pollVersion)
-                : query.Where(x => x.PollVersion != pollVersion);
+            defaultQuery = lastVersion
+                ? defaultQuery.Where(x => x.PollVersion == pollVersion)
+                : defaultQuery.Where(x => x.PollVersion != pollVersion);
 
-            var groupedQuery = query
+            var defaultGrouped = defaultQuery
                 .GroupBy(x => new { x.StudentEmail, x.StudentId, x.StudentName })
                 .Select(g => new StudentAverageRiskDto
                 {
@@ -182,15 +222,14 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
                     AvgRiskLevel = g.Average(x => x.AnswerRisk)
                 });
 
-            var count = await groupedQuery.CountAsync();
-
-            var data = await groupedQuery
+            var defaultCount = await defaultGrouped.CountAsync();
+            var defaultData = await defaultGrouped
                 .OrderByDescending(x => x.AvgRiskLevel)
                 .Skip((pagination.Page - 1) * pagination.PageSize)
                 .Take(pagination.PageSize)
                 .ToListAsync();
 
-            return new PagedResult<StudentAverageRiskDto>(count, data);
+            return new PagedResult<StudentAverageRiskDto>(defaultCount, defaultData);
         }
 
         public new async Task<Student> UpdateAsync(Student Entity)

--- a/test/Eras.Application.Tests/Features/PollInstances/Queries/GetPollInstanceQueryHandlerTests.cs
+++ b/test/Eras.Application.Tests/Features/PollInstances/Queries/GetPollInstanceQueryHandlerTests.cs
@@ -10,14 +10,16 @@ namespace Eras.Application.Tests.Features.PollInstances.Queries
     public class GetPollInstanceQueryHandlerTests
     {
         private readonly Mock<IPollInstanceRepository> _mockPollInstanceRepository;
+        private readonly Mock<IEvaluationRepository> _mockEvaluationRepository; 
         private readonly Mock<ILogger<GetPollInstanceByCohortAndDaysQueryHandler>> _mockLogger;
         private readonly GetPollInstanceByCohortAndDaysQueryHandler _handler;
 
         public GetPollInstanceQueryHandlerTests()
         {
             _mockPollInstanceRepository = new Mock<IPollInstanceRepository>();
+            _mockEvaluationRepository = new Mock<IEvaluationRepository>();
             _mockLogger = new Mock<ILogger<GetPollInstanceByCohortAndDaysQueryHandler>>();
-            _handler = new GetPollInstanceByCohortAndDaysQueryHandler(_mockPollInstanceRepository.Object, _mockLogger.Object);
+            _handler = new GetPollInstanceByCohortAndDaysQueryHandler(_mockPollInstanceRepository.Object, _mockEvaluationRepository.Object, _mockLogger.Object);
         }
 
         [Fact]
@@ -38,7 +40,7 @@ namespace Eras.Application.Tests.Features.PollInstances.Queries
             var pagedResult = new PagedResult<PollInstance>(pollInstances.Count(), pollInstances);
 
             _mockPollInstanceRepository
-                .Setup(Repo => Repo.GetByCohortIdAndLastDays(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int[]>(), It.IsAny<int?>(), It.IsAny<bool>(),It.IsAny<string>()))
+                .Setup(Repo => Repo.GetByCohortIdAndLastDays(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int[]>(), It.IsAny<int?>(), It.IsAny<bool>(),It.IsAny<string>(),It.IsAny<DateTime?>(),It.IsAny<DateTime?>()))
                 .ReturnsAsync(pagedResult);
 
             // Act
@@ -62,7 +64,7 @@ namespace Eras.Application.Tests.Features.PollInstances.Queries
             var query = new GetPollInstanceByCohortAndDaysQuery(pagination, cohortId, days, true, "poll-Uuid");
 
             _mockPollInstanceRepository
-                .Setup(Repo => Repo.GetByCohortIdAndLastDays(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int[]>(), It.IsAny<int?>(), It.IsAny<bool>(), It.IsAny<string>()))
+                .Setup(Repo => Repo.GetByCohortIdAndLastDays(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int[]>(), It.IsAny<int?>(), It.IsAny<bool>(), It.IsAny<string>(),It.IsAny<DateTime?>(),It.IsAny<DateTime?>()))
                 .ThrowsAsync(new Exception("Database error"));
 
             // Act

--- a/test/Eras.Application.Tests/Features/Reports/Polls/GetPollAvgQueryTest.cs
+++ b/test/Eras.Application.Tests/Features/Reports/Polls/GetPollAvgQueryTest.cs
@@ -11,14 +11,16 @@ namespace Eras.Application.Tests.Features.Reports.Polls;
 public class GetPollAvgQueryTest
 {
     private readonly Mock<IPollInstanceRepository> _mockPollInstanceRepo;
+    private readonly Mock<IEvaluationRepository> _mockEvaluationRepo;
     private readonly Mock<ILogger<PollAvgHandler>> _mockLogger;
     private readonly PollAvgHandler _handler;
 
     public GetPollAvgQueryTest()
     {
         _mockPollInstanceRepo = new Mock<IPollInstanceRepository>();
+        _mockEvaluationRepo = new Mock<IEvaluationRepository>();
         _mockLogger = new Mock<ILogger<PollAvgHandler>>();
-        _handler = new PollAvgHandler(_mockLogger.Object, _mockPollInstanceRepo.Object);
+        _handler = new PollAvgHandler(_mockLogger.Object, _mockPollInstanceRepo.Object, _mockEvaluationRepo.Object);
     }
     [Fact]
     public async Task Handle_Should_Return_Empty_Response_When_No_PollInstancesAsync()
@@ -28,12 +30,13 @@ public class GetPollAvgQueryTest
         {
             PollUuid = Guid.NewGuid(),
             CohortIds = [1, 2],
-            LastVersion = true
+            LastVersion = true,
+            EvaluationId = 1
         };
 
         // Mock the repository to return an empty list of Answers and map to AvgReportResponseVm
         _mockPollInstanceRepo
-            .Setup(Repo => Repo.GetReportByPollCohortAsync(query.PollUuid.ToString(), query.CohortIds, query.LastVersion))
+            .Setup(Repo => Repo.GetReportByPollCohortAsync(query.PollUuid.ToString(), query.CohortIds, query.LastVersion, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
             .Returns(Task.FromResult(new AvgReportResponseVm())); // Simulate no data
 
         // Act


### PR DESCRIPTION
## Description

Previously, all poll instances were included in reports regardless of
when they were completed, causing students from different evaluation
periods to appear mixed in the same report.

Changes:
- PollAvgHandler: fetches evaluation date range and passes it to GetReportByPollCohortAsync
- PollCountQueryHandler: same for GetCountReportByVariablesAsync
- GetStudentsByFiltersQueryHandler: passes startDate/endDate from evaluation, deduplicates and paginates results in memory to ensure count matches items
- GetStudentsByEvaluationIdQueryHandler: injects IEvaluationRepository to resolve dates
- GetPollInstanceByCohortAndDaysQueryHandler: injects IEvaluationRepository, resolves dates when EvaluationId is present
- GetAllAverageRiskByCohortAndPollQueryHandler: passes evaluationId to repository instead of null
- StudentRepository.GetStudentAverageRiskByCohortsAsync: when evaluationId is present, joins with PollInstances and filters by PI.FinishedAt within evaluation date range
- PollInstanceRepository: filters by PI.FinishedAt in GetReportByPollCohortAsync, GetCountReportByVariablesAsync and GetByCohortIdAndLastDays
- ErasEvaluationDetailsViewRepository: applies FinishedAt filter in BuildStudentsByFiltersQuery and GetStudentsByEvaluationIdFilters
- IPollInstanceRepository / IErasEvaluationDetailsViewRepository: updated method signatures

How to test:
1. Ensure evaluations have end_date set to 23:59:59 for full-day coverage
2. Check poll_instances.FinishedAt to know which students answered on which date
3. Test endpoints with evaluationId matching the date range:

   GET /api/v1/reports/polls/{uuid}/avg
     ?CohortIds=1&LastVersion=true&evaluationId={id}
     → pollCount should match only students within evaluation date range

   GET /api/v1/reports/polls/{uuid}/count
     ?CohortIds=1&VariableIds=1&LastVersion=true&evaluationId={id}
     → students in answers should match only that evaluation

   GET /api/v1/evaluations/StudentsByFilters
     ?PollUuid=...&evaluationId={id}&ComponentNames=academico&CohortIds=1&VariableIds=1
     → count and items must match, no duplicates

   GET /api/v1/evaluations/StudentsByEvaluationId
     ?EvaluationId={id}&ComponentNames=academico&CohortIds=1&VariableIds=1
     → only students within evaluation date range

   GET /api/v1/poll-instances/{uuid}
     ?cohortId=1&evaluationId={id}&page=0&pageSize=10&lastVersion=true&days=400
     → count and items should match only students from that evaluation

   GET /api/v1/students/average
     ?CohortIds=1&PollUuid=...&LastVersion=true&evaluationId={id}
     → risk students list should match only students from that evaluation

4. Switch between two evaluations with different date ranges
   → student counts must differ and never overlap incorrectly

Note: Evaluation end_date must include full day time (23:59:59) for correct filtering.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


