### PR TITLE
fix: correct KPI percentage change calculation using domain-specific …

### DIFF
--- a/src/Eras.Application/Contracts/Persistence/IEvaluationRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/IEvaluationRepository.cs
@@ -10,5 +10,6 @@ namespace Eras.Application.Contracts.Persistence
         Task<Evaluation?> GetByIdForUpdateAsync(int Id);        
         new Task<List<Evaluation>> GetAllAsync();
         Task<List<Evaluation>> GetByDateRange(DateTime startDate, DateTime endDate);
+        Task<int> CountByDateRangeAsync(DateTime startDate, DateTime endDate);
     }
 }

--- a/src/Eras.Application/Contracts/Persistence/IPollInstanceRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/IPollInstanceRepository.cs
@@ -27,4 +27,5 @@ public interface IPollInstanceRepository : IBaseRepository<PollInstance>
 
     new Task<PollInstance> UpdateAsync(PollInstance Entity);
     Task<CountReportResponseVm> GetCountReportByVariablesAsync(string PollUuid, List<int> CohortIds, List<int> VariableIds, bool LastVersion, DateTime startDate, DateTime endDate);
+    new Task<int> CountByDateRangeAsync(DateTime startDate, DateTime endDate);
 }

--- a/src/Eras.Application/Utils/CohortsHelper.cs
+++ b/src/Eras.Application/Utils/CohortsHelper.cs
@@ -73,23 +73,22 @@ public class CohortsHelper
         return false;
     }
 
+    private static (DateTime Start, DateTime End) GetCohortRangeForDate(DateTime date)
+    {
+        return date.Month <= 6
+            ? (new DateTime(date.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(date.Year, 6, 30, 23, 59, 59, DateTimeKind.Utc))
+            : (new DateTime(date.Year, 7, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(date.Year, 12, 31, 23, 59, 59, DateTimeKind.Utc));
+    }
+
     public static (DateTime Start, DateTime End) GetCurrentCohortRange()
     {
-        var now = DateTime.UtcNow;
-        return now.Month <= 6
-            ? (new DateTime(now.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc),
-            new DateTime(now.Year, 6, 30, 23, 59, 59, DateTimeKind.Utc))
-            : (new DateTime(now.Year, 7, 1, 0, 0, 0, DateTimeKind.Utc),
-            new DateTime(now.Year, 12, 31, 23, 59, 59, DateTimeKind.Utc));
+        return GetCohortRangeForDate(DateTime.UtcNow);
     }
 
     public static (DateTime Start, DateTime End) GetPreviousCohortRange()
     {
-        var now = DateTime.UtcNow;
-        return now.Month <= 6
-            ? (new DateTime(now.Year - 1, 7, 1, 0, 0, 0, DateTimeKind.Utc),
-            new DateTime(now.Year - 1, 12, 31, 23, 59, 59, DateTimeKind.Utc))
-            : (new DateTime(now.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc),
-            new DateTime(now.Year, 6, 30, 23, 59, 59, DateTimeKind.Utc));
+        return GetCohortRangeForDate(DateTime.UtcNow.AddMonths(-6));
     }
 }

--- a/src/Eras.Application/Utils/CohortsHelper.cs
+++ b/src/Eras.Application/Utils/CohortsHelper.cs
@@ -77,15 +77,19 @@ public class CohortsHelper
     {
         var now = DateTime.UtcNow;
         return now.Month <= 6
-            ? (new DateTime(now.Year, 1, 1), new DateTime(now.Year, 6, 30, 23, 59, 59, DateTimeKind.Utc))
-            : (new DateTime(now.Year, 7, 1), new DateTime(now.Year, 12, 31, 23, 59, 59, DateTimeKind.Utc));
+            ? (new DateTime(now.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(now.Year, 6, 30, 23, 59, 59, DateTimeKind.Utc))
+            : (new DateTime(now.Year, 7, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(now.Year, 12, 31, 23, 59, 59, DateTimeKind.Utc));
     }
 
     public static (DateTime Start, DateTime End) GetPreviousCohortRange()
     {
         var now = DateTime.UtcNow;
         return now.Month <= 6
-            ? (new DateTime(now.Year - 1, 7, 1), new DateTime(now.Year - 1, 12, 31, 23, 59, 59, DateTimeKind.Utc))
-            : (new DateTime(now.Year, 1, 1), new DateTime(now.Year, 6, 30, 23, 59, 59, DateTimeKind.Utc));
+            ? (new DateTime(now.Year - 1, 7, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(now.Year - 1, 12, 31, 23, 59, 59, DateTimeKind.Utc))
+            : (new DateTime(now.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(now.Year, 6, 30, 23, 59, 59, DateTimeKind.Utc));
     }
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/EvaluationRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/EvaluationRepository.cs
@@ -147,5 +147,13 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
 
             return results;
         }
+
+        public new async Task<int> CountByDateRangeAsync(DateTime startDate, DateTime endDate)
+        {
+            return await _context.Evaluations
+                .Where(e => e.StartDate >= DateTime.SpecifyKind(startDate, DateTimeKind.Utc)
+                        && e.StartDate <= DateTime.SpecifyKind(endDate, DateTimeKind.Utc))
+                .CountAsync();
+        }
     }
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
@@ -293,4 +293,12 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
         })];
         return new CountReportResponseVm { Components = report };
     }
+
+    public new async Task<int> CountByDateRangeAsync(DateTime startDate, DateTime endDate)
+    {
+        return await _context.PollInstances
+            .Where(pi => pi.FinishedAt >= DateTime.SpecifyKind(startDate, DateTimeKind.Utc)
+                    && pi.FinishedAt <= DateTime.SpecifyKind(endDate, DateTimeKind.Utc))
+            .CountAsync();
+    }
 }


### PR DESCRIPTION
## Description

This fix corrects how KPI percentage changes are calculated by using the appropriate date for each entity instead of a generic created_at field.

Each repository now filters by its relevant date (e.g., StartDate for evaluations, FinishedAt for poll instances), and cohort date ranges are handled in UTC to avoid timezone issues.

As a result, KPI percentages now accurately reflect the change between the current and previous periods instead of always returning 100%.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


