### PR TITLE
feat: add riskLevel in method GetReportByPollCohortAsync to add risklevel for every percentage in summary

### DIFF
--- a/src/Eras.Application/Models/Consolidator/AvgConsolidatorResponseVm.cs
+++ b/src/Eras.Application/Models/Consolidator/AvgConsolidatorResponseVm.cs
@@ -29,4 +29,5 @@ public class AnswerDetails
     public required string AnswerText { get; set; }
     public decimal AnswerPercentage { get; set; }
     public IEnumerable<string> StudentsEmails { get; set; } = [];
+    public int? RiskLevel { get; set; } 
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
@@ -221,7 +221,8 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
                         {
                             AnswerText = AnsPerVar.Key,
                             AnswerPercentage = AnsPerVar.First().AnswerPercentage,
-                            StudentsEmails = [.. AnsPerVar.Select(A => A.StudentEmail)]
+                            StudentsEmails = [.. AnsPerVar.Select(A => A.StudentEmail)],
+                            RiskLevel = (int)AnsPerVar.First().AnswerRisk
                         })]
                 })]
         })];


### PR DESCRIPTION
## Description

In order to add a riskLevel for every percentage or AnswerDetails, the GetReportByPollCohortAsync was updated. This helps in tooltips regarding the riskLevel to generate colors in summary-charts

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [X] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues

