### PR TITLE
fix: adjust end_date to end of day to include all records within eval…

### DIFF
--- a/src/Eras.Api/Controllers/CohortsController.cs
+++ b/src/Eras.Api/Controllers/CohortsController.cs
@@ -40,20 +40,20 @@ public class CohortsController(IMediator Mediator, ILogger<CohortsController> Lo
     }
 
     [HttpGet("summary")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> GetCohortsSummaryAsync(
-        [FromQuery] Pagination Pagination
+        [FromQuery] Pagination Pagination,
+        [FromQuery] int? EvaluationId
     )
     {
         GetCohortsSummaryQuery getCohortsSummaryQuery = new()
         {
-            Pagination = Pagination
+            Pagination = Pagination,
+            EvaluationId = EvaluationId
         };
         CohortSummaryResponse res = await _mediator.Send(getCohortsSummaryQuery);
-
         return Ok(res);
     }
+
     [HttpGet("details")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/src/Eras.Application/Contracts/Persistence/IStudentCohortRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/IStudentCohortRepository.cs
@@ -8,6 +8,6 @@ namespace Eras.Application.Contracts.Persistence
     {
         Task<Student?> GetByCohortIdAndStudentIdAsync(int CohortId, int StudentId);
         Task<IEnumerable<Student>?> GetAllStudentsByCohortIdAsync(int CohortId);
-        Task<CohortSummaryResponse> GetCohortsSummaryAsync(Pagination Pagination);
+        Task<CohortSummaryResponse> GetCohortsSummaryAsync(Pagination Pagination, DateTime? startDate = null, DateTime? endDate = null);
     }
 }

--- a/src/Eras.Application/Features/Cohort/Queries/GetCohortSummary/GetCohortsSummaryQuery.cs
+++ b/src/Eras.Application/Features/Cohort/Queries/GetCohortSummary/GetCohortsSummaryQuery.cs
@@ -7,5 +7,6 @@ namespace Eras.Application.Features.Cohorts.Queries
     public class GetCohortsSummaryQuery: IRequest<CohortSummaryResponse>
     {
         public required Pagination Pagination { get; set; }
+        public int? EvaluationId { get; set; } 
     }
 }

--- a/src/Eras.Application/Features/Cohort/Queries/GetCohortSummary/GetCohortsSummaryQueryHandler.cs
+++ b/src/Eras.Application/Features/Cohort/Queries/GetCohortSummary/GetCohortsSummaryQueryHandler.cs
@@ -9,18 +9,30 @@ namespace Eras.Application.Features.Cohorts.Queries
 {
     class GetCohortsSummaryQueryHandler(
         IStudentCohortRepository ScRepository,
+        IEvaluationRepository EvaluationRepository, 
         ILogger<GetCohortsSummaryQuery> Logger)
         : IRequestHandler<GetCohortsSummaryQuery, CohortSummaryResponse>
     {
         private readonly IStudentCohortRepository _screpository = ScRepository;
+        private readonly IEvaluationRepository _evaluationRepository = EvaluationRepository;
         private readonly ILogger<GetCohortsSummaryQuery> _logger = Logger;
 
         public async Task<CohortSummaryResponse> Handle(
             GetCohortsSummaryQuery Request,
             CancellationToken CancellationToken)
         {
-            var cohortSummary = await _screpository.GetCohortsSummaryAsync(Request.Pagination);
-            return cohortSummary;
+            DateTime? startDate = null;
+            DateTime? endDate = null;
+
+            if (Request.EvaluationId.HasValue)
+            {
+                var evaluation = await _evaluationRepository.GetByIdAsync(Request.EvaluationId.Value);
+                startDate = DateTime.SpecifyKind(evaluation.StartDate, DateTimeKind.Utc);
+                endDate = DateTime.SpecifyKind(evaluation.EndDate, DateTimeKind.Utc)
+                                .Date.AddDays(1).AddTicks(-1);
+            }
+
+            return await _screpository.GetCohortsSummaryAsync(Request.Pagination, startDate, endDate);
         }
     }
 }

