### PR TITLE
fix: handle poll instances based on the poll uuid and avoid duplicate  student on GetStudentsByFilters

### DIFF
--- a/src/Eras.Application/Services/PollOrchestratorService.cs
+++ b/src/Eras.Application/Services/PollOrchestratorService.cs
@@ -110,8 +110,9 @@ namespace Eras.Application.Services
                         {
                             createdPoll.studentDTOs.Add(createdStudent.Entity.ToDto());
                             // Create poll instances
+                            CreateCommandResponse<Poll> pollOfPollInstance = await CreatePollAsync(pollToCreate);
                             CreateCommandResponse<PollInstance> createdPollInstance = await CreatePollInstanceAsync(createdStudent.Entity,
-                                createdPollResponse.Entity.Uuid, pollToCreate.FinishedAt, EvaluationId);
+                                pollOfPollInstance.Entity.Uuid, pollToCreate.FinishedAt, EvaluationId);
                             // Create asnswers
                             if (createdPollInstance.Success)
                             {

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
@@ -86,7 +86,7 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
             .ToListAsync();
 
         var filtered = ApplyRiskFilter(entities, RiskLevels)
-            .GroupBy(v => new { v.StudentId, v.AnswerId })
+            .GroupBy(v => v.StudentId)
             .Select(g => g.First())
             .ToList();
 


### PR DESCRIPTION
## Description

As a side effect of the update to the StudentByFilters endpoint, duplicate students are avoided in that endpoint and a pollInstance is created with its respective UUID, not just the first UUID in the set of polls.

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


