### PR TITLE
Fix error saving evaluation poll when existing student retakes survey in a new evaluation period and the charts related shows all imported students

### DIFF
--- a/src/Eras.Application/Contracts/Persistence/IErasEvaluationDetailsViewRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/IErasEvaluationDetailsViewRepository.cs
@@ -18,4 +18,6 @@ public interface IErasEvaluationDetailsViewRepository : IBaseRepository<ErasEval
     Task<IEnumerable<GetStudentsRecentAlertsResponse>> GetRecentAlertsStudentAsync(int Page, int PageSize);
     Task<int> CountRecentAlerts();
 
+    Task<bool> ExistsPollInstanceForEvaluationAsync(int StudentId, string PollUuid, int EvaluationId);
+    Task<bool> ExistsPollInstanceForEvaluationByRangeAsync(int StudentId, string PollUuid, DateTime Startdate, DateTime Enddate);
 }

--- a/src/Eras.Application/Contracts/Persistence/IErasEvaluationDetailsViewRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/IErasEvaluationDetailsViewRepository.cs
@@ -17,7 +17,4 @@ public interface IErasEvaluationDetailsViewRepository : IBaseRepository<ErasEval
     Task<int> CountStudentsByFilters(string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevel, DateTime startDate, DateTime endDate, int? EvaluationId = null);
     Task<IEnumerable<GetStudentsRecentAlertsResponse>> GetRecentAlertsStudentAsync(int Page, int PageSize);
     Task<int> CountRecentAlerts();
-
-    Task<bool> ExistsPollInstanceForEvaluationAsync(int StudentId, string PollUuid, int EvaluationId);
-    Task<bool> ExistsPollInstanceForEvaluationByRangeAsync(int StudentId, string PollUuid, DateTime Startdate, DateTime Enddate);
 }

--- a/src/Eras.Application/Contracts/Persistence/IErasEvaluationDetailsViewRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/IErasEvaluationDetailsViewRepository.cs
@@ -12,9 +12,9 @@ namespace Eras.Application.Contracts.Persistence;
 public interface IErasEvaluationDetailsViewRepository : IBaseRepository<ErasEvaluationDetailsView>
 {
     Task<List<ErasEvaluationDetailsView>> GetByFiltersAsync(int? PollId, List<int>? ComponentIds, List<int>? CohortIds, List<int>? VariableIds);
-    Task<IEnumerable<ErasEvaluationDetailsView>> GetStudentsByFilters(string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevel, int Page, int PageSize, DateTime startDate, DateTime endDate);
+    Task<IEnumerable<ErasEvaluationDetailsView>> GetStudentsByFilters(string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevel, int Page, int PageSize, DateTime startDate, DateTime endDate, int? EvaluationId = null);
     Task<List<StudentsByFiltersResponse>> GetStudentsByEvaluationIdFilters(int EvaluationId, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevel, DateTime startDate, DateTime endDate);
-    Task<int> CountStudentsByFilters(string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevel, DateTime startDate, DateTime endDate);
+    Task<int> CountStudentsByFilters(string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevel, DateTime startDate, DateTime endDate, int? EvaluationId = null);
     Task<IEnumerable<GetStudentsRecentAlertsResponse>> GetRecentAlertsStudentAsync(int Page, int PageSize);
     Task<int> CountRecentAlerts();
 

--- a/src/Eras.Application/Contracts/Persistence/IPollInstanceRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/IPollInstanceRepository.cs
@@ -8,6 +8,7 @@ public interface IPollInstanceRepository : IBaseRepository<PollInstance>
 {
     Task<PollInstance?> GetByUuidAsync(string Uuid);
     Task<PollInstance?> GetByUuidAndStudentIdAsync(string Uuid, int StudentId);
+    Task<PollInstance?> GetByUuidAndStudentIdAsync(string Uuid, int StudentId, int EvaluationId);
     Task<bool> ExistsByPollNameAndStudentEmailAsync(string PollName, string StudentEmail);
 
     Task<IEnumerable<PollInstance>> GetByLastDays(int Days, bool LastVersion, string PollUuid);
@@ -26,6 +27,7 @@ public interface IPollInstanceRepository : IBaseRepository<PollInstance>
     Task<AvgReportResponseVm> GetReportByPollCohortAsync(string PollUuid, List<int> CohortIds, bool LastVersion, DateTime StartDate, DateTime EndDate);
 
     new Task<PollInstance> UpdateAsync(PollInstance Entity);
-    Task<CountReportResponseVm> GetCountReportByVariablesAsync(string PollUuid, List<int> CohortIds, List<int> VariableIds, bool LastVersion, DateTime startDate, DateTime endDate);
+    Task<CountReportResponseVm> GetCountReportByVariablesAsync(string PollUuid, List<int> CohortIds, List<int> VariableIds, bool LastVersion, DateTime startDate, DateTime endDate, int? EvaluationId);
     new Task<int> CountByDateRangeAsync(DateTime startDate, DateTime endDate);
+    Task<bool> ExistsForStudentAndEvaluationAsync(int StudentId, string PollUuid, int EvaluationId);
 }

--- a/src/Eras.Application/DTOs/PollInstanceDTO.cs
+++ b/src/Eras.Application/DTOs/PollInstanceDTO.cs
@@ -12,4 +12,5 @@ public class PollInstanceDTO
     public DateTime FinishedAt { get; set; }
     public int LastVersion { get; set; }
     public DateTime LastVersionDate { get; set; }
+    public int? EvaluationId { get; set; }
 }

