### PR TITLE
Enhancement: answers table is reduced by sourcePollInstanceId in order to improve loading time

### DIFF
--- a/src/Eras.Application/Contracts/Persistence/IPollInstanceRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/IPollInstanceRepository.cs
@@ -1,4 +1,5 @@
-﻿using Eras.Application.Models.Consolidator;
+﻿using Eras.Application.Dtos;
+using Eras.Application.Models.Consolidator;
 using Eras.Application.Utils;
 using Eras.Domain.Entities;
 
@@ -30,4 +31,6 @@ public interface IPollInstanceRepository : IBaseRepository<PollInstance>
     Task<CountReportResponseVm> GetCountReportByVariablesAsync(string PollUuid, List<int> CohortIds, List<int> VariableIds, bool LastVersion, DateTime startDate, DateTime endDate, int? EvaluationId);
     new Task<int> CountByDateRangeAsync(DateTime startDate, DateTime endDate);
     Task<bool> ExistsForStudentAndEvaluationAsync(int StudentId, string PollUuid, int EvaluationId);
+    Task<PollInstance?> FindMatchingSourceInstanceAsync(int studentId, int currentPollInstanceId, PollDTO incomingPoll);
+    Task SetSourceInstanceAsync(int pollInstanceId, int sourceInstanceId);
 }

--- a/src/Eras.Application/DTOs/Views/ErasCalculationsByPollDTO.cs
+++ b/src/Eras.Application/DTOs/Views/ErasCalculationsByPollDTO.cs
@@ -22,4 +22,5 @@ public class ErasCalculationsByPollDTO
     public decimal AverageRiskByCohortComponent { get; set; }
     public int StudentId { get; set; }
     public int PollVersion { get; set; }
+    public int ComponentId { get; set; }
 }

--- a/src/Eras.Application/Services/PollOrchestratorService.cs
+++ b/src/Eras.Application/Services/PollOrchestratorService.cs
@@ -116,23 +116,21 @@ namespace Eras.Application.Services
                             // Create asnswers
                             if (createdPollInstance.Success)
                             {
-                                //---------- await CreateAnswersAsync(pollToCreate, createdComponents, createdPollInstance);
                                 PollInstance? sourceInstance = await _pollInstanceRepository
                                     .FindMatchingSourceInstanceAsync(
                                         studentId: createdStudent.Entity.Id,
                                         currentPollInstanceId: createdPollInstance.Entity.Id,
-                                        incomingPoll: pollToCreate); // los answers vienen del DTO
+                                        incomingPoll: pollToCreate);
 
                                 if (sourceInstance != null)
                                 {
-                                    // Solo marcar el source, no insertar answers
+                                    // Mark source instance, no new answers created
                                     await _pollInstanceRepository.SetSourceInstanceAsync(
                                         createdPollInstance.Entity.Id,
                                         sourceInstance.Id);
                                 }
                                 else
                                 {
-                                    // Flujo normal, insertar answers
                                     await CreateAnswersAsync(pollToCreate, createdComponents, createdPollInstance);
                                 }
 

--- a/src/Eras.Application/Services/PollOrchestratorService.cs
+++ b/src/Eras.Application/Services/PollOrchestratorService.cs
@@ -116,7 +116,26 @@ namespace Eras.Application.Services
                             // Create asnswers
                             if (createdPollInstance.Success)
                             {
-                                await CreateAnswersAsync(pollToCreate, createdComponents, createdPollInstance);
+                                //---------- await CreateAnswersAsync(pollToCreate, createdComponents, createdPollInstance);
+                                PollInstance? sourceInstance = await _pollInstanceRepository
+                                    .FindMatchingSourceInstanceAsync(
+                                        studentId: createdStudent.Entity.Id,
+                                        currentPollInstanceId: createdPollInstance.Entity.Id,
+                                        incomingPoll: pollToCreate); // los answers vienen del DTO
+
+                                if (sourceInstance != null)
+                                {
+                                    // Solo marcar el source, no insertar answers
+                                    await _pollInstanceRepository.SetSourceInstanceAsync(
+                                        createdPollInstance.Entity.Id,
+                                        sourceInstance.Id);
+                                }
+                                else
+                                {
+                                    // Flujo normal, insertar answers
+                                    await CreateAnswersAsync(pollToCreate, createdComponents, createdPollInstance);
+                                }
+
                                 createdPollsInstances++;
                             }
                         }
@@ -152,7 +171,7 @@ namespace Eras.Application.Services
                     Uuid = PollUuid,
                     Student = Student,
                     FinishedAt = FinishedAt,
