### PR TITLE
feat: add endpoint to remove assessment by id

### DIFF
--- a/src/Eras.Api/Controllers/AssessmentManagement/AssessmentsController.cs
+++ b/src/Eras.Api/Controllers/AssessmentManagement/AssessmentsController.cs
@@ -102,6 +102,23 @@ public class AssessmentsController(IMediator Mediator, ILogger<AssessmentsContro
         return Ok(response);
     }
 
+    [HttpDelete("{id:int}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Delete(
+        int id,
+        CancellationToken cancellationToken)
+    {
+        try {
+            await Mediator.Send(new DeleteAssessmentCommand(id), cancellationToken);
+            return NoContent();
+        } catch(KeyNotFoundException)
+        {
+            return NotFound();
+        }
+    }
+
+
     [HttpGet("{id:int}/interventions")]
     [ProducesResponseType(typeof(IReadOnlyCollection<InterventionDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/src/Eras.Application/Contracts/Persistence/AssessmentManagement/IAssessmentRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/AssessmentManagement/IAssessmentRepository.cs
@@ -10,6 +10,8 @@ public interface IAssessmentRepository : IBaseRepository<Assessment>
     Task<IEnumerable<Assessment>> GetByStatusAsync(AssessmentStatus status);
 
     Task<Assessment?> GetByIdWithInterventionsAsync(int id);
+    Task DeleteAssessmentAsync(int assessmentId);
+
 
     Task<Intervention> AddInterventionAsync(int assessmentId, Intervention intervention); 
 

--- a/src/Eras.Application/Features/RemissionManagement/Commands.cs
+++ b/src/Eras.Application/Features/RemissionManagement/Commands.cs
@@ -28,6 +28,8 @@ public sealed record GetRemissionsByStatusQuery(AssessmentStatus Status)
 
 public sealed record GetAllRemissionsQuery() : IRequest<IReadOnlyCollection<AssessmentDto>>;
 
+public sealed record DeleteAssessmentCommand(int AssessmentId) : IRequest;
+
 public sealed record UpsertInterventionsCommand(int AssessmentId, IReadOnlyCollection<InterventionDto> Interventions)
     : IRequest<IReadOnlyCollection<InterventionDto>>;
 

--- a/src/Eras.Application/Features/RemissionManagement/Handlers/DeleteAssessmentCommandHandler.cs
+++ b/src/Eras.Application/Features/RemissionManagement/Handlers/DeleteAssessmentCommandHandler.cs
@@ -1,0 +1,22 @@
+using Eras.Application.Contracts.Persistence.AssessmentManagement;
+using MediatR;
+
+namespace Eras.Application.Features.RemissionManagement.Handlers;
+
+public sealed class DeleteAssessmentCommandHandler
+    : IRequestHandler<DeleteAssessmentCommand>
+{
+    private readonly IAssessmentRepository _repository;
+
+    public DeleteAssessmentCommandHandler(IAssessmentRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task Handle(
+        DeleteAssessmentCommand request,
+        CancellationToken cancellationToken)
+    {
+        await _repository.DeleteAssessmentAsync(request.AssessmentId);
+    }
+}

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/AssessmentRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/AssessmentRepository.cs
@@ -41,11 +41,11 @@ public sealed class AssessmentRepository(AppDbContext context, ILogger<Assessmen
         _context.Interventions.RemoveRange(interventions);
 
         Assessment? assessment = await _context.Set<Assessment>()
-            .FirstOrDefaultAsync(i => i.Id == assessmentId);
+            .FirstOrDefaultAsync(i => i.Id == assessmentId && i.Status != AssessmentStatus.Referred);
 
         if (assessment is null)
             throw new KeyNotFoundException(
-                $"Assessment '{assessmentId}' not found.");
+                $"Assessment '{assessmentId}' not found or not permitted.");
 
         _context.Set<Assessment>().Remove(assessment);
         await _context.SaveChangesAsync();

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/AssessmentRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/AssessmentRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Eras.Application.Contracts.Persistence.AssessmentManagement;
+using Eras.Domain.Entities;
 using Eras.Domain.Entities.AssessmentManagement;
 
 using Microsoft.EntityFrameworkCore;
@@ -29,6 +30,25 @@ public sealed class AssessmentRepository(AppDbContext context, ILogger<Assessmen
             .AsNoTracking()
             .Include(a => a.Interventions)
             .FirstOrDefaultAsync(a => a.Id == id);
+    }
+
+    public async Task DeleteAssessmentAsync(int assessmentId)
+    {
+        var interventions = await _context.Interventions
+            .Where(i => EF.Property<int?>(i, "remission_id") == assessmentId)
+            .ToListAsync();
+
+        _context.Interventions.RemoveRange(interventions);
+
+        Assessment? assessment = await _context.Set<Assessment>()
+            .FirstOrDefaultAsync(i => i.Id == assessmentId);
+
+        if (assessment is null)
+            throw new KeyNotFoundException(
+                $"Assessment '{assessmentId}' not found.");
+
+        _context.Set<Assessment>().Remove(assessment);
+        await _context.SaveChangesAsync();
     }
 
     public async Task<Intervention> AddInterventionAsync(int assessmentId, Intervention intervention)

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/AssessmentRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/AssessmentRepository.cs
@@ -41,7 +41,7 @@ public sealed class AssessmentRepository(AppDbContext context, ILogger<Assessmen
         _context.Interventions.RemoveRange(interventions);
 
         Assessment? assessment = await _context.Set<Assessment>()
-            .FirstOrDefaultAsync(i => i.Id == assessmentId && i.Status != AssessmentStatus.Referred);
+            .FirstOrDefaultAsync(i => i.Id == assessmentId && i.Status != AssessmentStatus.Remitted);
 
         if (assessment is null)
             throw new KeyNotFoundException(

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/AssessmentRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/AssessmentRepository.cs
@@ -34,18 +34,18 @@ public sealed class AssessmentRepository(AppDbContext context, ILogger<Assessmen
 
     public async Task DeleteAssessmentAsync(int assessmentId)
     {
-        var interventions = await _context.Interventions
-            .Where(i => EF.Property<int?>(i, "remission_id") == assessmentId)
-            .ToListAsync();
-
-        _context.Interventions.RemoveRange(interventions);
-
         Assessment? assessment = await _context.Set<Assessment>()
             .FirstOrDefaultAsync(i => i.Id == assessmentId && i.Status != AssessmentStatus.Remitted);
 
         if (assessment is null)
             throw new KeyNotFoundException(
                 $"Assessment '{assessmentId}' not found or not permitted.");
+
+        var interventions = await _context.Interventions
+            .Where(i => EF.Property<int?>(i, "remission_id") == assessmentId)
+            .ToListAsync();
+
+        _context.Interventions.RemoveRange(interventions);
 
         _context.Set<Assessment>().Remove(assessment);
         await _context.SaveChangesAsync();


### PR DESCRIPTION
## Description

Added `api/v1/assessments/{assessmentId}` with remove an assessment with interventions included.

## Type of change

- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues

#255 
