### PR TITLE
fix: use UTC for date range filtering

### DIFF
--- a/src/Eras.Infrastructure/External/CosmicLatteClient/CosmicLatteAPIService.cs
+++ b/src/Eras.Infrastructure/External/CosmicLatteClient/CosmicLatteAPIService.cs
@@ -631,15 +631,15 @@ namespace Eras.Infrastructure.External.CosmicLatteClient
             // Add 1 day to EndDate to account for evaluations finished
             // on the EndDate.
             if(wasStartDateProvided && wasEndDateProvided && 
-               EvaluationFinishedAtDate >= DateTime.Parse(StartDate) &&
-               EvaluationFinishedAtDate <= DateTime.Parse(EndDate).AddDays(1)
+               EvaluationFinishedAtDate >= DateTime.Parse(StartDate).ToUniversalTime() &&
+               EvaluationFinishedAtDate <= DateTime.Parse(EndDate).ToUniversalTime().AddDays(1)
               )
             {
                 return true;
             }
 
             if(wasStartDateProvided && !wasEndDateProvided &&
-               EvaluationFinishedAtDate >= DateTime.Parse(StartDate)
+               EvaluationFinishedAtDate >= DateTime.Parse(StartDate).ToUniversalTime()
               )
             {
                 return true;


### PR DESCRIPTION
## Description

Added `ToUniversalTime()` method call for start and end date filters for importing polls

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