-                    EvaluationId = EvaluationId
+                    EvaluationId = EvaluationId,
                 };
 
                 pollInstance.Audit = new AuditInfo()

--- a/src/Eras.Domain/Entities/PollInstance.cs
+++ b/src/Eras.Domain/Entities/PollInstance.cs
@@ -12,5 +12,6 @@ namespace Eras.Domain.Entities
         public DateTime LastVersionDate { get; set; }
         public DateTime FinishedAt { get; set; }
         public int? EvaluationId { get; set; }
+        public int? SourcePollInstanceId { get; set; }
     }
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Entities/PollInstanceEntity.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Entities/PollInstanceEntity.cs
@@ -13,5 +13,6 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Entities
         public AuditInfo Audit { get; set; } = default!;
         public DateTime FinishedAt { get; set; }
         public int? EvaluationId { get; set; }
+        public int? SourcePollInstanceId { get; set; }
     }
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260514142743_AddSourcePollInstanceId.Designer.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260514142743_AddSourcePollInstanceId.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Eras.Infrastructure.Persistence.PostgreSQL;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260514142743_AddSourcePollInstanceId")]
+    partial class AddSourcePollInstanceId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260514142743_AddSourcePollInstanceId.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260514142743_AddSourcePollInstanceId.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Eras.Infrastructure.Persistence.PostgreSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSourcePollInstanceId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "SourcePollInstanceId",
+                table: "poll_instances",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.Sql(@"
+                WITH ranked AS (
+                    SELECT 
+                        pi.""Id"",
+                        pi.""StudentId"",
+                        pi.""FinishedAt"",
+                        FIRST_VALUE(pi.""Id"") OVER (
+                            PARTITION BY pi.""StudentId"" 
+                            ORDER BY pi.""FinishedAt"" ASC
+                        ) AS original_id
+                    FROM poll_instances pi
+                )
+                UPDATE poll_instances
+                SET ""SourcePollInstanceId"" = ranked.original_id
+                FROM ranked
+                WHERE poll_instances.""Id"" = ranked.""Id""
+                AND ranked.""Id"" != ranked.original_id;
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SourcePollInstanceId",
+                table: "poll_instances");
+        }
+    }
+}

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
@@ -1,7 +1,11 @@
-﻿using Eras.Application.Contracts.Persistence;
+﻿using System.Security.Cryptography;
+using System.Text;
+
+using Eras.Application.Contracts.Persistence;
+using Eras.Application.Dtos;
 using Eras.Application.DTOs.Views;
-using Eras.Application.Utils;
 using Eras.Application.Models.Consolidator;
+using Eras.Application.Utils;
 using Eras.Domain.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Mappers;
@@ -246,7 +250,7 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
             .Where(A => A.Uuid == PollUuid)
             .Select(A => A.LastVersion)
             .FirstOrDefault();
-        IQueryable<ErasCalculationsByPollDTO> reportQuery=
+        IQueryable<ErasCalculationsByPollDTO> reportQuery =
             from A in _context.ErasCalculationsByPoll
             join PI in _context.PollInstances on A.PollInstanceId equals PI.Id
             where A.PollUuid == PollUuid
@@ -318,4 +322,64 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
                         && p.Uuid == PollUuid
                         && p.EvaluationId == EvaluationId);
     }
