### PR TITLE
fix: filter ComponentsAvgByStudent by StudentId instead of PollInstan…

### DIFF
--- a/src/Eras.Api/Controllers/PollInstancesController.cs
+++ b/src/Eras.Api/Controllers/PollInstancesController.cs
@@ -8,6 +8,7 @@ using Eras.Application.Features.PollInstances.Queries.GetPollInstancesByCohortAn
 using MediatR;
 
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Eras.Api.Controllers;
 
@@ -21,6 +22,7 @@ public class PollInstancesController(IMediator Mediator, ILogger<StudentsControl
     private readonly ILogger<StudentsController> _logger = Logger;
 
     [HttpGet("{PollUuid}")]
+    [Authorize]
     public async Task<IActionResult> GetPollInstancesByCohortIdAndDaysAsync(
             [FromQuery] int[] CohortId,
             [FromQuery] int Days,
@@ -34,6 +36,7 @@ public class PollInstancesController(IMediator Mediator, ILogger<StudentsControl
     }
 
     [HttpGet("{Uuid}/cohorts/avg")]
+    [Authorize]
     public async Task<IActionResult> GetComponentsAvgGroupedByCohortAsync([FromRoute] string Uuid, [FromQuery] bool LastVersion)
     {
         var getCohortComponentsByPollQuery = new GetCohortComponentsByPollQuery() { PollUuid = Uuid, LastVersion = LastVersion };
@@ -54,6 +57,7 @@ public class PollInstancesController(IMediator Mediator, ILogger<StudentsControl
     }
 
     [HttpGet("{Id}/avg")]
+    [Authorize]
     public async Task<IActionResult> GetComponentsRiskAvgByStudentAsync([FromQuery] int StudentId, [FromRoute] int Id)
     {
         var getComponentsRiskAvgByStudent = new GetComponentsAvgByStudentQuery()

--- a/src/Eras.Api/Controllers/PollInstancesController.cs
+++ b/src/Eras.Api/Controllers/PollInstancesController.cs
@@ -61,6 +61,9 @@ public class PollInstancesController(IMediator Mediator, ILogger<StudentsControl
             StudentId = StudentId,
             PollId = Id
         };
-        return Ok(await _mediator.Send(getComponentsRiskAvgByStudent));
+        var result = await _mediator.Send(getComponentsRiskAvgByStudent);
+        if (result == null || !result.Any())
+            return NotFound(new { status = "error", message = "Student not found" });
+        return Ok(result);
     }
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ComponentsAvgRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ComponentsAvgRepository.cs
@@ -17,7 +17,7 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
         public async Task<List<ComponentsAvg>> ComponentsAvgByStudent(int StudentId, int PollId)
         {
             List<ComponentsAvg> result = await _context.ErasCalculationsByPoll
-                                .Where(V => V.PollInstanceId == StudentId && V.PollId == PollId)
+                                .Where(V => V.StudentId == StudentId && V.PollId == PollId)
                                 .GroupBy(V => new { V.PollId, V.ComponentId, V.ComponentName })
                                 .Select(G => new ComponentsAvg
                                 {


### PR DESCRIPTION
## Description

This mainly includes handling the 404 case when the student ID does not exist, and verifying that the rest of the endpoint behavior works correctly.

GET
 [/api/v1/poll-instances/{Id}/avg]

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


