### PR TITLE
401 feature create interventions endpoints

### DIFF
--- a/src/Eras.Api/ApiServiceRegistration.cs
+++ b/src/Eras.Api/ApiServiceRegistration.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.OpenApi.Models;
+using Eras.Api.Filters; 
 
 namespace Eras.Api
 {
@@ -15,6 +16,7 @@ namespace Eras.Api
             Services.AddEndpointsApiExplorer();
             Services.AddSwaggerGen(Options =>
             {
+                Options.SchemaFilter<PolymorphicInterventionSchemaFilter>();
                 Options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
                 {
                     In = ParameterLocation.Header,

--- a/src/Eras.Api/Controllers/AssessmentManagement/AssessmentsController.cs
+++ b/src/Eras.Api/Controllers/AssessmentManagement/AssessmentsController.cs
@@ -146,4 +146,16 @@ public class AssessmentsController(IMediator Mediator, ILogger<AssessmentsContro
 
         return Ok(response);
     }    
+
+    [HttpDelete("{id:guid}/interventions/{interventionId:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteIntervention(
+        Guid id,
+        Guid interventionId,
+        CancellationToken cancellationToken)
+    {
+        await Mediator.Send(new DeleteInterventionCommand(id, interventionId), cancellationToken);
+        return NoContent();
+    }
 }

--- a/src/Eras.Api/Controllers/AssessmentManagement/AssessmentsController.cs
+++ b/src/Eras.Api/Controllers/AssessmentManagement/AssessmentsController.cs
@@ -101,4 +101,49 @@ public class AssessmentsController(IMediator Mediator, ILogger<AssessmentsContro
 
         return Ok(response);
     }
+
+    [HttpGet("{id:guid}/interventions")]
+    [ProducesResponseType(typeof(IReadOnlyCollection<InterventionDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<IReadOnlyCollection<InterventionDto>>> GetInterventions(
+        Guid id,
+        CancellationToken cancellationToken)
+    {
+        var response = await Mediator.Send(
+            new GetInterventionsByAssessmentQuery(id),
+            cancellationToken);
+
+        return Ok(response);
+    }
+
+    [HttpPost("interventions")]
+    [ProducesResponseType(typeof(InterventionDto), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<InterventionDto>> AddIntervention(
+        [FromBody] AddInterventionDto dto,
+        CancellationToken cancellationToken)
+    {
+        var response = await Mediator.Send(
+            new AddInterventionCommand(dto.AssessmentId, dto.Intervention),
+            cancellationToken);
+
+        return Created(string.Empty, response);
+    }
+
+    [HttpPut("{id:guid}/interventions")]
+    [ProducesResponseType(typeof(IReadOnlyCollection<InterventionDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<IReadOnlyCollection<InterventionDto>>> UpsertInterventions(
+        Guid id,
+        [FromBody] IReadOnlyCollection<InterventionDto> interventions,
+        CancellationToken cancellationToken)
+    {
+        var response = await Mediator.Send(
+            new UpsertInterventionsCommand(id, interventions),
+            cancellationToken);
+
+        return Ok(response);
+    }    
 }

--- a/src/Eras.Api/Filters/PolymorphicInterventionSchemaFilter.cs
+++ b/src/Eras.Api/Filters/PolymorphicInterventionSchemaFilter.cs
@@ -1,0 +1,71 @@
+using Eras.Application.DTOs.AssessmentManagement;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Eras.Api.Filters;
+
+[ExcludeFromCodeCoverage]
+public class PolymorphicInterventionSchemaFilter : ISchemaFilter
+{
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        if (context.Type == typeof(InterventionDto))
+        {
+            schema.Properties["kind"] = new OpenApiSchema
+            {
+                Type = "string",
+                Enum = new List<IOpenApiAny>
+                {
+                    new OpenApiString("Individual"),
+                    new OpenApiString("Group")
+                }
+            };
+
+            schema.Properties["area"] = new OpenApiSchema { Type = "string", Nullable = true };
+            schema.Properties["participantIds"] = new OpenApiSchema
+            {
+                Type = "array",
+                Items = new OpenApiSchema { Type = "string", Format = "uuid" }
+            };
+
+            schema.Example = new OpenApiObject
+            {
+                ["kind"] = new OpenApiString("Individual or Group"),
+                ["dateUtc"] = new OpenApiString("2026-05-06T10:00:00Z"),
+                ["activityType"] = new OpenApiString("string"),
+                ["professional"] = new OpenApiString("string"),
+                ["comments"] = new OpenApiString("string"),
+                ["attachments"] = new OpenApiArray(),
+                ["area"] = new OpenApiString("(Group only) string"),
+                ["participantIds"] = new OpenApiArray
+                {
+                    new OpenApiString("(Group only) 7f317802-fb3e-4d95-8c87-3b39ff7cc604")
+                }
+            };
+        }
+
+        if (context.Type == typeof(AddInterventionDto))
+        {
+            schema.Example = new OpenApiObject
+            {
+                ["assessmentId"] = new OpenApiString("5fa85f64-5717-4562-b3fc-2c963f66afa6"),
+                ["intervention"] = new OpenApiObject
+                {
+                    ["kind"] = new OpenApiString("Individual or Group"),
+                    ["dateUtc"] = new OpenApiString("2026-05-06T10:00:00Z"),
+                    ["activityType"] = new OpenApiString("string"),
+                    ["professional"] = new OpenApiString("string"),
+                    ["comments"] = new OpenApiString("string"),
+                    ["attachments"] = new OpenApiArray(),
+                    ["area"] = new OpenApiString("(Group only) string"),
+                    ["participantIds"] = new OpenApiArray
+                    {
+                        new OpenApiString("(Group only) 7f317802-fb3e-4d95-8c87-3b39ff7cc604")
+                    }
+                }
+            };
+        }
+    }
+}

--- a/src/Eras.Application/Contracts/Persistence/AssessmentManagement/IAssessmentRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/AssessmentManagement/IAssessmentRepository.cs
@@ -14,4 +14,6 @@ public interface IAssessmentRepository : IBaseRepository<Assessment>
     Task<Intervention> AddInterventionAsync(Guid assessmentId, Intervention intervention); 
 
     Task<IReadOnlyCollection<Intervention>> ReplaceInterventionsAsync(Guid assessmentId, IReadOnlyCollection<Intervention> interventions);
+
+    Task DeleteInterventionAsync(Guid assessmentId, Guid interventionId);
 }

--- a/src/Eras.Application/Contracts/Persistence/AssessmentManagement/IAssessmentRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/AssessmentManagement/IAssessmentRepository.cs
@@ -8,4 +8,10 @@ public interface IAssessmentRepository : IBaseRepository<Assessment>
     Task<IEnumerable<Assessment>> GetByStudentIdAsync(Guid studentId);
 
     Task<IEnumerable<Assessment>> GetByStatusAsync(AssessmentStatus status);
+
+    Task<Assessment?> GetByIdWithInterventionsAsync(Guid id);
+
+    Task<Intervention> AddInterventionAsync(Guid assessmentId, Intervention intervention); 
+
+    Task<IReadOnlyCollection<Intervention>> ReplaceInterventionsAsync(Guid assessmentId, IReadOnlyCollection<Intervention> interventions);
 }

--- a/src/Eras.Application/DTOs/AssessmentManagement/AddInterventionDto.cs
+++ b/src/Eras.Application/DTOs/AssessmentManagement/AddInterventionDto.cs
@@ -1,0 +1,7 @@
+namespace Eras.Application.DTOs.AssessmentManagement;
+
+public sealed record AddInterventionDto
+{
+    public required Guid AssessmentId { get; init; }
+    public required InterventionDto Intervention { get; init; }
+}

--- a/src/Eras.Application/DTOs/AssessmentManagement/InterventionDto.cs
+++ b/src/Eras.Application/DTOs/AssessmentManagement/InterventionDto.cs
@@ -1,5 +1,10 @@
-﻿namespace Eras.Application.DTOs.AssessmentManagement;
+﻿using System.Text.Json.Serialization;
 
+namespace Eras.Application.DTOs.AssessmentManagement;
+
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "kind")]
+[JsonDerivedType(typeof(IndividualInterventionDto), "Individual")]
+[JsonDerivedType(typeof(GroupInterventionDto), "Group")]
 public abstract record InterventionDto
 {
     public Guid? Id { get; init; }

--- a/src/Eras.Application/Features/RemissionManagement/Commands.cs
+++ b/src/Eras.Application/Features/RemissionManagement/Commands.cs
@@ -36,3 +36,6 @@ public sealed record GetInterventionsByAssessmentQuery(Guid AssessmentId)
 
 public sealed record AddInterventionCommand(Guid AssessmentId, InterventionDto Intervention)
     : IRequest<InterventionDto>;
+
+public sealed record DeleteInterventionCommand(Guid AssessmentId, Guid InterventionId)
+    : IRequest;

--- a/src/Eras.Application/Features/RemissionManagement/Commands.cs
+++ b/src/Eras.Application/Features/RemissionManagement/Commands.cs
@@ -27,3 +27,12 @@ public sealed record GetRemissionsByStatusQuery(AssessmentStatus Status)
     : IRequest<IReadOnlyCollection<AssessmentDto>>;
 
 public sealed record GetAllRemissionsQuery() : IRequest<IReadOnlyCollection<AssessmentDto>>;
+
+public sealed record UpsertInterventionsCommand(Guid AssessmentId, IReadOnlyCollection<InterventionDto> Interventions)
+    : IRequest<IReadOnlyCollection<InterventionDto>>;
+
+public sealed record GetInterventionsByAssessmentQuery(Guid AssessmentId)
+    : IRequest<IReadOnlyCollection<InterventionDto>>;
+
+public sealed record AddInterventionCommand(Guid AssessmentId, InterventionDto Intervention)
+    : IRequest<InterventionDto>;

--- a/src/Eras.Application/Features/RemissionManagement/Handlers/AddInterventionCommandHandler.cs
+++ b/src/Eras.Application/Features/RemissionManagement/Handlers/AddInterventionCommandHandler.cs
@@ -1,0 +1,79 @@
+using Eras.Application.Contracts.Persistence.AssessmentManagement;
+using Eras.Application.DTOs.AssessmentManagement;
+using Eras.Application.Mappers.AssessmentManagement;
+using Eras.Domain.Entities.AssessmentManagement;
+
+using MediatR;
+
+namespace Eras.Application.Features.RemissionManagement.Handlers;
+
+public sealed class AddInterventionCommandHandler
+    : IRequestHandler<AddInterventionCommand, InterventionDto>
+{
+    private readonly IAssessmentRepository _repository;
+    private readonly IMapper<IndividualInterventionDto, IndividualIntervention> _individualMapper;
+    private readonly IMapper<GroupInterventionDto, GroupIntervention> _groupMapper;
+    private readonly IMapper<Assessment, AssessmentDto> _toDtoMapper;
+
+    public AddInterventionCommandHandler(
+        IAssessmentRepository repository,
+        IMapper<IndividualInterventionDto, IndividualIntervention> individualMapper,
+        IMapper<GroupInterventionDto, GroupIntervention> groupMapper,
+        IMapper<Assessment, AssessmentDto> toDtoMapper)
+    {
+        _repository = repository;
+        _individualMapper = individualMapper;
+        _groupMapper = groupMapper;
+        _toDtoMapper = toDtoMapper;
+    }
+
+    public async Task<InterventionDto> Handle(
+        AddInterventionCommand request,
+        CancellationToken cancellationToken)
+    {
+        Assessment? assessment = await _repository.GetByIdWithInterventionsAsync(request.AssessmentId);
+
+        if (assessment is null)
+            throw new KeyNotFoundException($"Assessment '{request.AssessmentId}' not found.");
+
+        Intervention newIntervention = MapIntervention(request.Intervention);
+
+        Intervention persisted = await _repository.AddInterventionAsync(request.AssessmentId, newIntervention);
+
+        return request.Intervention switch
+        {
+            IndividualInterventionDto => new IndividualInterventionDto
+            {
+                Id = persisted.Id,
+                DateUtc = persisted.DateUtc,
+                ActivityType = persisted.ActivityType,
+                Professional = persisted.Professional,
+                Comments = persisted.Comments,
+                Attachments = persisted.Attachments
+            },
+            GroupInterventionDto => new GroupInterventionDto
+            {
+                Id = persisted.Id,
+                DateUtc = persisted.DateUtc,
+                ActivityType = persisted.ActivityType,
+                Professional = persisted.Professional,
+                Comments = persisted.Comments,
+                Attachments = persisted.Attachments,
+                Area = ((GroupIntervention)persisted).Area,
+                ParticipantIds = ((GroupIntervention)persisted).ParticipantIds
+            },
+            _ => throw new NotSupportedException($"Intervention DTO type '{request.Intervention.GetType().Name}' is not supported.")
+        };
+    }
+
+    private Intervention MapIntervention(InterventionDto dto)
+    {
+        return dto switch
+        {
+            IndividualInterventionDto individual => _individualMapper.Map(individual),
+            GroupInterventionDto group => _groupMapper.Map(group),
+            _ => throw new NotSupportedException(
+                $"Intervention DTO type '{dto.GetType().Name}' is not supported.")
+        };
+    }
+}

--- a/src/Eras.Application/Features/RemissionManagement/Handlers/DeleteInterventionCommandHandler.cs
+++ b/src/Eras.Application/Features/RemissionManagement/Handlers/DeleteInterventionCommandHandler.cs
@@ -1,0 +1,22 @@
+using Eras.Application.Contracts.Persistence.AssessmentManagement;
+using MediatR;
+
+namespace Eras.Application.Features.RemissionManagement.Handlers;
+
+public sealed class DeleteInterventionCommandHandler
+    : IRequestHandler<DeleteInterventionCommand>
+{
+    private readonly IAssessmentRepository _repository;
+
+    public DeleteInterventionCommandHandler(IAssessmentRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task Handle(
+        DeleteInterventionCommand request,
+        CancellationToken cancellationToken)
+    {
+        await _repository.DeleteInterventionAsync(request.AssessmentId, request.InterventionId);
+    }
+}

--- a/src/Eras.Application/Features/RemissionManagement/Handlers/GetInterventionsByAssessmentQueryHandler.cs
+++ b/src/Eras.Application/Features/RemissionManagement/Handlers/GetInterventionsByAssessmentQueryHandler.cs
@@ -1,0 +1,35 @@
+using Eras.Application.Contracts.Persistence.AssessmentManagement;
+using Eras.Application.DTOs.AssessmentManagement;
+using Eras.Application.Mappers.AssessmentManagement;
+using Eras.Domain.Entities.AssessmentManagement;
+
+using MediatR;
+
+namespace Eras.Application.Features.RemissionManagement.Handlers;
+
+public sealed class GetInterventionsByAssessmentQueryHandler
+    : IRequestHandler<GetInterventionsByAssessmentQuery, IReadOnlyCollection<InterventionDto>>
+{
+    private readonly IAssessmentRepository _repository;
+    private readonly IMapper<Assessment, AssessmentDto> _toDtoMapper;
+
+    public GetInterventionsByAssessmentQueryHandler(
+        IAssessmentRepository repository,
+        IMapper<Assessment, AssessmentDto> toDtoMapper)
+    {
+        _repository = repository;
+        _toDtoMapper = toDtoMapper;
+    }
+
+    public async Task<IReadOnlyCollection<InterventionDto>> Handle(
+        GetInterventionsByAssessmentQuery request,
+        CancellationToken cancellationToken)
+    {
+        Assessment? assessment = await _repository.GetByIdWithInterventionsAsync(request.AssessmentId);
+
+        if (assessment is null)
+            throw new KeyNotFoundException($"Assessment '{request.AssessmentId}' not found.");
+
+        return _toDtoMapper.Map(assessment).Interventions;
+    }
+}

--- a/src/Eras.Application/Features/RemissionManagement/Handlers/UpsertInterventionsCommandHandler.cs
+++ b/src/Eras.Application/Features/RemissionManagement/Handlers/UpsertInterventionsCommandHandler.cs
@@ -1,0 +1,66 @@
+using Eras.Application.Contracts.Persistence.AssessmentManagement;
+using Eras.Application.DTOs.AssessmentManagement;
+using Eras.Application.Mappers.AssessmentManagement;
+using Eras.Domain.Entities.AssessmentManagement;
+
+using MediatR;
+
+namespace Eras.Application.Features.RemissionManagement.Handlers;
+
+public sealed class UpsertInterventionsCommandHandler
+    : IRequestHandler<UpsertInterventionsCommand, IReadOnlyCollection<InterventionDto>>
+{
+    private readonly IAssessmentRepository _repository;
+    private readonly IMapper<IndividualInterventionDto, IndividualIntervention> _individualMapper;
+    private readonly IMapper<GroupInterventionDto, GroupIntervention> _groupMapper;
+    private readonly IMapper<Assessment, AssessmentDto> _toDtoMapper;
+
+    public UpsertInterventionsCommandHandler(
+        IAssessmentRepository repository,
+        IMapper<IndividualInterventionDto, IndividualIntervention> individualMapper,
+        IMapper<GroupInterventionDto, GroupIntervention> groupMapper,
+        IMapper<Assessment, AssessmentDto> toDtoMapper)
+    {
+        _repository = repository;
+        _individualMapper = individualMapper;
+        _groupMapper = groupMapper;
+        _toDtoMapper = toDtoMapper;
+    }
+
+    public async Task<IReadOnlyCollection<InterventionDto>> Handle(
+        UpsertInterventionsCommand request,
+        CancellationToken cancellationToken)
+    {
+        Assessment? assessment = await _repository.GetByIdWithInterventionsAsync(request.AssessmentId);
+
+        if (assessment is null)
+            throw new KeyNotFoundException($"Assessment '{request.AssessmentId}' not found.");
+
+        IReadOnlyCollection<Intervention> newInterventions = MapInterventions(request.Interventions);
+
+        await _repository.ReplaceInterventionsAsync(request.AssessmentId, newInterventions);
+
+        return request.Interventions;
+    }
+
+    private IReadOnlyCollection<Intervention> MapInterventions(
+        IReadOnlyCollection<InterventionDto> dtos)
+    {
+        List<Intervention> result = new(dtos.Count);
+
+        foreach (InterventionDto dto in dtos)
+        {
+            Intervention mapped = dto switch
+            {
+                IndividualInterventionDto individual => _individualMapper.Map(individual),
+                GroupInterventionDto group => _groupMapper.Map(group),
+                _ => throw new NotSupportedException(
+                    $"Intervention DTO type '{dto.GetType().Name}' is not supported.")
+            };
+
+            result.Add(mapped);
+        }
+
+        return result;
+    }
+}

--- a/src/Eras.Domain/Entities/AssessmentManagement/Assessment.cs
+++ b/src/Eras.Domain/Entities/AssessmentManagement/Assessment.cs
@@ -22,5 +22,5 @@ public sealed class Assessment : BaseEntity
 
     public required AssessmentStatus Status { get; init; }
 
-    public IReadOnlyCollection<Intervention> Interventions { get; init; } = Array.Empty<Intervention>();
+    public IReadOnlyCollection<Intervention> Interventions { get; init; } = new List<Intervention>();
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/AssessmentRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/AssessmentRepository.cs
@@ -58,4 +58,19 @@ public sealed class AssessmentRepository(AppDbContext context, ILogger<Assessmen
         await _context.SaveChangesAsync();
         return interventions;
     }
+
+    public async Task DeleteInterventionAsync(Guid assessmentId, Guid interventionId)
+    {
+        Intervention? intervention = await _context.Set<Intervention>()
+            .FirstOrDefaultAsync(i =>
+                i.Id == interventionId &&
+                EF.Property<Guid?>(i, "remission_id") == assessmentId);
+
+        if (intervention is null)
+            throw new KeyNotFoundException(
+                $"Intervention '{interventionId}' not found for assessment '{assessmentId}'.");
+
+        _context.Set<Intervention>().Remove(intervention);
+        await _context.SaveChangesAsync();
+    }
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/AssessmentRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/AssessmentRepository.cs
@@ -22,4 +22,40 @@ public sealed class AssessmentRepository(AppDbContext context, ILogger<Assessmen
             .Where(x => x.Status == status)
             .ToListAsync();
     }
+
+    public async Task<Assessment?> GetByIdWithInterventionsAsync(Guid id)
+    {
+        return await _context.Set<Assessment>()
+            .AsNoTracking()
+            .Include(a => a.Interventions)
+            .FirstOrDefaultAsync(a => a.Id == id);
+    }
+
+    public async Task<Intervention> AddInterventionAsync(Guid assessmentId, Intervention intervention)
+    {
+        _context.Set<Intervention>().Add(intervention);
+        _context.Entry(intervention).Property("remission_id").CurrentValue = assessmentId;
+        await _context.SaveChangesAsync();
+        return intervention;
+    }
+
+    public async Task<IReadOnlyCollection<Intervention>> ReplaceInterventionsAsync(
+        Guid assessmentId,
+        IReadOnlyCollection<Intervention> interventions)
+    {
+        var existing = await _context.Set<Intervention>()
+            .Where(i => EF.Property<Guid?>(i, "remission_id") == assessmentId)
+            .ToListAsync();
+
+        _context.Set<Intervention>().RemoveRange(existing);
+
+        foreach (Intervention intervention in interventions)
+        {
+            _context.Set<Intervention>().Add(intervention);
+            _context.Entry(intervention).Property("remission_id").CurrentValue = assessmentId;
+        }
+
+        await _context.SaveChangesAsync();
+        return interventions;
+    }
 }


### PR DESCRIPTION
## Description

Add intervention management endpoints to AssessmentsController.
 
- POST /assessments/interventions - creates a new intervention for an assessment
- GET /assessments/{id}/interventions - retrieves all interventions for an assessment
- PUT /assessments/{id}/interventions - replaces the full intervention list for an assessment
- DELETE /assessments/{id}/interventions/{interventionId} - deletes a specific intervention
 
Interventions are sub-entities of Assessment. Individual and Group intervention types are supported via a kind discriminator field.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


