### PR TITLE
399 bug be student details   open ended questions are included in the average calculated of risk components

### DIFF
--- a/src/Eras.Api/Controllers/AssessmentManagement/AssessmentsController.cs
+++ b/src/Eras.Api/Controllers/AssessmentManagement/AssessmentsController.cs
@@ -218,4 +218,26 @@ public class AssessmentsController(IMediator Mediator, ILogger<AssessmentsContro
             ".txt" => "text/plain",
             _ => "application/octet-stream"
         };
+
+
+    [HttpDelete("interventions/{interventionId:int}/attachments/{fileName}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteAttachment(
+        int interventionId,
+        string fileName,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Mediator.Send(
+                new DeleteInterventionAttachmentCommand(interventionId, fileName),
+                cancellationToken);
+            return NoContent();
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound();
+        }
+    }
 }

--- a/src/Eras.Api/Controllers/AssessmentManagement/AssessmentsController.cs
+++ b/src/Eras.Api/Controllers/AssessmentManagement/AssessmentsController.cs
@@ -166,6 +166,7 @@ public class AssessmentsController(IMediator Mediator, ILogger<AssessmentsContro
     [ProducesResponseType(typeof(IReadOnlyCollection<string>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<ActionResult<IReadOnlyCollection<string>>> UploadAttachments(
         int interventionId,
         [FromForm] IFormFileCollection files,
@@ -178,11 +179,18 @@ public class AssessmentsController(IMediator Mediator, ILogger<AssessmentsContro
             .Select(f => (f.OpenReadStream(), f.FileName))
             .ToList();
 
-        var result = await Mediator.Send(
-            new UploadInterventionAttachmentsCommand(interventionId, fileStreams),
-            cancellationToken);
+        try
+        {
+            var result = await Mediator.Send(
+                new UploadInterventionAttachmentsCommand(interventionId, fileStreams),
+                cancellationToken);
 
-        return Ok(result);
+            return Ok(result);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Conflict(new { title = ex.Message });
+        }
     }
 
     [HttpGet("interventions/{interventionId}/attachments/{fileName}")]

--- a/src/Eras.Application/Contracts/Persistence/AssessmentManagement/IAssessmentRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/AssessmentManagement/IAssessmentRepository.cs
@@ -23,4 +23,7 @@ public interface IAssessmentRepository : IBaseRepository<Assessment>
 
     Task AddAttachmentsAsync(int interventionId, IReadOnlyCollection<string> paths, IReadOnlyCollection<string> hashes);
     Task<IReadOnlyCollection<string>> GetAttachmentHashesAsync(int interventionId, CancellationToken cancellationToken);
+
+    Task<Intervention?> GetInterventionByIdAsync(int interventionId);
+    Task RemoveAttachmentAsync(int interventionId, string relativePath);
 }

--- a/src/Eras.Application/Features/RemissionManagement/Commands.cs
+++ b/src/Eras.Application/Features/RemissionManagement/Commands.cs
@@ -46,3 +46,8 @@ public sealed record UploadInterventionAttachmentsCommand(
     int InterventionId,
     IReadOnlyCollection<(Stream Stream, string FileName)> Files
 ) : IRequest<IReadOnlyCollection<string>>;
+
+public sealed record DeleteInterventionAttachmentCommand(
+    int InterventionId,
+    string FileName
+) : IRequest;

--- a/src/Eras.Application/Features/RemissionManagement/Handlers/DeleteInterventionAttachmentCommandHandler.cs
+++ b/src/Eras.Application/Features/RemissionManagement/Handlers/DeleteInterventionAttachmentCommandHandler.cs
@@ -1,0 +1,40 @@
+using Eras.Application.Contracts.Infrastructure;
+using Eras.Application.Contracts.Persistence.AssessmentManagement;
+
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Eras.Application.Features.RemissionManagement.Handlers;
+
+public sealed class DeleteInterventionAttachmentCommandHandler : IRequestHandler<DeleteInterventionAttachmentCommand>
+{
+    private readonly IAssessmentRepository _repository;
+    private readonly IFileStorageService _fileStorage;
+    private readonly ILogger<DeleteInterventionAttachmentCommandHandler> _logger;
+
+    public DeleteInterventionAttachmentCommandHandler(
+        IAssessmentRepository repository,
+        IFileStorageService fileStorage,
+        ILogger<DeleteInterventionAttachmentCommandHandler> logger)
+    {
+        _repository = repository;
+        _fileStorage = fileStorage;
+        _logger = logger;
+    }
+
+    public async Task Handle(DeleteInterventionAttachmentCommand request, CancellationToken cancellationToken)
+    {
+        string relativePath = Path.Combine(
+            "interventions",
+            request.InterventionId.ToString(),
+            request.FileName);
+
+        await _fileStorage.DeleteAsync(relativePath);
+
+        await _repository.RemoveAttachmentAsync(request.InterventionId, relativePath);
+
+        _logger.LogInformation(
+            "Attachment '{FileName}' deleted from intervention '{Id}'.",
+            request.FileName, request.InterventionId);
+    }
+}

--- a/src/Eras.Application/Features/RemissionManagement/Handlers/UploadInterventionAttachmentsCommandHandler.cs
+++ b/src/Eras.Application/Features/RemissionManagement/Handlers/UploadInterventionAttachmentsCommandHandler.cs
@@ -30,8 +30,8 @@ public sealed class UploadInterventionAttachmentsCommandHandler
     }
 
     public async Task<IReadOnlyCollection<string>> Handle(
-    UploadInterventionAttachmentsCommand request,
-    CancellationToken cancellationToken)
+        UploadInterventionAttachmentsCommand request,
+        CancellationToken cancellationToken)
     {
         foreach ((_, string fileName) in request.Files)
         {
@@ -63,6 +63,9 @@ public sealed class UploadInterventionAttachmentsCommandHandler
             savedPaths.Add(path);
             savedHashes.Add(hash);
         }
+
+        if (savedPaths.Count == 0 && request.Files.Count > 0)
+            throw new InvalidOperationException("All files have already been uploaded to this intervention.");
 
         if (savedPaths.Count > 0)
             await _repository.AddAttachmentsAsync(request.InterventionId, savedPaths, savedHashes);

--- a/src/Eras.Application/Mappers/VariableMapper.cs
+++ b/src/Eras.Application/Mappers/VariableMapper.cs
@@ -15,6 +15,7 @@ namespace Eras.Application.Mappers
                 Position = Dto.Position,
                 Audit = Dto.Audit?? new AuditInfo(),
                 Version = Dto.Version,
+                Type = Dto.Type,
             };
         }
         public static VariableDTO ToDto(this Variable Domain)
@@ -26,6 +27,7 @@ namespace Eras.Application.Mappers
                 Position = Domain.Position,
                 Audit = Domain.Audit,
                 Version = Domain.Version,
+                Type = Domain.Type,
             };
         }
     }