+
+    public async Task SetSourceInstanceAsync(int pollInstanceId, int sourceInstanceId)
+    {
+        var pi = await _context.PollInstances.FindAsync(pollInstanceId);
+        if (pi != null)
+        {
+            pi.SourcePollInstanceId = sourceInstanceId;
+            await _context.SaveChangesAsync();
+        }
+    }
+
+    private string ComputeAnswerHash(PollDTO pollDTO)
+    {
+        var answers = pollDTO.Components
+            .SelectMany(c => c.Variables)
+            .Select(v => $"{v.Answer.PollVariableId}:{v.Answer}:{v.Answer.Score}");
+
+        var content = string.Join("|", answers.OrderBy(x => x));
+
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(content)));
+    }
+    public async Task<PollInstance?> FindMatchingSourceInstanceAsync(int studentId, int currentPollInstanceId, PollDTO incomingPoll)
+    {
+        var incomingHash = ComputeHashFromDTO(incomingPoll);
+
+        var candidates = await _context.PollInstances
+            .Where(pi => pi.StudentId == studentId
+                      && pi.SourcePollInstanceId == null
+                      && pi.Id != currentPollInstanceId)
+            .Include(pi => pi.Answers)
+            .OrderByDescending(pi => pi.FinishedAt)
+            .ToListAsync();
+
+        return PollInstanceMapper.ToDomain(candidates.FirstOrDefault(pi =>
+            ComputeHashFromAnswers(pi.Answers) == incomingHash));
+    }
+
+    // Hash desde el DTO (entrante)
+    private string ComputeHashFromDTO(PollDTO pollDTO)
+    {
+        var entries = pollDTO.Components
+            .SelectMany(c => c.Variables)
+            .Select(v => $"{v.Answer.PollVariableId}:{v.Answer}:{v.Answer.Score}")
+            .OrderBy(x => x);
+
+        return Hash(string.Join("|", entries));
+    }
+
+    // Hash desde las answers ya guardadas en DB
+    private string ComputeHashFromAnswers(ICollection<AnswerEntity> answers)
+    {
+        var entries = answers
+            .Select(a => $"{a.PollVariableId}:{a.AnswerText}:{a.RiskLevel}")
+            .OrderBy(x => x);
+
+        return Hash(string.Join("|", entries));
+    }
+
+    private string Hash(string content) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(content)));
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
@@ -261,6 +261,7 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
             where PI.EvaluationId == EvaluationId
             select new ErasCalculationsByPollDTO
             {
+                ComponentId = A.ComponentId,
                 ComponentName = A.ComponentName,
                 ComponentAverageRisk = A.ComponentAverageRisk,
                 AnswerText = A.AnswerText,
@@ -277,6 +278,7 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
         List<ErasCalculationsByPollDTO> results = await reportQuery.ToListAsync();
 
         List<CountReportComponent> report = [.. results
+        .OrderBy(A => A.ComponentId)
         .GroupBy(A => A.ComponentName)
         .Select(AnsPerComp => new CountReportComponent {
             Description = AnsPerComp.Key.ToUpper(),
@@ -355,26 +357,25 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
             .OrderByDescending(pi => pi.FinishedAt)
             .ToListAsync();
 
-        return PollInstanceMapper.ToDomain(candidates.FirstOrDefault(pi =>
-            ComputeHashFromAnswers(pi.Answers) == incomingHash));
+        var foundHash = candidates.FirstOrDefault(pi =>
+            ComputeHashFromAnswers(pi.Answers) == incomingHash);
+        return foundHash != null ? PollInstanceMapper.ToDomain(foundHash) : null;
     }
 
-    // Hash desde el DTO (entrante)
     private string ComputeHashFromDTO(PollDTO pollDTO)
     {
         var entries = pollDTO.Components
             .SelectMany(c => c.Variables)
-            .Select(v => $"{v.Answer.PollVariableId}:{v.Answer}:{v.Answer.Score}")
+            .Select(v => $"{v.Answer.Answer}")
             .OrderBy(x => x);
 
         return Hash(string.Join("|", entries));
     }
 
-    // Hash desde las answers ya guardadas en DB
     private string ComputeHashFromAnswers(ICollection<AnswerEntity> answers)
     {
         var entries = answers
-            .Select(a => $"{a.PollVariableId}:{a.AnswerText}:{a.RiskLevel}")
+            .Select(a => $"{a.AnswerText}")
             .OrderBy(x => x);
 
         return Hash(string.Join("|", entries));

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Views/Ups/vErasCalculationByPoll.sql
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Views/Ups/vErasCalculationByPoll.sql
@@ -1,5 +1,40 @@
 CREATE VIEW vErasCalculationByPoll AS
-WITH PercentageCalc AS (
+WITH ResolvedAnswers AS (
+    SELECT 
+        a."Id",
+        a.poll_instance_id,
+        a.poll_variable_id,
+        a.answer_text,
+        a.risk_level,
+        a.version_date,
+        a.version_number,
+        a.created_at,
+        a.created_by,
+        a.modified_by,
+        a.updated_at
+    FROM answers a
+    JOIN poll_instances pi ON pi."Id" = a.poll_instance_id
+    WHERE pi."SourcePollInstanceId" IS NULL
+
+    UNION ALL
+
+    SELECT
+        a."Id",
+        pi."Id" AS poll_instance_id,
+        a.poll_variable_id,
+        a.answer_text,
+        a.risk_level,
+        a.version_date,
+        a.version_number,
+        a.created_at,
+        a.created_by,
+        a.modified_by,
+        a.updated_at
+    FROM poll_instances pi
+    JOIN answers a ON a.poll_instance_id = pi."SourcePollInstanceId"
+    WHERE pi."SourcePollInstanceId" IS NOT NULL
+),
+PercentageCalc AS (
     SELECT
         a.poll_variable_id,
         answer_text,
@@ -10,7 +45,7 @@ WITH PercentageCalc AS (
         ) AS answer_percentage,
         COUNT(answer_text) AS answer_count
     FROM
-        answers a
+        ResolvedAnswers a
     GROUP BY
         a.poll_variable_id, answer_text
 ),
@@ -20,7 +55,7 @@ RiskAverageByComponent AS (
         c."name" AS component_name,
         ROUND(AVG(a.risk_level),2) AS average_risk
     FROM
-        answers a
+        ResolvedAnswers a
     JOIN poll_variable pv ON a.poll_variable_id = pv."Id"
     JOIN variables v ON pv.variable_id = v."Id"
     JOIN components c ON v.component_id = c."Id"
@@ -33,7 +68,7 @@ RiskAverageByVariable AS (
         v."name" AS variable_name,
         ROUND(AVG(a.risk_level),2) AS average_risk
     FROM
-        answers a
+        ResolvedAnswers a
     JOIN poll_variable pv ON a.poll_variable_id = pv."Id"
     JOIN variables v ON pv.variable_id = v."Id"
     GROUP BY
@@ -47,7 +82,7 @@ RiskCountByPollInstance AS (
         SUM(a.risk_level) AS poll_instance_risk_sum,
         COUNT(a.risk_level) AS poll_instance_answers_count
     FROM
-        answers a
+        ResolvedAnswers a
     JOIN poll_instances pi2 ON pi2."Id" = a.poll_instance_id
     JOIN students s ON s."Id" = pi2."StudentId"
     GROUP BY
@@ -59,7 +94,7 @@ RiskAvgByCohortComponent AS (
         c."Id" AS component_id,
         ROUND(AVG(a.risk_level),2) AS average_risk_by_cohort_component
     FROM
-        answers a
+        ResolvedAnswers a
     JOIN poll_variable pv ON pv."Id" = a.poll_variable_id
     JOIN variables v ON v."Id" = pv.variable_id
     JOIN components c ON c."Id" = v.component_id
@@ -93,7 +128,7 @@ select
     racbc.average_risk_by_cohort_component,
     a.version_number as poll_version
 FROM
-    answers a
+    ResolvedAnswers a
 JOIN poll_variable pv ON a.poll_variable_id = pv."Id"
 JOIN variables v ON pv.variable_id = v."Id"
 JOIN components c ON v.component_id = c."Id"

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Views/Ups/vErasEvaluationDetails.sql
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Views/Ups/vErasEvaluationDetails.sql
@@ -28,7 +28,10 @@ JOIN polls p ON ep.poll_id = p."Id"
 LEFT JOIN poll_instances pi ON pi."EvaluationId" = e."Id"
 LEFT JOIN students s ON pi."StudentId" = s."Id"
 LEFT JOIN student_cohort sc ON s."Id" = sc.student_id
-LEFT JOIN answers ans ON pi."Id" = ans.poll_instance_id
+LEFT JOIN answers ans ON ans.poll_instance_id = COALESCE(
+                            pi."SourcePollInstanceId",
+                            pi."Id"
+                        )
 LEFT JOIN poll_variable pv ON ans.poll_variable_id = pv."Id"
 LEFT JOIN variables v ON pv.variable_id = v."Id"
 LEFT JOIN components comp ON v.component_id = comp."Id"


### PR DESCRIPTION
## Description

The recent alerts endpoint is closely tied to the ErasEvaluationDetails view. It contains a lot of data, similar to the answers table.

This enhancement reduces the size of the answers table by avoiding duplicated exports for students who already have the same answers within a poll instance.

A new attribute, sourcePollInstanceId, was added to identify the original poll instance where the student answer already exists. When applicable, duplicated records (student + poll instance) are no longer stored, and instead the reference to the original poll instance is persisted.

This PR also includes a migration for the new attribute.

To avoid long loading times in recent alerts and ensure the update has the expected performance impact, please truncate the following tables before running the migration
``` bash
truncate table poll_instances Cascade;
truncate table evaluation Cascade;
truncate table variables Cascade;
truncate table polls cascade;
```
**Performance impact:**

In the affected scenario, the endpoint response time decreased from approximately 9 seconds to 0.935 seconds (measured from the browser network inspector), representing an improvement of nearly 89%.

The benchmark was executed using a dataset with a similar volume of Recent Alerts data seen in the ticket #403.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [X] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues

#403 

