### PR TITLE
fix: return all students matching risk level filter

### DIFF
--- a/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByFilters/GetStudentsByFiltersQueryHandler.cs
+++ b/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByFilters/GetStudentsByFiltersQueryHandler.cs
@@ -50,8 +50,6 @@ public class GetStudentsByFiltersQueryHandler :
             );
 
             var studentsResponses = studentsList
-            .GroupBy(Student => new { Student.StudentId, Student.AnswerId })
-            .Select(g => g.First())
             .Select(Student => new StudentsByFiltersResponse
             {
                 Id = Student.StudentId,

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
@@ -85,7 +85,10 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
             .Distinct()
             .ToListAsync();
 
-        var filtered = ApplyRiskFilter(entities, RiskLevels).ToList();
+        var filtered = ApplyRiskFilter(entities, RiskLevels)
+            .GroupBy(v => new { v.StudentId, v.AnswerId })
+            .Select(g => g.First())
+            .ToList();
 
         var paged = filtered
             .Skip((Page - 1) * PageSize)


### PR DESCRIPTION
## Description

- Apply Distinct on StudentId+AnswerId to avoid duplicate entries
- Ensure GetStudentsByFilters returns complete filtered list

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