--- a/src/Eras.Application/Dtos/StudentDTO.cs
+++ b/src/Eras.Application/Dtos/StudentDTO.cs
@@ -14,7 +14,7 @@ public class StudentDTO
     
     [Required(ErrorMessage = "Student name is required.")]
     [StringLength(254, MinimumLength = 2, ErrorMessage = "Name must be between 2 and 254 characters.")]
-    [RegularExpression(@"^[a-zA-ZÀ-ÿ\s]+$", ErrorMessage = "Name can only contain letters and spaces.")]
+    [RegularExpression(@"^[a-zA-ZÀ-ÿ'\s]+$", ErrorMessage = "Name can only contain letters and spaces.")]
     public string Name { get; set; } = string.Empty;
     
     [Required(ErrorMessage = "Email is required.")]

--- a/src/Eras.Application/Features/Consolidator/Queries/Polls/GetPollCountQueryHandler.cs
+++ b/src/Eras.Application/Features/Consolidator/Queries/Polls/GetPollCountQueryHandler.cs
@@ -36,7 +36,7 @@ public class PollCountQueryHandler(
                                 .AddDays(1)
                                 .AddTicks(-1); 
 
-            var answersByFilters = await _pollInstanceRepository.GetCountReportByVariablesAsync(Req.PollUuid, Req.CohortIds, Req.VariableIds, Req.LastVersion, startDate, endDate)
+            var answersByFilters = await _pollInstanceRepository.GetCountReportByVariablesAsync(Req.PollUuid, Req.CohortIds, Req.VariableIds, Req.LastVersion, startDate, endDate, Req.EvaluationId)
                 ?? throw new NotFoundException($"Error in query for filters: {Req.PollUuid}; {Req.CohortIds}");
 
             if (answersByFilters == null) 

--- a/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByFilters/GetStudentsByFiltersQueryHandler.cs
+++ b/src/Eras.Application/Features/EvaluationDetails/Queries/GetStudentsByFilters/GetStudentsByFiltersQueryHandler.cs
@@ -41,12 +41,13 @@ public class GetStudentsByFiltersQueryHandler :
                 Request.PageValues.Page,
                 Request.PageValues.PageSize,
                 startDate,
-                endDate
+                endDate,
+                Request.EvaluationId
             );
 
             var totalCount = await _repository.CountStudentsByFilters(
                 Request.PollUuid, Request.ComponentNames, Request.CohortIds,
-                Request.VariableIds, Request.RiskLevels, startDate, endDate
+                Request.VariableIds, Request.RiskLevels, startDate, endDate, Request.EvaluationId
             );
 
             var studentsResponses = studentsList

--- a/src/Eras.Application/Features/PollInstances/Commands/CreatePollInstance/CreatePollInstanceCommandHandler.cs
+++ b/src/Eras.Application/Features/PollInstances/Commands/CreatePollInstance/CreatePollInstanceCommandHandler.cs
@@ -28,7 +28,7 @@ namespace Eras.Application.Features.PollInstances.Commands.CreatePollInstance
                     return new CreateCommandResponse<PollInstance>(null, 0, "Error", false);
                 }
 