--- a/src/Eras.Application/Features/Consolidator/Queries/Polls/GetPollAvgQueryHandler.cs
+++ b/src/Eras.Application/Features/Consolidator/Queries/Polls/GetPollAvgQueryHandler.cs
@@ -31,7 +31,10 @@ public class PollAvgHandler(
             }
 
             var startDate = DateTime.SpecifyKind(evaluation.StartDate, DateTimeKind.Utc);
-            var endDate = DateTime.SpecifyKind(evaluation.EndDate, DateTimeKind.Utc);
+            var endDate = DateTime.SpecifyKind(evaluation.EndDate, DateTimeKind.Utc)
+                                .Date
+                                .AddDays(1)
+                                .AddTicks(-1); 
 
             var answersByFilters = await _pollInstanceRepository.GetReportByPollCohortAsync(Request.PollUuid.ToString(), Request.CohortIds, Request.LastVersion, startDate, endDate)
                 ?? throw new NotFoundException($"Error in query for filters: {Request.PollUuid}; {Request.CohortIds}");

--- a/src/Eras.Application/Features/Consolidator/Queries/Polls/GetPollCountQueryHandler.cs
+++ b/src/Eras.Application/Features/Consolidator/Queries/Polls/GetPollCountQueryHandler.cs
@@ -31,7 +31,10 @@ public class PollCountQueryHandler(
             }
 
             var startDate = DateTime.SpecifyKind(evaluation.StartDate, DateTimeKind.Utc);
-            var endDate = DateTime.SpecifyKind(evaluation.EndDate, DateTimeKind.Utc);
+            var endDate = DateTime.SpecifyKind(evaluation.EndDate, DateTimeKind.Utc)
+                                .Date
+                                .AddDays(1)
+                                .AddTicks(-1); 
 
             var answersByFilters = await _pollInstanceRepository.GetCountReportByVariablesAsync(Req.PollUuid, Req.CohortIds, Req.VariableIds, Req.LastVersion, startDate, endDate)
                 ?? throw new NotFoundException($"Error in query for filters: {Req.PollUuid}; {Req.CohortIds}");