--- a/src/Eras.Domain/Entities/Variable.cs
+++ b/src/Eras.Domain/Entities/Variable.cs
@@ -12,5 +12,6 @@ namespace Eras.Domain.Entities
         public int IdComponent { get; set; }
         public int PollVariableId { get; set; }
         public int IdPoll { get; set; }
+        public string Type { get; set; } = string.Empty;
     }
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Configurations/VariableConfiguration.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Configurations/VariableConfiguration.cs
@@ -30,6 +30,11 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Configurations
                 .HasColumnName("position")
                 .HasDefaultValue(0)
                 .IsRequired();
+            Builder.Property(Variable => Variable.QuestionType)
+                .HasColumnName("question_type")
+                .HasMaxLength(50)
+                .IsRequired(false)
+                .HasDefaultValue(string.Empty);
         }
 
         private void ConfigureRelationShips(EntityTypeBuilder<VariableEntity> Builder)

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Entities/Variable.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Entities/Variable.cs
@@ -11,5 +11,6 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Entities
         public ComponentEntity Component { get; set; } = default!;
         public ICollection<PollVariableJoin> PollVariables { get; set; } = [];
         public AuditInfo Audit { get; set; } = default!;
+        public string QuestionType { get; set; } = string.Empty;
     }
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Mappers/VariableMapper.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Mappers/VariableMapper.cs
@@ -11,6 +11,7 @@ public static class VariableMapper
         Name = Entity.Name,
         Position = Entity.Position,
         Audit = Entity.Audit,
+        Type = Entity.QuestionType,
     };
     public static VariableEntity ToPersistence(this Variable Model) => new()
     {
@@ -18,6 +19,7 @@ public static class VariableMapper
         Name = Model.Name,
         Position = Model.Position,
         Audit = Model.Audit,
-        ComponentId = Model.IdComponent
+        ComponentId = Model.IdComponent,
+        QuestionType = Model.Type,
     };
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260608183644_add-question-type-to-variables.Designer.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260608183644_add-question-type-to-variables.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Eras.Infrastructure.Persistence.PostgreSQL;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260608183644_add-question-type-to-variables")]
+    partial class addquestiontypetovariables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260608183644_add-question-type-to-variables.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260608183644_add-question-type-to-variables.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Eras.Infrastructure.Persistence.PostgreSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class addquestiontypetovariables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "question_type",
+                table: "variables",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "question_type",
+                table: "variables");
+        }
+    }
+}

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/AssessmentRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/AssessmentRepository.cs
@@ -101,7 +101,13 @@ public sealed class AssessmentRepository(AppDbContext context, ILogger<Assessmen
         await _context.SaveChangesAsync();
     }
 