-                PollInstance? pollInstanceDB = await _pollInstanceRepository.GetByUuidAndStudentIdAsync(Request.PollInstance.Uuid, Request.PollInstance.Student.Id);
+                PollInstance? pollInstanceDB = await _pollInstanceRepository.GetByUuidAndStudentIdAsync(Request.PollInstance.Uuid, Request.PollInstance.Student.Id, Request.PollInstance.EvaluationId ?? 0);
 
                 if (pollInstanceDB != null) return new CreateCommandResponse<PollInstance>(pollInstanceDB, 0, "Success", true);
 

--- a/src/Eras.Application/Features/PollInstances/Queries/GetByUuidAndStudentId/GetPollInstanceByUuidAndStudentIdQuery.cs
+++ b/src/Eras.Application/Features/PollInstances/Queries/GetByUuidAndStudentId/GetPollInstanceByUuidAndStudentIdQuery.cs
@@ -14,4 +14,5 @@ public class GetPollInstanceByUuidAndStudentIdQuery: IRequest<GetQueryResponse<P
 {
     public required string PollUuid;
     public required int StudentId;
+    public required int EvaluationId;
 }

--- a/src/Eras.Application/Mappers/PollInstanceMapper.cs
+++ b/src/Eras.Application/Mappers/PollInstanceMapper.cs
@@ -19,6 +19,7 @@ namespace Eras.Application.Mappers
                 FinishedAt = Dto.FinishedAt,
                 LastVersion = Dto.LastVersion,
                 LastVersionDate = Dto.LastVersionDate,
+                EvaluationId = Dto.EvaluationId,
             };
         }
         public static PollInstanceDTO ToDTO(this PollInstance Entity)
@@ -35,6 +36,7 @@ namespace Eras.Application.Mappers
                 FinishedAt = Entity.FinishedAt,
                 LastVersion = Entity.LastVersion,
                 LastVersionDate = Entity.LastVersionDate,
+                EvaluationId = Entity.EvaluationId,
             };
 
         }

--- a/src/Eras.Application/Services/PollOrchestratorService.cs
+++ b/src/Eras.Application/Services/PollOrchestratorService.cs
@@ -46,15 +46,18 @@ namespace Eras.Application.Services
         private bool IsNewVersion = false;
         private DateTime InitDate;
         private readonly IEvaluationRepository _evaluationRepository;
+        private readonly IPollInstanceRepository _pollInstanceRepository;
 
         public PollOrchestratorService(
             IMediator Mediator, 
             ILogger<PollOrchestratorService> Logger,
-            IEvaluationRepository EvaluationRepository)
+            IEvaluationRepository EvaluationRepository,
+            IPollInstanceRepository PollInstanceRepository)
         {
             _logger = Logger;
             _mediator = Mediator;
             _evaluationRepository = EvaluationRepository;
+            _pollInstanceRepository = PollInstanceRepository;
         }
 
         public async Task<CreateCommandResponse<CreatedPollDTO>> ImportPollInstancesAsync(List<PollDTO> PollsToCreate, int EvaluationId)
@@ -109,7 +112,7 @@ namespace Eras.Application.Services
                             createdPoll.studentDTOs.Add(createdStudent.Entity.ToDto());
                             // Create poll instances
                             CreateCommandResponse<PollInstance> createdPollInstance = await CreatePollInstanceAsync(createdStudent.Entity,
-                                createdPollResponse.Entity.Uuid, pollToCreate.FinishedAt);
+                                createdPollResponse.Entity.Uuid, pollToCreate.FinishedAt, EvaluationId);
                             // Create asnswers
                             if (createdPollInstance.Success)
                             {
@@ -126,45 +129,47 @@ namespace Eras.Application.Services
                 return new CreateCommandResponse<CreatedPollDTO>(null, 0, $"Error during import process {ex.Message}", false);
             }
         }
