### PR TITLE
fix: return 404 when student not found in GetStudentAnswersByPoll

### DIFF
--- a/src/Eras.Application/Features/Answers/Queries/GetStudentAnswersByPollQueryHandler.cs
+++ b/src/Eras.Application/Features/Answers/Queries/GetStudentAnswersByPollQueryHandler.cs
@@ -11,25 +11,33 @@ namespace Eras.Application.Features.Answers.Queries
     public class GetStudentAnswersByPollQueryHandler : IRequestHandler<GetStudentAnswersByPollQuery, PagedResult<StudentAnswer>>
     {
         private readonly IStudentAnswersRepository _studentAnswersRepository;
+        private readonly IStudentRepository _studentRepository;
         private readonly ILogger<GetStudentAnswersByPollQueryHandler> _logger;
 
-        public GetStudentAnswersByPollQueryHandler(IStudentAnswersRepository StudentAnswersRepository, ILogger<GetStudentAnswersByPollQueryHandler> Logger)
+        public GetStudentAnswersByPollQueryHandler(
+            IStudentAnswersRepository StudentAnswersRepository,
+            IStudentRepository StudentRepository,
+            ILogger<GetStudentAnswersByPollQueryHandler> Logger)
         {
             _studentAnswersRepository = StudentAnswersRepository;
+            _studentRepository = StudentRepository;
             _logger = Logger;
         }
+
         public async Task<PagedResult<StudentAnswer>> Handle(GetStudentAnswersByPollQuery Request, CancellationToken CancellationToken)
         {
-
             if (Request.PollId <= 0 || Request.StudentId <= 0)
                 throw new ArgumentException("PollId and StudentId must be positive integers.");
 
             if (Request.Query == null)
                 throw new ArgumentNullException("Request must contain pagination");
 
-            var answers = await _studentAnswersRepository.GetStudentAnswersPagedAsync(Request.StudentId, Request.PollId, Request.Query.Page, Request.Query.PageSize);
-            
-            return answers;
+            var student = await _studentRepository.GetByIdAsync(Request.StudentId);
+            if (student == null)
+                throw new KeyNotFoundException($"Student with ID {Request.StudentId} not found.");
+
+            return await _studentAnswersRepository.GetStudentAnswersPagedAsync(
+                Request.StudentId, Request.PollId, Request.Query.Page, Request.Query.PageSize);
         }
     }
 }

--- a/test/Eras.Application.Tests/Features/Answers/Queries/GetStudentAnswersByPollQueryHandlerTest.cs
+++ b/test/Eras.Application.Tests/Features/Answers/Queries/GetStudentAnswersByPollQueryHandlerTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Eras.Application.Contracts.Persistence;
@@ -10,26 +11,38 @@ using Eras.Application.Utils;
 using Eras.Domain.Entities;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Xunit; 
 
 namespace Eras.Application.Tests.Features.Answers.Queries;
+
 public class GetStudentAnswersByPollQueryHandlerTest
 {
     private readonly Mock<IStudentAnswersRepository> _mockAnswerRepository;
+    private readonly Mock<IStudentRepository> _mockStudentRepository;
     private readonly Mock<ILogger<GetStudentAnswersByPollQueryHandler>> _mockLogger;
     private readonly GetStudentAnswersByPollQueryHandler _handler;
 
     public GetStudentAnswersByPollQueryHandlerTest()
     {
         _mockAnswerRepository = new Mock<IStudentAnswersRepository>();
+        _mockStudentRepository = new Mock<IStudentRepository>(); 
         _mockLogger = new Mock<ILogger<GetStudentAnswersByPollQueryHandler>>();
-        _handler = new GetStudentAnswersByPollQueryHandler(_mockAnswerRepository.Object, _mockLogger.Object);
+        
+        _handler = new GetStudentAnswersByPollQueryHandler(
+            _mockAnswerRepository.Object, 
+            _mockStudentRepository.Object, 
+            _mockLogger.Object);
     }
 
     [Fact]
     public async Task Handle_Should_Return_Success_ResponseAsync()
     {
-        // Arrange
         var query = new GetStudentAnswersByPollQuery() { PollId = 1, StudentId = 1 };
+
+        _mockStudentRepository
+            .Setup(r => r.GetByIdAsync(It.Is<int>(id => id == 1)))
+            .ReturnsAsync(new Student { Id = 1 }); 
+
         var studentAnswers = new List<StudentAnswer>() {
             new StudentAnswer
             {
@@ -59,10 +72,8 @@ public class GetStudentAnswersByPollQueryHandlerTest
                 10))
             .ReturnsAsync(pagedResult);
 
-        // Act
         var result = await _handler.Handle(query, CancellationToken.None);
 
-        // Assert
         Assert.NotNull(result);
         Assert.Equal(2, result.Count);
     }


### PR DESCRIPTION
## Description

Added the missing 404 Not Found validation for non-existent students, as requested in the Developer Notes. All other endpoint functionalities were already working.

GET
[/api/v1/students/{Id}/polls/{InstanceId}/answers]

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


