### PR TITLE
fix/BE-361_Use evaluation finishedAt date as the filter for surveys t…

### DIFF
--- a/src/Eras.Infrastructure/External/CosmicLatteClient/CosmicLatteAPIService.cs
+++ b/src/Eras.Infrastructure/External/CosmicLatteClient/CosmicLatteAPIService.cs
@@ -195,24 +195,12 @@ namespace Eras.Infrastructure.External.CosmicLatteClient
                 string studentName = apiResponse.Data.Answers.ElementAt(0).Value.AnswersList[0];
                 string studentEmail = apiResponse.Data.Answers.ElementAt(1).Value.AnswersList[0];
                 string studentCohort = apiResponse.Data.Answers.ElementAt(2).Value.AnswersList[0];
+                DateTime evaluationFinishedAtDate = apiResponse.Data.Evaluation.FinishedAt;
                 StudentDTO studentDto = CreateStudent(studentName, studentEmail, studentCohort);
                 List<ComponentDTO> clonedListComponents = new List<ComponentDTO>();
+                bool isEvaluationWithinRange = ValidateEvaluationWithinDateRange(StartDate, EndDate, evaluationFinishedAtDate);
 
-                if(string.IsNullOrEmpty(StartDate) &&
-                    string.IsNullOrEmpty(EndDate))
-                {
-                    clonedListComponents = CloneComponentsList(Components);
-                }else if (!string.IsNullOrEmpty(StartDate) && 
-                    !string.IsNullOrEmpty(EndDate) && 
-                    CohortsHelper.CohortInDateRange(studentCohort ,DateTime.Parse(StartDate), DateTime.Parse(EndDate))
-                    )
-                {
-                    clonedListComponents = CloneComponentsList(Components);
-                }
-                else if(!string.IsNullOrEmpty(StartDate) &&
-                    string.IsNullOrEmpty(EndDate) &&
-                    CohortsHelper.GetCohort(DateTime.Parse(StartDate)) == studentCohort
-                    )
+                if (isEvaluationWithinRange)
                 {
                     clonedListComponents = CloneComponentsList(Components);
                 }
@@ -613,6 +601,36 @@ namespace Eras.Infrastructure.External.CosmicLatteClient
             {
                 component.Variables = component.Variables.OrderBy(v => v.Position).ToList();
             }
+        }
+
+        private bool ValidateEvaluationWithinDateRange(string StartDate, string EndDate, DateTime EvaluationFinishedAtDate)
+        {
+            bool wasStartDateProvided = !string.IsNullOrEmpty(StartDate);
+            bool wasEndDateProvided = !string.IsNullOrEmpty(EndDate);
+
+            if(!wasStartDateProvided && !wasEndDateProvided)
+            {
+                return true;
+            }
+            
+            // Add 1 day to EndDate to account for evaluations finished
+            // on the EndDate.
+            if(wasStartDateProvided && wasEndDateProvided && 
+               EvaluationFinishedAtDate >= DateTime.Parse(StartDate) &&
+               EvaluationFinishedAtDate <= DateTime.Parse(EndDate).AddDays(1)
+              )
+            {
+                return true;
+            }
+
+            if(wasStartDateProvided && !wasEndDateProvided &&
+               EvaluationFinishedAtDate >= DateTime.Parse(StartDate)
+              )
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION

* fix/BE-361 Use evaluation finishedAt date as the filter for surveys to import

* fix/BE-361 Adjust EndDate to account for finished evaluations on the same endDate

(cherry picked from commit 8efff8736e3e0e7ca951607196e307ac3b980e35)

## Description



## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