-        public async Task<CreateCommandResponse<PollInstance>> CreatePollInstanceAsync(Student Student, string PollUuid, DateTime FinishedAt)
+        public async Task<CreateCommandResponse<PollInstance>> CreatePollInstanceAsync(Student Student, string PollUuid, DateTime FinishedAt, int EvaluationId)
         {
             try
             {
-                var queryPollInstance = new GetPollInstanceByUuidAndStudentIdQuery()
-                {
-                    PollUuid = PollUuid,
-                    StudentId = Student.Id,
-                };
-                var responseQuery = await _mediator.Send(queryPollInstance);
-                if (responseQuery.Status == QueryEnums.QueryResultStatus.Success)
-                {
-                    if (IsNewVersion)
-                    {
-                        responseQuery.Body.LastVersion = VersionNumber;
-                        responseQuery.Body.LastVersionDate = InitDate;
-                        var updateCommand = new UpdatePollInstanceByIdCommand() { PollInstanceDTO = responseQuery.Body.ToDTO() };
-                        var responseUpdate = await _mediator.Send(updateCommand);
-                        return responseUpdate;
-                    }
-                    else
-                        return new CreateCommandResponse<PollInstance>(responseQuery.Body, 0, "Already exists", true);
+                bool alreadyExists = await _pollInstanceRepository.ExistsForStudentAndEvaluationAsync(Student.Id, PollUuid, EvaluationId);
 
-                }
-                else
+                if (alreadyExists)
                 {
-                    PollInstance pollInstance = new PollInstance() { Uuid = PollUuid, Student = Student, FinishedAt = FinishedAt };
-
-                    pollInstance.Audit = new AuditInfo()
+                    // True duplicate within same import run — fetch and return existing
+                    var queryPollInstance = new GetPollInstanceByUuidAndStudentIdQuery()
                     {
-                        CreatedBy = "Cosmic latte import",
-                        CreatedAt = DateTime.UtcNow,
-                        ModifiedAt = DateTime.UtcNow,
+                        PollUuid = PollUuid,
+                        StudentId = Student.Id,
+                        EvaluationId = EvaluationId
                     };
-                    pollInstance.LastVersion = VersionNumber;
-                    pollInstance.LastVersionDate = InitDate;
-                    CreatePollInstanceCommand createPollInstanceCommand = new CreatePollInstanceCommand() { PollInstance = pollInstance.ToDTO() };
-                    return await _mediator.Send(createPollInstanceCommand);
+                    var responseQuery = await _mediator.Send(queryPollInstance);
+                    return new CreateCommandResponse<PollInstance>(
+                        responseQuery.Body, 0, "Already exists for this evaluation", true);
                 }
+                PollInstance pollInstance = new PollInstance()
+                {
+                    Uuid = PollUuid,
+                    Student = Student,
+                    FinishedAt = FinishedAt,
+                    EvaluationId = EvaluationId
+                };
+
+                pollInstance.Audit = new AuditInfo()
+                {
+                    CreatedBy = "Cosmic latte import",
+                    CreatedAt = DateTime.UtcNow,
+                    ModifiedAt = DateTime.UtcNow,
+                };
+                pollInstance.LastVersion = VersionNumber;
+                pollInstance.LastVersionDate = InitDate;
+
+                CreatePollInstanceCommand createPollInstanceCommand = new CreatePollInstanceCommand()
+                {
+                    PollInstance = pollInstance.ToDTO()
+                };
+                return await _mediator.Send(createPollInstanceCommand);
             }
             catch (Exception ex)
             {

--- a/src/Eras.Application/Services/PollOrchestratorService.cs
+++ b/src/Eras.Application/Services/PollOrchestratorService.cs
@@ -65,7 +65,6 @@ namespace Eras.Application.Services
             try
             {
                 InitDate = DateTime.UtcNow;
-                // Create poll
                 PollDTO pollDTO = PollsToCreate[0];
                 CreateCommandResponse<Poll> createdPollResponse = await CreatePollAsync(pollDTO);
                 int createdPollsInstances = 0;
@@ -137,7 +136,6 @@ namespace Eras.Application.Services
 
                 if (alreadyExists)
                 {
-                    // True duplicate within same import run — fetch and return existing
                     var queryPollInstance = new GetPollInstanceByUuidAndStudentIdQuery()
                     {
                         PollUuid = PollUuid,

--- a/src/Eras.Domain/Entities/PollInstance.cs
+++ b/src/Eras.Domain/Entities/PollInstance.cs
@@ -11,5 +11,6 @@ namespace Eras.Domain.Entities
         public int LastVersion { get; set; }
         public DateTime LastVersionDate { get; set; }
         public DateTime FinishedAt { get; set; }
+        public int? EvaluationId { get; set; }
     }
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Entities/PollInstanceEntity.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Entities/PollInstanceEntity.cs
@@ -12,5 +12,6 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Entities
         public DateTime LastVersionDate { get; set; }
         public AuditInfo Audit { get; set; } = default!;
         public DateTime FinishedAt { get; set; }
+        public int? EvaluationId { get; set; }
     }
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Mappers/PollInstanceMapper.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Mappers/PollInstanceMapper.cs
@@ -17,7 +17,7 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Mappers
                 FinishedAt = Entity.FinishedAt,
                 LastVersion = Entity.LastVersion,
                 LastVersionDate = Entity.LastVersionDate,
-
+                EvaluationId = Entity.EvaluationId,
             };
         }
 
@@ -46,6 +46,7 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Mappers
                 FinishedAt = Model.FinishedAt,
                 LastVersion = Model.LastVersion,
                 LastVersionDate = Model.LastVersionDate,
+                EvaluationId = Model.EvaluationId,
             };
         }
     }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260508194702_AddEvaluationIdToPollInstance.Designer.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260508194702_AddEvaluationIdToPollInstance.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Eras.Infrastructure.Persistence.PostgreSQL;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260508194702_AddEvaluationIdToPollInstance")]