-    public async Task AddAttachmentsAsync( int interventionId, IReadOnlyCollection<string> paths, IReadOnlyCollection<string> hashes)
+    public async Task<Intervention?> GetInterventionByIdAsync(int interventionId)
+    {
+        return await _context.Set<Intervention>()
+            .FirstOrDefaultAsync(i => i.Id == interventionId);
+    }
+
+    public async Task AddAttachmentsAsync(int interventionId, IReadOnlyCollection<string> paths, IReadOnlyCollection<string> hashes)
     {
         Intervention? intervention = await _context.Set<Intervention>()
             .FirstOrDefaultAsync(i => i.Id == interventionId);
@@ -123,13 +129,31 @@ public sealed class AssessmentRepository(AppDbContext context, ILogger<Assessmen
         await _context.SaveChangesAsync();
     }
 
-    public async Task<IReadOnlyCollection<string>> GetAttachmentHashesAsync(
-        int interventionId,
-        CancellationToken cancellationToken)
+    public async Task<IReadOnlyCollection<string>> GetAttachmentHashesAsync(int interventionId, CancellationToken cancellationToken)
     {
         Intervention? intervention = await _context.Set<Intervention>()
             .FirstOrDefaultAsync(i => i.Id == interventionId, cancellationToken);
 
         return intervention?.AttachmentHashes ?? Array.Empty<string>();
+    }
+
+
+    public async Task RemoveAttachmentAsync(int interventionId, string relativePath)
+    {
+        Intervention? intervention = await _context.Set<Intervention>()
+            .FirstOrDefaultAsync(i => i.Id == interventionId);
+
+        if (intervention is null)
+            throw new KeyNotFoundException($"Intervention '{interventionId}' not found.");
+
+        List<string> updated = intervention.Attachments
+            .Where(a => !a.EndsWith(relativePath, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        _context.Entry(intervention)
+            .Property(i => i.Attachments)
+            .CurrentValue = updated.AsReadOnly();
+
+        await _context.SaveChangesAsync();
     }
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/AssessmentRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/AssessmentRepository.cs
@@ -146,8 +146,10 @@ public sealed class AssessmentRepository(AppDbContext context, ILogger<Assessmen
         if (intervention is null)
             throw new KeyNotFoundException($"Intervention '{interventionId}' not found.");
 
+        string fileNameToRemove = Path.GetFileName(relativePath);
+
         List<string> updated = intervention.Attachments
-            .Where(a => !a.EndsWith(relativePath, StringComparison.OrdinalIgnoreCase))
+            .Where(a => !Path.GetFileName(a).Equals(fileNameToRemove, StringComparison.OrdinalIgnoreCase))
             .ToList();
 
         _context.Entry(intervention)

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ComponentsAvgRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ComponentsAvgRepository.cs
@@ -16,17 +16,37 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
 
         public async Task<List<ComponentsAvg>> ComponentsAvgByStudent(int StudentId, int PollId)
         {
-            List<ComponentsAvg> result = await _context.ErasCalculationsByPoll
-                                .Where(V => V.StudentId == StudentId && V.PollId == PollId)
-                                .GroupBy(V => new { V.PollId, V.ComponentId, V.ComponentName })
-                                .Select(G => new ComponentsAvg
-                                {
-                                    PollId = G.Key.PollId,
-                                    ComponentId = G.Key.ComponentId,
-                                    Name = G.Key.ComponentName,
-                                    ComponentAvg = (float) G.Average(V => V.AnswerRisk)
-                                })
-                                .ToListAsync();
+            var rows = await _context.ErasCalculationsByPoll
+                .Where(V => V.StudentId == StudentId && V.PollId == PollId)
+                .Select(V => new 
+                {
+                    V.PollId,
+                    V.ComponentId,
+                    V.ComponentName,
+                    V.AnswerRisk,
+                    V.AnswerText
+                })
+                .ToListAsync();
+
+            List<ComponentsAvg> result = rows
+                .GroupBy(V => new { V.PollId, V.ComponentId, V.ComponentName })
+                .Select(G => new ComponentsAvg
+                {
+                    PollId = G.Key.PollId,
+                    ComponentId = G.Key.ComponentId,
+                    Name = G.Key.ComponentName,
+                    ComponentAvg = (float) Math.Round(
+                        G.Where(V => 
+                            V.AnswerText != "-" &&
+                            V.AnswerText != "" &&
+                            !string.IsNullOrEmpty(V.AnswerText) &&
+                            V.AnswerText != "None" && V.AnswerText != "none" &&
+                            V.AnswerText != "Ninguno" && V.AnswerText != "ninguno" &&
+                            V.AnswerText != "Ninguna" && V.AnswerText != "ninguna")
+                        .Average(V => (double)V.AnswerRisk), 2)
+                })
+                .ToList();
+
             return result;
         }
     }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ComponentsAvgRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ComponentsAvgRepository.cs
@@ -7,6 +7,14 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
 {
     public class ComponentsAvgRepository : IComponentsAvgRepository
     {
+        private static readonly HashSet<string> _excludedAnswers = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "-",
+            "None",
+            "Ninguno",
+            "Ninguna"
+        };
+
         private readonly AppDbContext _context;
 
         public ComponentsAvgRepository(AppDbContext Context)
@@ -37,12 +45,8 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
                     Name = G.Key.ComponentName,
                     ComponentAvg = (float) Math.Round(
                         G.Where(V => 
-                            V.AnswerText != "-" &&
-                            V.AnswerText != "" &&
                             !string.IsNullOrEmpty(V.AnswerText) &&
-                            V.AnswerText != "None" && V.AnswerText != "none" &&
-                            V.AnswerText != "Ninguno" && V.AnswerText != "ninguno" &&
-                            V.AnswerText != "Ninguna" && V.AnswerText != "ninguna")
+                            !_excludedAnswers.Contains(V.AnswerText))
                         .Average(V => (double)V.AnswerRisk), 2)
                 })
                 .ToList();

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
@@ -201,11 +201,17 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
         List<ErasCalculationsByPollDTO> results = await reportQuery.ToListAsync();
 
         List<AvgReportComponent> report = [.. results
+        .Where(A => A.AnswerText != "-" && 
+            A.AnswerText != "" && 
+            !string.IsNullOrEmpty(A.AnswerText) &&
+            A.AnswerText != "None" && A.AnswerText != "none" &&
+            A.AnswerText != "Ninguno" && A.AnswerText != "ninguno" &&
+            A.AnswerText != "Ninguna" && A.AnswerText != "ninguna")
         .GroupBy(A => A.ComponentName)
         .Select(AnsPerComp => new AvgReportComponent
         {
             Description = AnsPerComp.Key.ToUpper(),
-            AverageRisk = Math.Round(AnsPerComp.Average(X => X.AnswerRisk), 2),
+            AverageRisk = Math.Round(AnsPerComp.Average(A => A.AnswerRisk), 2),
             Questions = [.. AnsPerComp
                 .OrderBy(A => A.VariableAverageRisk)
                 .GroupBy(A => new { A.Question, A.Position })
@@ -214,7 +220,7 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
                     Question = AnsPerVar.Key.Question,
                     Position = AnsPerVar.Key.Position,
                     AverageAnswer = AnsPerVar.GroupBy(A => A.AnswerText).OrderByDescending(A => A.Count()).First().Key,
-                    AverageRisk = Math.Round(AnsPerVar.Average(X => X.AnswerRisk), 2),
+                    AverageRisk = Math.Round(AnsPerComp.Average(A => A.AnswerRisk), 2),
                     AnswersDetails = [.. AnsPerVar
                         .GroupBy(A => A.AnswerText)
                         .Select(AnsPerVar => new AnswerDetails
@@ -280,6 +286,12 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
 
         List<CountReportComponent> report = [.. results
         .OrderBy(A => A.ComponentId)
+        .Where(A => A.AnswerText != "-" && 
+            A.AnswerText != "" && 
+            !string.IsNullOrEmpty(A.AnswerText) &&
+            A.AnswerText != "None" && A.AnswerText != "none" &&
+            A.AnswerText != "Ninguno" && A.AnswerText != "ninguno" &&
+            A.AnswerText != "Ninguna" && A.AnswerText != "ninguna")
         .GroupBy(A => A.ComponentName)
         .Select(AnsPerComp => new CountReportComponent {
             Description = AnsPerComp.Key.ToUpper(),

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
@@ -168,6 +168,7 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
             select new ErasCalculationsByPollDTO
             {
                 ComponentName = A.ComponentName,
+                ComponentAverageRisk = A.ComponentAverageRisk,
                 Question = A.Question,
                 Position = A.Position,
                 AnswerText = A.AnswerText,
@@ -188,6 +189,7 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
             select new ErasCalculationsByPollDTO
             {
                 ComponentName = A.ComponentName,
+                ComponentAverageRisk = A.ComponentAverageRisk,
                 Question = A.Question,
                 Position = A.Position,
                 AnswerText = A.AnswerText,
@@ -200,38 +202,55 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
 
         List<ErasCalculationsByPollDTO> results = await reportQuery.ToListAsync();
 
+        var avgByComponent = results
+            .GroupBy(A => A.ComponentName)
+            .ToDictionary(
+                g => g.Key,
+                g => g.First().ComponentAverageRisk
+            );
+
+        var avgByQuestion = results
+            .GroupBy(A => new { A.ComponentName, A.Position, A.Question })
+            .ToDictionary(
+                g => g.Key,
+                g => g.First().VariableAverageRisk
+            );
+
         List<AvgReportComponent> report = [.. results
-        .Where(A => A.AnswerText != "-" && 
-            A.AnswerText != "" && 
-            !string.IsNullOrEmpty(A.AnswerText) &&
-            A.AnswerText != "None" && A.AnswerText != "none" &&
-            A.AnswerText != "Ninguno" && A.AnswerText != "ninguno" &&
-            A.AnswerText != "Ninguna" && A.AnswerText != "ninguna")
-        .GroupBy(A => A.ComponentName)
-        .Select(AnsPerComp => new AvgReportComponent
-        {
-            Description = AnsPerComp.Key.ToUpper(),
-            AverageRisk = Math.Round(AnsPerComp.Average(A => A.AnswerRisk), 2),
-            Questions = [.. AnsPerComp
-                .OrderBy(A => A.VariableAverageRisk)
-                .GroupBy(A => new { A.Question, A.Position })
-                .Select(AnsPerVar => new AvgReportQuestions
-                {
-                    Question = AnsPerVar.Key.Question,
-                    Position = AnsPerVar.Key.Position,
-                    AverageAnswer = AnsPerVar.GroupBy(A => A.AnswerText).OrderByDescending(A => A.Count()).First().Key,
-                    AverageRisk = Math.Round(AnsPerComp.Average(A => A.AnswerRisk), 2),
-                    AnswersDetails = [.. AnsPerVar
-                        .GroupBy(A => A.AnswerText)
-                        .Select(AnsPerVar => new AnswerDetails
-                        {
-                            AnswerText = AnsPerVar.Key,
-                            AnswerPercentage = AnsPerVar.First().AnswerPercentage,
-                            StudentsEmails = [.. AnsPerVar.Select(A => A.StudentEmail)],
-                            RiskLevel = (int)AnsPerVar.First().AnswerRisk
-                        })]
-                })]
-        })];
+            .GroupBy(A => A.ComponentName)
+            .Select(AnsPerComp => new AvgReportComponent
+            {
+                Description = AnsPerComp.Key.ToUpper(),
+                AverageRisk = avgByComponent.TryGetValue(AnsPerComp.Key, out var compAvg) ? compAvg : 0,
+                Questions = [.. AnsPerComp
+                    .OrderBy(A => A.VariableAverageRisk)
+                    .GroupBy(A => new { A.Question, A.Position })
+                    .Select(AnsPerVar => new AvgReportQuestions
+                    {
+                        Question = AnsPerVar.Key.Question,
+                        Position = AnsPerVar.Key.Position,
+                        AverageAnswer = AnsPerVar
+                            .Where(A => A.AnswerText != "-" && 
+                                A.AnswerText != "" && 
+                                !string.IsNullOrEmpty(A.AnswerText) &&
+                                A.AnswerText != "None" && A.AnswerText != "none" &&
+                                A.AnswerText != "Ninguno" && A.AnswerText != "ninguno" &&
+                                A.AnswerText != "Ninguna" && A.AnswerText != "ninguna")
+                            .GroupBy(A => A.AnswerText)
+                            .OrderByDescending(A => A.Count())
+                            .FirstOrDefault()?.Key ?? "-",
+                        AverageRisk = avgByComponent.TryGetValue(AnsPerComp.Key, out var qCompAvg) ? qCompAvg : 0,
+                        AnswersDetails = [.. AnsPerVar          // <- todas las respuestas visibles
+                            .GroupBy(A => A.AnswerText)
+                            .Select(AnsGroup => new AnswerDetails
+                            {
+                                AnswerText = AnsGroup.Key,
+                                AnswerPercentage = AnsGroup.First().AnswerPercentage,
+                                StudentsEmails = [.. AnsGroup.Select(A => A.StudentEmail)],
+                                RiskLevel = (int)AnsGroup.First().AnswerRisk
+                            })]
+                    })]
+            })];
         return new AvgReportResponseVm { Components = report, PollCount = results.DistinctBy(R => R.StudentEmail).Count() };
     }
 
@@ -271,6 +290,7 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
                 ComponentId = A.ComponentId,
                 ComponentName = A.ComponentName,
                 ComponentAverageRisk = A.ComponentAverageRisk,
+                VariableAverageRisk = A.VariableAverageRisk,
                 AnswerText = A.AnswerText,
                 AnswerRisk = A.AnswerRisk,
                 Question = A.Question,
@@ -284,40 +304,50 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
         
         List<ErasCalculationsByPollDTO> results = await reportQuery.ToListAsync();
 
+        var avgByComponent = results
+            .GroupBy(A => A.ComponentName)
+            .ToDictionary(
+                g => g.Key,
+                g => g.First().ComponentAverageRisk
+            );
+
+        var avgByQuestion = results
+            .GroupBy(A => new { A.ComponentName, A.Position, A.Question })
+            .ToDictionary(
+                g => g.Key,
+                g => g.First().VariableAverageRisk
+            );
+            
         List<CountReportComponent> report = [.. results
-        .OrderBy(A => A.ComponentId)
-        .Where(A => A.AnswerText != "-" && 
-            A.AnswerText != "" && 
-            !string.IsNullOrEmpty(A.AnswerText) &&
-            A.AnswerText != "None" && A.AnswerText != "none" &&
-            A.AnswerText != "Ninguno" && A.AnswerText != "ninguno" &&
-            A.AnswerText != "Ninguna" && A.AnswerText != "ninguna")
-        .GroupBy(A => A.ComponentName)
-        .Select(AnsPerComp => new CountReportComponent {
-            Description = AnsPerComp.Key.ToUpper(),
-            AverageRisk = (double)Math.Round(AnsPerComp.Average(A => A.AnswerRisk), 2),
-            Questions = [.. AnsPerComp
-                .OrderBy(Q => Q.AnswerRisk)
-                .GroupBy(Q => new { Q.Position, Q.Question })
-                .Select(AnsPerQuestion => new CountReportQuestion {
-                    AverageRisk = (double)Math.Round(AnsPerQuestion.Average(A => A.AnswerRisk),2),
-                    Position = AnsPerQuestion.Key.Position,
-                    Question = AnsPerQuestion.Key.Question,
-                    Answers = [.. AnsPerQuestion
-                        .GroupBy(A => A.AnswerRisk)
-                        .Select(AnsPerAns => new CountReportAnswer
-                        {
-                            AnswerRisk = AnsPerAns.Key,
-                            Count = AnsPerAns.Count(),
-                            Students = [.. AnsPerAns.Select(S => new CountReportStudent {
+            .OrderBy(A => A.ComponentId)
+            .GroupBy(A => A.ComponentName)
+            .Select(AnsPerComp => new CountReportComponent {
+                Description = AnsPerComp.Key.ToUpper(),
+                AverageRisk = avgByComponent.TryGetValue(AnsPerComp.Key, out var compAvg) ? (double)compAvg : 0,
+                Questions = [.. AnsPerComp
+                    .OrderBy(Q => Q.AnswerRisk)
+                    .GroupBy(Q => new { Q.Position, Q.Question })
+                    .Select(AnsPerQuestion => new CountReportQuestion {
+                        AverageRisk = avgByQuestion.TryGetValue(
+                            new { ComponentName = AnsPerComp.Key, AnsPerQuestion.Key.Position, AnsPerQuestion.Key.Question },
+                            out var qAvg) ? (double)qAvg : 0,
+                        Position = AnsPerQuestion.Key.Position,
+                        Question = AnsPerQuestion.Key.Question,
+                        Answers = [.. AnsPerQuestion
+                            .GroupBy(A => A.AnswerRisk)
+                            .Select(AnsPerAns => new CountReportAnswer
+                            {
+                                AnswerRisk = AnsPerAns.Key,
+                                Count = AnsPerAns.Count(),
+                                Students = [.. AnsPerAns.Select(S => new CountReportStudent {
                                     AnswerText = S.AnswerText,
                                     Name = S.StudentEmail,
                                     Email = S.StudentEmail,
                                     CohortId = S.CohortId
+                                })]
                             })]
                     })]
-                })]
-        })];
+            })];
         return new CountReportResponseVm { Components = report };
     }
 

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Views/Ups/vErasCalculationByPoll.sql
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Views/Ups/vErasCalculationByPoll.sql
@@ -111,10 +111,10 @@ SELECT
     p."uuid" AS poll_uuid,
     v.component_id,
     c."name" AS component_name,
-    pc.poll_variable_id,
+    a.poll_variable_id,
     v."name" AS question,
     v.position AS position,
-    pc.answer_text,
+    a.answer_text,
     a.poll_instance_id,
     sc.student_id,
     rcbi.student_name,
@@ -138,16 +138,16 @@ JOIN polls p ON pv.poll_id = p."Id"
 JOIN poll_instances pi ON a.poll_instance_id = pi."Id"
 JOIN student_cohort sc ON sc.student_id = pi."StudentId"
 JOIN cohorts coh ON coh."Id" = sc.cohort_id
-JOIN PercentageCalc pc ON a.poll_variable_id = pc.poll_variable_id AND a.answer_text = pc.answer_text
+LEFT JOIN PercentageCalc pc ON a.poll_variable_id = pc.poll_variable_id AND a.answer_text = pc.answer_text
 LEFT JOIN RiskAverageByComponent rac ON c."name" = rac.component_name AND p."Id" = rac.poll_id
 LEFT JOIN RiskAverageByVariable rav ON v."Id" = rav.variable_id
 LEFT JOIN RiskCountByPollInstance rcbi ON a.poll_instance_id = rcbi.poll_instance_id
 LEFT JOIN RiskAvgByCohortComponent racbc ON racbc.cohort_id = sc.cohort_id AND racbc.component_id = c."Id"
 GROUP BY
-    p."Id", poll_uuid, v.component_id, component_name, pc.poll_variable_id,
-    question, v.position, pc.answer_text, a.poll_instance_id, sc.student_id,
+    p."Id", poll_uuid, v.component_id, component_name, a.poll_variable_id,
+    question, v.position, a.answer_text, a.poll_instance_id, sc.student_id,
     rcbi.student_name, rcbi.student_email, pc.answer_count, pc.answer_percentage,
     rcbi.poll_instance_risk_sum, rcbi.poll_instance_answers_count,
     rac.average_risk, rav.average_risk, sc.cohort_id, coh."name",
     racbc.average_risk_by_cohort_component, c."name", a.risk_level, poll_version
-ORDER BY pc.poll_variable_id, pc.answer_percentage DESC;
+ORDER BY a.poll_variable_id, pc.answer_percentage DESC;

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Views/Ups/vErasCalculationByPoll.sql
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Views/Ups/vErasCalculationByPoll.sql
@@ -1,3 +1,4 @@
+DROP VIEW IF EXISTS vErasCalculationByPoll;
 CREATE VIEW vErasCalculationByPoll AS
 WITH ResolvedAnswers AS (
     SELECT 
@@ -44,35 +45,35 @@ PercentageCalc AS (
             2
         ) AS answer_percentage,
         COUNT(answer_text) AS answer_count
-    FROM
-        ResolvedAnswers a
-    GROUP BY
-        a.poll_variable_id, answer_text
+    FROM ResolvedAnswers a
+    WHERE a.answer_text NOT IN ('-', '', 'None', 'none', 'Ninguno', 'ninguno', 'Ninguna', 'ninguna')
+  AND a.answer_text IS NOT NULL
+    GROUP BY a.poll_variable_id, answer_text
 ),
 RiskAverageByComponent AS (
     SELECT
         pv.poll_id,
         c."name" AS component_name,
         ROUND(AVG(a.risk_level),2) AS average_risk
-    FROM
-        ResolvedAnswers a
+    FROM ResolvedAnswers a
     JOIN poll_variable pv ON a.poll_variable_id = pv."Id"
     JOIN variables v ON pv.variable_id = v."Id"
     JOIN components c ON v.component_id = c."Id"
-    GROUP BY
-        pv.poll_id, c."name"
+    WHERE a.answer_text NOT IN ('-', '', 'None', 'none', 'Ninguno', 'ninguno', 'Ninguna', 'ninguna')
+  AND a.answer_text IS NOT NULL
+    GROUP BY pv.poll_id, c."name"
 ),
 RiskAverageByVariable AS (
     SELECT
         v."Id" AS variable_id,
         v."name" AS variable_name,
         ROUND(AVG(a.risk_level),2) AS average_risk
-    FROM
-        ResolvedAnswers a
+    FROM ResolvedAnswers a
     JOIN poll_variable pv ON a.poll_variable_id = pv."Id"
     JOIN variables v ON pv.variable_id = v."Id"
-    GROUP BY
-        v."Id", v."name" /*, pv.poll_id Repeating result by some reason*/
+    WHERE a.answer_text NOT IN ('-', '', 'None', 'none', 'Ninguno', 'ninguno', 'Ninguna', 'ninguna')
+  AND a.answer_text IS NOT NULL
+    GROUP BY v."Id", v."name"
 ),
 RiskCountByPollInstance AS (
     SELECT
@@ -81,30 +82,32 @@ RiskCountByPollInstance AS (
         s."email" AS student_email,
         SUM(a.risk_level) AS poll_instance_risk_sum,
         COUNT(a.risk_level) AS poll_instance_answers_count
-    FROM
-        ResolvedAnswers a
+    FROM ResolvedAnswers a
+    JOIN poll_variable pv ON a.poll_variable_id = pv."Id"
+    JOIN variables v ON pv.variable_id = v."Id"
     JOIN poll_instances pi2 ON pi2."Id" = a.poll_instance_id
     JOIN students s ON s."Id" = pi2."StudentId"
-    GROUP BY
-        a.poll_instance_id, s."name", s."email"
+    WHERE a.answer_text NOT IN ('-', '', 'None', 'none', 'Ninguno', 'ninguno', 'Ninguna', 'ninguna')
+  AND a.answer_text IS NOT NULL
+    GROUP BY a.poll_instance_id, s."name", s."email"
 ),
 RiskAvgByCohortComponent AS (
     SELECT
         sc.cohort_id,
         c."Id" AS component_id,
         ROUND(AVG(a.risk_level),2) AS average_risk_by_cohort_component
-    FROM
-        ResolvedAnswers a
+    FROM ResolvedAnswers a
     JOIN poll_variable pv ON pv."Id" = a.poll_variable_id
     JOIN variables v ON v."Id" = pv.variable_id
     JOIN components c ON c."Id" = v.component_id
     JOIN poll_instances pi ON pi."Id" = a.poll_instance_id
     JOIN student_cohort sc ON sc.student_id = pi."StudentId"
-    GROUP BY
-        sc.cohort_id, c."Id"
+    WHERE a.answer_text NOT IN ('-', '', 'None', 'none', 'Ninguno', 'ninguno', 'Ninguna', 'ninguna')
+  AND a.answer_text IS NOT NULL
+    GROUP BY sc.cohort_id, c."Id"
 )
-select
-	p."Id" AS poll_id,
+SELECT
+    p."Id" AS poll_id,
     p."uuid" AS poll_uuid,
     v.component_id,
     c."name" AS component_name,
@@ -126,9 +129,8 @@ select
     sc.cohort_id,
     coh."name" AS cohort_name,
     racbc.average_risk_by_cohort_component,
-    a.version_number as poll_version
-FROM
-    ResolvedAnswers a
+    a.version_number AS poll_version
+FROM ResolvedAnswers a
 JOIN poll_variable pv ON a.poll_variable_id = pv."Id"
 JOIN variables v ON pv.variable_id = v."Id"
 JOIN components c ON v.component_id = c."Id"
@@ -137,36 +139,15 @@ JOIN poll_instances pi ON a.poll_instance_id = pi."Id"
 JOIN student_cohort sc ON sc.student_id = pi."StudentId"
 JOIN cohorts coh ON coh."Id" = sc.cohort_id
 JOIN PercentageCalc pc ON a.poll_variable_id = pc.poll_variable_id AND a.answer_text = pc.answer_text
-JOIN RiskAverageByComponent rac 
-  ON c."name" = rac.component_name AND p."Id" = rac.poll_id
-JOIN RiskAverageByVariable rav ON v."Id" = rav.variable_id
-JOIN RiskCountByPollInstance rcbi ON a.poll_instance_id = rcbi.poll_instance_id
-JOIN RiskAvgByCohortComponent racbc ON racbc.cohort_id = sc.cohort_id AND racbc.component_id = c."Id"
-GROUP by
-	p."Id",
-    poll_uuid,
-    v.component_id,
-    component_name,
-    pc.poll_variable_id,
-    question,
-    v.position,
-    pc.answer_text,
-    a.poll_instance_id,
-    sc.student_id,
-    rcbi.student_name,
-    rcbi.student_email,
-    pc.answer_count,
-    pc.answer_percentage,
-    rcbi.poll_instance_risk_sum,
-    rcbi.poll_instance_answers_count,
-    rac.average_risk,
-    rav.average_risk,
-    sc.cohort_id,
-    coh."name",
-    racbc.average_risk_by_cohort_component,
-    c."name",
-    a.risk_level,
-    poll_version
-ORDER BY
-    pc.poll_variable_id,
-    pc.answer_percentage DESC;
+LEFT JOIN RiskAverageByComponent rac ON c."name" = rac.component_name AND p."Id" = rac.poll_id
+LEFT JOIN RiskAverageByVariable rav ON v."Id" = rav.variable_id
+LEFT JOIN RiskCountByPollInstance rcbi ON a.poll_instance_id = rcbi.poll_instance_id
+LEFT JOIN RiskAvgByCohortComponent racbc ON racbc.cohort_id = sc.cohort_id AND racbc.component_id = c."Id"
+GROUP BY
+    p."Id", poll_uuid, v.component_id, component_name, pc.poll_variable_id,
+    question, v.position, pc.answer_text, a.poll_instance_id, sc.student_id,
+    rcbi.student_name, rcbi.student_email, pc.answer_count, pc.answer_percentage,
+    rcbi.poll_instance_risk_sum, rcbi.poll_instance_answers_count,
+    rac.average_risk, rav.average_risk, sc.cohort_id, coh."name",
+    racbc.average_risk_by_cohort_component, c."name", a.risk_level, poll_version
+ORDER BY pc.poll_variable_id, pc.answer_percentage DESC;


### PR DESCRIPTION
## Description

The ticket mentions excluding 0 values from the calculation, but the important distinction is not the numeric value itself — it’s whether the answer represents an intentional evaluation or a non-applicable/missing response.

Cases like "-", empty values, "None", "Ninguno" or skipped open-text answers are treated as non-applicable responses because they do not represent an actual evaluated risk. Those values should be excluded from both the sum and the divisor to avoid artificially lowering the average.

However, there are valid answers that legitimately map to a risk score of 0. For example, responses like "Bipolar" or other, are actual evaluated answers, not skipped fields. In those cases, the 0 is intentional and must still be included in the average calculation.

So the logic is not “exclude every 0”, but rather:

Exclude non-applicable or unanswered responses
Keep valid evaluated answers, even when their calculated risk score is 0

This preserves the integrity of the risk calculation while preventing dilution caused by missing or non-substantive responses.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


