### PR TITLE
Fix page values in query for pagination in getStudentsByFilter

### DIFF
--- a/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByFilters/GetStudentsByFiltersQueryHandler.cs
+++ b/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByFilters/GetStudentsByFiltersQueryHandler.cs
@@ -35,8 +35,8 @@ public class GetStudentsByFiltersQueryHandler :
                 Request.CohortIds,
                 Request.VariableIds,
                 Request.RiskLevels,
-                1,
-                int.MaxValue,
+                Request.PageValues.Page,
+                Request.PageValues.PageSize,
                 startDate,
                 endDate
             );


### PR DESCRIPTION
## Description

The pagination for retrieving details about risk level on reports is broken. This fix addresses the pagination in evaluationDetailsevaluationDetails: `/api/v1/evaluations/StudentsByFilters`

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


