### PR TITLE
fix: increase PollName max length to 100 in EvaluationDTO and DB

### DIFF
--- a/src/Eras.Application/DTOs/EvaluationDTO.cs
+++ b/src/Eras.Application/DTOs/EvaluationDTO.cs
@@ -19,7 +19,7 @@ public class EvaluationDTO
     [DataType(DataType.DateTime)]
     public required DateTime EndDate { get; set; }
 
-    [MaxLength(50)]
+    [MaxLength(100)]
     public string PollName { get; set; } = string.Empty;
 
     [MaxLength(50)]


### PR DESCRIPTION
## Description



## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


