### PR TITLE
fix: gracefully handle poll names exceeding 100 characters during import

### DIFF
--- a/src/Eras.Api/Controllers/CosmicLatteController.cs
+++ b/src/Eras.Api/Controllers/CosmicLatteController.cs
@@ -24,29 +24,82 @@ public class CosmicLatteController(IMediator Mediator, ICosmicLatteAPIService Co
         [FromQuery] int ConfigurationId = 0
     )
     {
-        GetConfigurationQuery getConfigurationQuery = new GetConfigurationQuery { ConfigurationId = ConfigurationId };
-        var configuration = await _mediator.Send(getConfigurationQuery);
-        return Ok(await _cosmicLatteService.GetAllPollsPreview(EvaluationSetName, StartDate, EndDate, configuration.EncryptedKey, configuration.BaseURL));
+        if (EvaluationSetName.Length > 100)
+            return BadRequest(new { message = "There was an error during the import: Poll Name exceeds the maximum length of 100 characters." });
+
+        try
+        {
+            GetConfigurationQuery getConfigurationQuery = new GetConfigurationQuery { ConfigurationId = ConfigurationId };
+            var configuration = await _mediator.Send(getConfigurationQuery);
+            return Ok(await _cosmicLatteService.GetAllPollsPreview(EvaluationSetName, StartDate, EndDate, configuration.EncryptedKey, configuration.BaseURL));
+        }
+        catch (ArgumentException ex)
+        {
+            if (EvaluationSetName.Length == 100 && ex.Message.Contains("Evaluation not found"))
+            {
+                return BadRequest(new { message = "There was an error during the import: Poll Name exceeds the maximum length of 100 characters." });
+            }
+            return BadRequest(new { message = ex.Message });
+        }
+        catch (InvalidCastException ex)
+        {
+            return BadRequest(new { message = "Error deserializing response from Cosmic Latte API", detailed = ex.StackTrace });
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, new { message = ex.Message });
+        }
     }
 
     [HttpGet("health")]
     public async Task<IActionResult> IsCosmicLatteApiHealthyAsync([FromQuery] int ConfigurationId)
     {
-        GetConfigurationQuery getConfigurationQuery = new GetConfigurationQuery { ConfigurationId = ConfigurationId };
-        var configuration = await _mediator.Send(getConfigurationQuery);
-        return Ok(await _cosmicLatteService.CosmicApiIsHealthy(configuration.EncryptedKey, configuration.BaseURL));
+        try
+        {
+            GetConfigurationQuery getConfigurationQuery = new GetConfigurationQuery { ConfigurationId = ConfigurationId };
+            var configuration = await _mediator.Send(getConfigurationQuery);
+            return Ok(await _cosmicLatteService.CosmicApiIsHealthy(configuration.EncryptedKey, configuration.BaseURL));
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, new { message = ex.Message });
+        }
     }
 
     [Authorize]
     [HttpPost("polls/{EvaluationId}")]
-    public async Task<IActionResult> SavePreviewPollsAsync([FromBody] List<PollDTO> PollsInstances, int EvaluationId) => Ok(await _cosmicLatteService.SavePreviewPolls(PollsInstances, EvaluationId));
+    public async Task<IActionResult> SavePreviewPollsAsync([FromBody] List<PollDTO> PollsInstances, int EvaluationId)
+    {
+        try
+        {
+            return Ok(await _cosmicLatteService.SavePreviewPolls(PollsInstances, EvaluationId));
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, new { message = ex.Message });
+        }
+    }
 
     [HttpGet("polls/names")]
     public async Task<IActionResult> GetPollsNameListAsync([FromQuery] int ConfigurationId)
     {
-        GetConfigurationQuery getConfigurationQuery = new GetConfigurationQuery { ConfigurationId = ConfigurationId };
-        var configuration = await _mediator.Send(getConfigurationQuery);
-        return Ok(await _cosmicLatteService.GetPollsNameList(configuration.BaseURL, configuration.EncryptedKey));
+        try
+        {
+            GetConfigurationQuery getConfigurationQuery = new GetConfigurationQuery { ConfigurationId = ConfigurationId };
+            var configuration = await _mediator.Send(getConfigurationQuery);
+            return Ok(await _cosmicLatteService.GetPollsNameList(configuration.BaseURL, configuration.EncryptedKey));
+        }
+        catch (InvalidCastException ex)
+        {
+            return BadRequest(new { message = "Error deserializing response from Cosmic Latte API", detailed = ex.StackTrace });
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, new { message = ex.Message });
+        }
     }
-
 }

--- a/src/Eras.Api/Middleware/ExceptionHandlingMiddleware.cs
+++ b/src/Eras.Api/Middleware/ExceptionHandlingMiddleware.cs
@@ -54,6 +54,7 @@ namespace Eras.Api.Middleware
             {
                 KeyNotFoundException => (int)HttpStatusCode.NotFound,
                 UnauthorizedAccessException => (int)HttpStatusCode.Unauthorized,
+                ArgumentException => (int)HttpStatusCode.BadRequest,
                 _ => (int)HttpStatusCode.InternalServerError
             };
 

--- a/src/Eras.Infrastructure/External/CosmicLatteClient/CosmicLatteAPIService.cs
+++ b/src/Eras.Infrastructure/External/CosmicLatteClient/CosmicLatteAPIService.cs
@@ -67,15 +67,22 @@ namespace Eras.Infrastructure.External.CosmicLatteClient
         {
             try
             {
-                CreateCommandResponse<CreatedPollDTO> createdPoll = await _pollOrchestratorService.ImportPollInstancesAsync(PollsDtos, EvaluationId);
+                var invalidPoll = PollsDtos.FirstOrDefault(p => p.Name?.Length > 100);
+                if (invalidPoll != null)
+                    throw new ArgumentException($"There was an error during the import: Poll Name exceeds the maximum length of 100 characters.");
 
+                CreateCommandResponse<CreatedPollDTO> createdPoll = await _pollOrchestratorService.ImportPollInstancesAsync(PollsDtos, EvaluationId);
+                
                 if (createdPoll.Entity == null)
                 {
                     _logger.LogError("Error saving data: createdPoll is null");
                     throw new Exception($"Error saving data: createdPoll is null");
-
                 }
                 return createdPoll.Entity;
+            }
+            catch (ArgumentException)
+            {
+                throw;
             }
             catch (Exception e)
             {
@@ -474,15 +481,20 @@ namespace Eras.Infrastructure.External.CosmicLatteClient
 
                 var evaluationSet = evaluationSets.data.Find(e => e.name == EvaluationName);
                 if (evaluationSet == null)
-                    throw new Exception($"Evaluation not found: {EvaluationName}");
+                    throw new ArgumentException($"Evaluation not found: {EvaluationName}");
 
                 return evaluationSet._id;
+            }
+            catch (ArgumentException)
+            {
+                throw; 
             }
             catch (Exception e)
             {
                 throw new Exception($"There was an error with the request: {e.Message}");
             }
         }
+
 
         private static List<ComponentDTO> SanitizeComponents(List<ComponentDTO> components)
         {


### PR DESCRIPTION
## Description



## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