--- a/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByFilters/GetStudentsByFiltersQueryHandler.cs
+++ b/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByFilters/GetStudentsByFiltersQueryHandler.cs
@@ -27,7 +27,10 @@ public class GetStudentsByFiltersQueryHandler :
         {
             var evaluation = await _evaluationRepository.GetByIdAsync(Request.EvaluationId); 
             var startDate = DateTime.SpecifyKind(evaluation.StartDate, DateTimeKind.Utc);
-            var endDate = DateTime.SpecifyKind(evaluation.EndDate, DateTimeKind.Utc);
+            var endDate = DateTime.SpecifyKind(evaluation.EndDate, DateTimeKind.Utc)
+                                .Date
+                                .AddDays(1)
+                                .AddTicks(-1); 
 
             var studentsList = await _repository.GetStudentsByFilters(
                 Request.PollUuid,

--- a/src/Eras.Application/Features/PollInstances/Queries/GetPollInstancesByCohortAndDays/GetPollInstanceByCohortAndDaysQueryHandler.cs
+++ b/src/Eras.Application/Features/PollInstances/Queries/GetPollInstancesByCohortAndDays/GetPollInstanceByCohortAndDaysQueryHandler.cs
@@ -33,7 +33,10 @@ namespace Eras.Application.Features.PollInstances.Queries.GetPollInstancesByCoho
             {
                 var evaluation = await _evaluationRepository.GetByIdAsync(Request.EvaluationId.Value);
                 startDate = DateTime.SpecifyKind(evaluation.StartDate, DateTimeKind.Utc);
-                endDate = DateTime.SpecifyKind(evaluation.EndDate, DateTimeKind.Utc);
+                endDate = DateTime.SpecifyKind(evaluation.EndDate, DateTimeKind.Utc)
+                  .Date
+                  .AddDays(1)
+                  .AddTicks(-1);
             }
 
                 var pollInstances = await _pollInstanceRepository.GetByCohortIdAndLastDays(Request.Pagination.Page, Request.Pagination.PageSize, Request.CohortId, Request.Days, Request.LastVersion, Request.PollUuid, startDate, endDate);

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/StudentCohortRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/StudentCohortRepository.cs
@@ -1,11 +1,9 @@
 ﻿using Eras.Application.Contracts.Persistence;
 using Eras.Application.Models.Response.Controllers.CohortsController;
-
 using Eras.Application.Utils;
 using Eras.Domain.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Joins;
 using Eras.Infrastructure.Persistence.PostgreSQL.Mappers;
-
 using Microsoft.EntityFrameworkCore;
 
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
@@ -26,6 +24,7 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
         public async Task<IEnumerable<Student>?> GetAllStudentsByCohortIdAsync(int CohortId)
         {
             var cohortStudents = await _context.StudentCohorts.Include(Cs => Cs.Student).Where(StudentCohort => StudentCohort.CohortId.Equals(CohortId)).ToListAsync();
+
             var domainStudents = new List<Student>();
             foreach (var student in cohortStudents)
             {
@@ -34,23 +33,32 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
             return domainStudents;
         }
 
-        public async Task<CohortSummaryResponse> GetCohortsSummaryAsync(Pagination Pagination)
+        public async Task<CohortSummaryResponse> GetCohortsSummaryAsync(
+            Pagination Pagination,
+            DateTime? startDate = null,
+            DateTime? endDate = null)
         {
             var cohortStudents = _context.StudentCohorts
                 .Include(Cs => Cs.Cohort)
-                .Include(Cs => Cs.Student);
-            int StudentCount = cohortStudents.Distinct().Count();
-
-            var cohorts = await cohortStudents
+                .Include(Cs => Cs.Student)
                 .ThenInclude(S => S.PollInstances)
                 .ThenInclude(P => P.Answers)
-                .ThenInclude(A => A.PollVariable)
-                .ToListAsync();
+                .ThenInclude(A => A.PollVariable);
+
+            int StudentCount = await cohortStudents.CountAsync();
+
+            var cohorts = await cohortStudents.ToListAsync();
+
             var cohortsDomain = cohorts.Select(C => new CohortStudentPollsSummary
             {
                 Student = C.ToJoinDomain(),
-                PollInstances = C.Student.PollInstances.Select(P => P.ToSummaryDomain()).ToList()
+                PollInstances = C.Student.PollInstances
+                    .Where(P => (!startDate.HasValue || P.FinishedAt >= startDate) &&
+                                (!endDate.HasValue   || P.FinishedAt <= endDate))
+                    .Select(P => P.ToSummaryDomain())
+                    .ToList()
             })
+            .Where(C => C.PollInstances.Any())
             .Skip((Pagination.Page - 1) * Pagination.PageSize)
             .Take(Pagination.PageSize);
 
@@ -62,7 +70,9 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
                 StudentName = S.Student.Name,
                 CohortId = S.Student.Cohort?.Id,
                 CohortName = S.Student.Cohort?.Name,
-                PollinstancesAverage = S.PollInstances.Average(P => P.Answers.Average(A => A.RiskLevel)),
+                PollinstancesAverage = S.PollInstances.Any()
+                    ? S.PollInstances.Average(P => P.Answers.Average(A => A.RiskLevel))
+                    : 0,
                 PollinstancesCount = S.PollInstances.Count,
             }).ToList();
 

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/StudentRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/StudentRepository.cs
@@ -175,7 +175,8 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
                 if (evaluation != null)
                 {
                     var startDate = DateTime.SpecifyKind(evaluation.StartDate, DateTimeKind.Utc);
-                    var endDate = DateTime.SpecifyKind(evaluation.EndDate, DateTimeKind.Utc);
+                    var endDate = DateTime.SpecifyKind(evaluation.EndDate, DateTimeKind.Utc)
+                          .Date.AddDays(1).AddTicks(-1);
 
                     var query = from A in _context.ErasCalculationsByPoll
                                 join PI in _context.PollInstances on A.PollInstanceId equals PI.Id


### PR DESCRIPTION

## Description

Fixed end-of-day adjustment for endDate across all evaluation date filters. Dates were being interpreted as 00:00:00, excluding records from the same day. Applied .Date.AddDays(1).AddTicks(-1) to all relevant handlers and repositories. Also wired EvaluationId through the cohorts summary flow (controller → handler → repository).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