+    partial class AddEvaluationIdToPollInstance
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260508194702_AddEvaluationIdToPollInstance.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260508194702_AddEvaluationIdToPollInstance.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Eras.Infrastructure.Persistence.PostgreSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEvaluationIdToPollInstance : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "EvaluationId",
+                table: "poll_instances",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EvaluationId",
+                table: "poll_instances");
+        }
+    }
+}

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
@@ -75,10 +75,10 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
     public async Task<IEnumerable<ErasEvaluationDetailsView>> GetStudentsByFilters(
     string PollUuid, List<string> ComponentNames, List<int> CohortIds,
     List<int>? VariableIds, List<decimal>? RiskLevels,
-    int Page, int PageSize, DateTime startDate, DateTime endDate)
+    int Page, int PageSize, DateTime startDate, DateTime endDate, int? EvaluationId = null)
     {
         var query = BuildStudentsByFiltersQuery(
-        PollUuid, ComponentNames, CohortIds, VariableIds, startDate, endDate);
+        PollUuid, ComponentNames, CohortIds, VariableIds, startDate, endDate, EvaluationId);
 
         var entities = await query
             .OrderBy(v => v.StudentName)
@@ -99,9 +99,10 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
     }
 
     public async Task<int> CountStudentsByFilters(
-        string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevels, DateTime startDate, DateTime endDate)
+        string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, List<decimal>? RiskLevels,
+        DateTime startDate, DateTime endDate, int? EvaluationId = null)
     {
-        var query = BuildStudentsByFiltersQuery(PollUuid, ComponentNames, CohortIds, VariableIds, startDate, endDate);
+        var query = BuildStudentsByFiltersQuery(PollUuid, ComponentNames, CohortIds, VariableIds, startDate, endDate, EvaluationId);
         var entities = await query.ToListAsync();
         return ApplyRiskFilter(entities, RiskLevels)
             .Select(v => v.StudentId)
@@ -181,7 +182,7 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
     }
 
     private IQueryable<ErasEvaluationDetailsViewEntity> BuildStudentsByFiltersQuery(
-        string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, DateTime startDate, DateTime endDate)
+        string PollUuid, List<string> ComponentNames, List<int> CohortIds, List<int>? VariableIds, DateTime startDate, DateTime endDate, int? EvaluationId = null)
     {
         var query = _context.Set<ErasEvaluationDetailsViewEntity>()
             .AsNoTracking()
@@ -192,6 +193,9 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
 
         if (VariableIds != null && VariableIds.Any())
             query = query.Where(v => VariableIds.Contains(v.VariableId));
+
+        if (EvaluationId.HasValue)
+            query = query.Where(v => v.EvaluationId == EvaluationId.Value);
 
         return query;
     }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
@@ -126,6 +126,26 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
             .ToList();
     }
 
+    public async Task<bool> ExistsPollInstanceForEvaluationAsync(int StudentId, string PollUuid, int EvaluationId)
+    {
+        return await _context.Set<ErasEvaluationDetailsViewEntity>()
+            .AsNoTracking()
+            .AnyAsync(v => v.StudentId == StudentId
+                        && v.PollUuid == PollUuid
+                        && v.EvaluationId == EvaluationId);
+    }
+
+    //questioon
+    public async Task<bool> ExistsPollInstanceForEvaluationByRangeAsync(int StudentId, string PollUuid, DateTime Startdate, DateTime Enddate)
+    {
+        return await _context.Set<ErasEvaluationDetailsViewEntity>()
+            .AsNoTracking()
+            .AnyAsync(v => v.StudentId == StudentId
+                        && v.PollUuid == PollUuid
+                        && v.StartDate == Startdate
+                        && v.EndDate == Enddate);
+    }
+
     private async Task<IEnumerable<GetStudentsRecentAlertsResponse>> GetRecentAlertsWithoutPagination()
     {
         var prevItems = await _context.ErasEvaluationDetailsView

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
@@ -126,27 +126,6 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
             .Take(PageSize)
             .ToList();
     }
-
-    public async Task<bool> ExistsPollInstanceForEvaluationAsync(int StudentId, string PollUuid, int EvaluationId)
-    {
-        return await _context.Set<ErasEvaluationDetailsViewEntity>()
-            .AsNoTracking()
-            .AnyAsync(v => v.StudentId == StudentId
-                        && v.PollUuid == PollUuid
-                        && v.EvaluationId == EvaluationId);
-    }
-
-    //questioon
-    public async Task<bool> ExistsPollInstanceForEvaluationByRangeAsync(int StudentId, string PollUuid, DateTime Startdate, DateTime Enddate)
-    {
-        return await _context.Set<ErasEvaluationDetailsViewEntity>()
-            .AsNoTracking()
-            .AnyAsync(v => v.StudentId == StudentId
-                        && v.PollUuid == PollUuid
-                        && v.StartDate == Startdate
-                        && v.EndDate == Enddate);
-    }
-
     private async Task<IEnumerable<GetStudentsRecentAlertsResponse>> GetRecentAlertsWithoutPagination()
     {
         var prevItems = await _context.ErasEvaluationDetailsView

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
@@ -252,8 +252,9 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
             where A.PollUuid == PollUuid
             where CohortIds.Contains(A.CohortId)
             where VariableIds.Contains(A.PollVariableId)
-            where PI.FinishedAt >= startDate && PI.FinishedAt <= endDate
-            where EvaluationId == null || PI.EvaluationId == EvaluationId
+            //where PI.FinishedAt >= startDate && PI.FinishedAt <= endDate -- OLD conditional
+            where PI.Audit.CreatedAt >= startDate && PI.FinishedAt <= endDate
+            where PI.EvaluationId == EvaluationId
             select new ErasCalculationsByPollDTO
             {
                 ComponentName = A.ComponentName,

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
@@ -22,7 +22,13 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
 
     public async Task<PollInstance?> GetByUuidAndStudentIdAsync(string Uuid, int StudentId)
     {
-        PollInstanceEntity? results = await _context.PollInstances.FirstOrDefaultAsync(Poll => Poll.Uuid.Equals(Uuid) && Poll.StudentId.Equals(StudentId));
+        PollInstanceEntity? results = await _context.PollInstances.FirstOrDefaultAsync(Poll => Poll.Uuid.Equals(Uuid) && Poll.StudentId == StudentId);
+        return results?.ToDomain();
+    }
+
+    public async Task<PollInstance?> GetByUuidAndStudentIdAsync(string Uuid, int StudentId, int EvaluationId)
+    {
+        PollInstanceEntity? results = await _context.PollInstances.FirstOrDefaultAsync(Poll => Poll.Uuid.Equals(Uuid) && Poll.StudentId == StudentId && Poll.EvaluationId == EvaluationId);
         return results?.ToDomain();
     }
 
@@ -233,7 +239,7 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
         return Entity;
     }
 
-    public async Task<CountReportResponseVm> GetCountReportByVariablesAsync(string PollUuid, List<int> CohortIds, List<int> VariableIds, bool LastVersion, DateTime startDate, DateTime endDate)
+    public async Task<CountReportResponseVm> GetCountReportByVariablesAsync(string PollUuid, List<int> CohortIds, List<int> VariableIds, bool LastVersion, DateTime startDate, DateTime endDate, int? EvaluationId)
     {
 
         int pollVersion = _context.Polls
@@ -246,7 +252,8 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
             where A.PollUuid == PollUuid
             where CohortIds.Contains(A.CohortId)
             where VariableIds.Contains(A.PollVariableId)
-            where PI.FinishedAt >= startDate && PI.FinishedAt <= endDate 
+            where PI.FinishedAt >= startDate && PI.FinishedAt <= endDate
+            where EvaluationId == null || PI.EvaluationId == EvaluationId
             select new ErasCalculationsByPollDTO
             {
                 ComponentName = A.ComponentName,
@@ -300,5 +307,14 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
             .Where(pi => pi.FinishedAt >= DateTime.SpecifyKind(startDate, DateTimeKind.Utc)
                     && pi.FinishedAt <= DateTime.SpecifyKind(endDate, DateTimeKind.Utc))
             .CountAsync();
+    }
+
+    public async Task<bool> ExistsForStudentAndEvaluationAsync(int StudentId, string PollUuid, int EvaluationId)
+    {
+        return await _context.PollInstances
+            .AsNoTracking()
+            .AnyAsync(p => p.StudentId == StudentId
+                        && p.Uuid == PollUuid
+                        && p.EvaluationId == EvaluationId);
     }
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Views/Ups/vErasEvaluationDetails.sql
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Views/Ups/vErasEvaluationDetails.sql
@@ -25,7 +25,7 @@ SELECT DISTINCT
 FROM evaluation e
 JOIN evaluation_poll ep ON e."Id" = ep.evaluation_id
 JOIN polls p ON ep.poll_id = p."Id"
-LEFT JOIN poll_instances pi ON p.uuid = pi.uuid
+LEFT JOIN poll_instances pi ON pi."EvaluationId" = e."Id"
 LEFT JOIN students s ON pi."StudentId" = s."Id"
 LEFT JOIN student_cohort sc ON s."Id" = sc.student_id
 LEFT JOIN answers ans ON pi."Id" = ans.poll_instance_id

--- a/test/Eras.Application.Tests/Features/PollInstances/Queries/GetPollInstanceByUuidAndStudentIdQueryHandlerTest.cs
+++ b/test/Eras.Application.Tests/Features/PollInstances/Queries/GetPollInstanceByUuidAndStudentIdQueryHandlerTest.cs
@@ -29,7 +29,7 @@ public class GetPollInstanceByUuidAndStudentIdQueryHandlerTest
     public async Task Handle_Should_Return_Success_ResponseAsync()
     {
         // Arrange
-        var query = new GetPollInstanceByUuidAndStudentIdQuery() { PollUuid = "uuid1", StudentId = 1 };
+        var query = new GetPollInstanceByUuidAndStudentIdQuery() { PollUuid = "uuid1", StudentId = 1, EvaluationId = 1 };
         var pollInstance = new PollInstance { Id=1,Uuid = "uuid1", FinishedAt = DateTime.UtcNow,
             LastVersionDate = DateTime.Now, LastVersion = 1 , Answers = new List<Answer>()};
         _mockPollRepository


### PR DESCRIPTION
## Description

Previously, when a student retook the same survey on a different date, the new submission was not imported correctly. As a result, the student’s data was missing from Dynamic Charts and Summary Charts. Only surveys from new students were being imported.

To fix this, a new optional attribute called **EvaluationId** was added to `poll_instances`. This attribute allows poll instances to be associated with the correct evaluation and ensures the corresponding student data is imported and displayed properly.

- Added EvaluationId to poll_instances
- A poll instance is created when a new Evaluation is imported
- Updated import logic to support students retaking surveys
- Ensured charts display the correct data for all evaluations

A migration was added to include the new optional column. However, for charts to work correctly and avoid inconsistent results, all existing records with a NULL evaluationId must be removed before running the application. (We need all PollInstances has EvaluationId, if you create evaluation processes in this branch they will have based on number of students).
The following commands could be helpful.

``` bash
TRUNCATE TABLE poll_instances CASCADE;
TRUNCATE TABLE evaluation CASCADE;
```

The review can be performed in the Frontend by importing the same student into two different evaluation processes.

Use the poll: TestLuis. This poll contains a student named Luis Herbas, who completed the survey twice in different periods (2025 and 2026).
* Create a new evaluation using the TestLuis poll with the following date range: 01/01/2025 - 12/31/2025
* Import all students.
* Create another evaluation using the same TestLuis poll with this date range: 01/01/2026 - 03/24/2026
* Import all students again.

**Expected Result**
In Dynamic Charts, the same student (Luis Herbas) should appear in both evaluations, not only in one of them.

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues

#318 
