### PR TITLE
Fix the statuses of evaluation processes with responses regarding the polls answered related to each one

### DIFF
--- a/src/Eras.Application/ApplicationServiceRegistration.cs
+++ b/src/Eras.Application/ApplicationServiceRegistration.cs
@@ -26,6 +26,7 @@ namespace Eras.Application.Services
             Services.AddScoped<IPollService, PollService>();
             Services.AddScoped<IAnswerService, AnswerService>();
             Services.AddScoped<PollOrchestratorService, PollOrchestratorService>();
+            Services.AddScoped<EvaluationStatusUpdater>();
             Services.ConfigureMappers();
             return Services;
         }

--- a/src/Eras.Application/Contracts/Persistence/IEvaluationRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/IEvaluationRepository.cs
@@ -11,5 +11,7 @@ namespace Eras.Application.Contracts.Persistence
         new Task<List<Evaluation>> GetAllAsync();
         Task<List<Evaluation>> GetByDateRange(DateTime startDate, DateTime endDate);
         Task<int> CountByDateRangeAsync(DateTime startDate, DateTime endDate);
+        Task<IEnumerable<Evaluation>> GetExpiredWithPendingStatusAsync(IEnumerable<string> status, DateTime endDateBefore);
+        Task UpdateStatusAsync(int evaluationId, string status);
     }
 }

--- a/src/Eras.Application/Events/AnswerSubmittedEvent.cs
+++ b/src/Eras.Application/Events/AnswerSubmittedEvent.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using MediatR;
+
+namespace Eras.Application.Events;
+
+public record AnswerSubmittedEvent(int EvaluationId) : INotification;

--- a/src/Eras.Application/Events/EvaluationCreatedEvent.cs
+++ b/src/Eras.Application/Events/EvaluationCreatedEvent.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using MediatR;
+
+namespace Eras.Application.Events;
+
+public record EvaluationCreatedEvent(int EvaluationId) : INotification;

--- a/src/Eras.Application/Features/Evaluations/Commands/CreateEvaluation/CreateEvaluationCommandHandler.cs
+++ b/src/Eras.Application/Features/Evaluations/Commands/CreateEvaluation/CreateEvaluationCommandHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Eras.Application.Contracts.Persistence;
+using Eras.Application.Events;
 using Eras.Application.Mappers;
 using Eras.Application.Models.Response.Common;
 using Eras.Domain.Common;
@@ -53,7 +54,7 @@ namespace Eras.Application.Features.Evaluations.Commands
             }
             evaluation.Status = status;
             Evaluation response = await _evaluationRepository.AddAsync(evaluation);
-            if (poll != null && status.Equals(EvaluationConstants.EvaluationStatus.Ready.ToString()))
+            if (poll != null)
             {
                 Request.EvaluationDTO.PollId = poll.Id;
                 Request.EvaluationDTO.Id = response.Id;
@@ -62,6 +63,7 @@ namespace Eras.Application.Features.Evaluations.Commands
                     EvaluationDTO = Request.EvaluationDTO
                 };
                 await _mediator.Send(evaluationPollCommand);
+                await _mediator.Publish(new EvaluationCreatedEvent(response.Id));
             }
             return new CreateCommandResponse<Evaluation>(response, 1, "Success", true);
         }

--- a/src/Eras.Application/Features/Evaluations/Commands/UpdateEvaluation/UpdateEvaluationCommandHandler.cs
+++ b/src/Eras.Application/Features/Evaluations/Commands/UpdateEvaluation/UpdateEvaluationCommandHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Eras.Application.Contracts.Persistence;
+using Eras.Application.Events;
 using Eras.Application.Models.Response.Common;
 using Eras.Domain.Entities;
 using Eras.Error.Bussiness;
@@ -66,6 +67,7 @@ namespace Eras.Application.Features.Evaluations.Commands.UpdateEvaluation
                 }
             }
             await _evaluationRepository.UpdateAsync(evaluationDB);
+            await _mediator.Publish(new EvaluationCreatedEvent(Request.EvaluationDTO.Id));
 
             _logger.LogInformation("Successfully updated Evaluation ID {Id}", evaluationDB.Id);
             return new CreateCommandResponse<Evaluation>(evaluationDB, 1, "Success", true);

--- a/src/Eras.Application/Features/Evaluations/Handlers/AnswerSubmittedEventHandler.cs
+++ b/src/Eras.Application/Features/Evaluations/Handlers/AnswerSubmittedEventHandler.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Eras.Application.Services;
+using Eras.Application.Events;
+
+using MediatR;
+
+namespace Eras.Application.Features.Evaluations.Handlers;
+
+public class AnswerSubmittedEventHandler : INotificationHandler<AnswerSubmittedEvent>
+{
+   private readonly EvaluationStatusUpdater _updater;
+   public AnswerSubmittedEventHandler(EvaluationStatusUpdater updater)
+       => _updater = updater;
+
+   public Task Handle(AnswerSubmittedEvent notification, CancellationToken ct)
+       => _updater.UpdateStatusAsync(notification.EvaluationId);
+}

--- a/src/Eras.Application/Features/Evaluations/Handlers/EvaluationCreatedEventHandler.cs
+++ b/src/Eras.Application/Features/Evaluations/Handlers/EvaluationCreatedEventHandler.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Eras.Application.Events;
+using Eras.Application.Services;
+
+using MediatR;
+
+namespace Eras.Application.Features.Evaluations.Handlers;
+
+public class EvaluationCreatedEventHandler : INotificationHandler<EvaluationCreatedEvent>
+{
+   private readonly EvaluationStatusUpdater _updater;
+   public EvaluationCreatedEventHandler(EvaluationStatusUpdater updater)
+       => _updater = updater;
+
+   public Task Handle(EvaluationCreatedEvent notification, CancellationToken ct)
+       => _updater.UpdateStatusAsync(notification.EvaluationId);
+}

--- a/src/Eras.Application/Services/EvaluationStatusService.cs
+++ b/src/Eras.Application/Services/EvaluationStatusService.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Eras.Application.Contracts.Persistence;
+using Eras.Domain.Entities;
+
+namespace Eras.Application.Services;
+
+public static class EvaluationStatusService
+{
+    public static EvaluationConstants.EvaluationStatus ComputeStatus(Evaluation evaluation)
+    {
+        if (evaluation.Polls == null || evaluation.Polls.Count == 0)
+        {
+            return EvaluationConstants.EvaluationStatus.Pending;
+        }
+
+        bool hasAnswers = evaluation.PollInstances != null && 
+            evaluation.PollInstances.Any(pi => pi.Answers.Count > 0 || pi.SourcePollInstanceId != null);
+
+        var now = DateTime.UtcNow;
+
+        if (!hasAnswers)
+        {
+            return now > evaluation.EndDate
+                ? EvaluationConstants.EvaluationStatus.Uncompleted
+                : EvaluationConstants.EvaluationStatus.Ready;
+        }
+        return now > evaluation.EndDate
+            ? EvaluationConstants.EvaluationStatus.Completed
+            : EvaluationConstants.EvaluationStatus.InProgress;
+    }
+}

--- a/src/Eras.Application/Services/EvaluationStatusUpdater.cs
+++ b/src/Eras.Application/Services/EvaluationStatusUpdater.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Eras.Application.Contracts.Persistence;
+using Eras.Domain.Entities;
+
+namespace Eras.Application.Services;
+
+public class EvaluationStatusUpdater
+{
+   private readonly IEvaluationRepository _repository;
+    
+   public EvaluationStatusUpdater(IEvaluationRepository repository)
+   {
+       _repository = repository;
+   }
+
+   public async Task UpdateStatusAsync(int evaluationId)
+   {
+       var evaluation = await _repository.GetByIdAsync(evaluationId);
+       if (evaluation == null) return;
+
+       await PersistIfChangedAsync(evaluation);
+   }
+
+   public async Task UpdateStatusAsync(Evaluation evaluation)
+   {
+       await PersistIfChangedAsync(evaluation);
+   }
+
+   private async Task PersistIfChangedAsync(Evaluation evaluation)
+   {
+       var newStatus = EvaluationStatusService.ComputeStatus(evaluation).ToString();
+       if (evaluation.Status == newStatus) return;
+
+       evaluation.Status = newStatus;
+       evaluation.Audit.ModifiedAt = DateTime.UtcNow;
+       await _repository.UpdateStatusAsync(evaluation.Id, newStatus);
+   }
+}

--- a/src/Eras.Application/Services/PollOrchestratorService.cs
+++ b/src/Eras.Application/Services/PollOrchestratorService.cs
@@ -2,6 +2,7 @@
 using Eras.Application.Dtos;
 using Eras.Application.DTOs;
 using Eras.Application.DTOs.CL;
+using Eras.Application.Events;
 using Eras.Application.Features.Answers.Commands.CreateAnswerList;
 using Eras.Application.Features.Cohorts.Commands.CreateCohort;
 using Eras.Application.Features.Components.Commands.CreateCommand;
@@ -133,7 +134,7 @@ namespace Eras.Application.Services
                                 {
                                     await CreateAnswersAsync(pollToCreate, createdComponents, createdPollInstance);
                                 }
-
+                                await _mediator.Publish(new AnswerSubmittedEvent(EvaluationId));
                                 createdPollsInstances++;
                             }
                         }

--- a/src/Eras.Infrastructure/InfrastructureServiceRegistration.cs
+++ b/src/Eras.Infrastructure/InfrastructureServiceRegistration.cs
@@ -13,6 +13,7 @@ using Microsoft.IdentityModel.Tokens;
 using Eras.Application.Models;
 using Eras.Infrastructure.FileStorage;
 using Microsoft.Extensions.Logging;
+using Eras.Infrastructure.Persistence.PostgreSQL.Jobs;
 
 namespace Eras.Infrastructure
 {
@@ -25,6 +26,7 @@ namespace Eras.Infrastructure
             Services.AddScoped<IKeycloakAuthService<TokenResponse>, KeycloakAuthService>();
             Services.AddScoped<ICosmicLatteAPIService, CosmicLatteAPIService>();
             Services.AddScoped<IApiKeyEncryptor, AesApiKeyEncryptor>();
+            Services.AddHostedService<EvaluationStatusSyncJob>();
 
             Services.Configure<FileStorageSettings>(Configuration.GetSection("FileStorage"));
 

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Configurations/EvaluationConfiguration.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Configurations/EvaluationConfiguration.cs
@@ -51,6 +51,11 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Configurations
                 .WithMany()
                 .HasForeignKey(e => e.ConfigurationId)
                 .OnDelete(DeleteBehavior.Restrict);
+
+            Builder.HasMany(e => e.PollInstances)
+                .WithOne(pi => pi.Evaluation)
+                .HasForeignKey(pi => pi.EvaluationId)
+                .OnDelete(DeleteBehavior.SetNull);
         }
     }
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Entities/EvaluationEntity.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Entities/EvaluationEntity.cs
@@ -9,7 +9,6 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Entities
     {
         public string Name { get; set; } = string.Empty;
         public string Status { get; set; } = string.Empty;
-        public string CurrentStatus => GetStatus().ToString();
         public string PollName {  get; set; } = string.Empty ;
         public string Country { get; set; } = string.Empty;
         public int ConfigurationId { get; set; }
@@ -17,23 +16,7 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Entities
         public DateTime StartDate { get; set; }
         public DateTime EndDate { get; set; }
         public ICollection<EvaluationPollJoin> EvaluationPolls { get; set; } = [];
+        public ICollection<PollInstanceEntity> PollInstances { get; set; } = [];
         public AuditInfo Audit { get; set; } = default!;
-        public EvStatus GetStatus()
-        {
-            if (EvaluationPolls == null || EvaluationPolls.Count == 0)
-            {
-                return EvStatus.Pending;
-            }
-
-            var now = DateTime.UtcNow;
-            //TODO: Check for PollInstances (Answers) instead of just the Poll
-            return EvaluationPolls.Count != 0 //&& EvaluationPolls.Any(ep => ep.Poll.PollVariables.Any(pv => pv.Answers.Count != 0)))
-            ? (now > EndDate
-                ? EvStatus.Completed
-                : EvStatus.InProgress)
-            : (now > EndDate
-                ? EvStatus.Uncompleted
-                : EvStatus.Ready);
-        }
     }
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Entities/PollInstanceEntity.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Entities/PollInstanceEntity.cs
@@ -13,6 +13,7 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Entities
         public AuditInfo Audit { get; set; } = default!;
         public DateTime FinishedAt { get; set; }
         public int? EvaluationId { get; set; }
+        public EvaluationEntity? Evaluation { get; set; }
         public int? SourcePollInstanceId { get; set; }
     }
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Jobs/EvaluationStatusSyncJob.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Jobs/EvaluationStatusSyncJob.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Eras.Application.Contracts.Persistence;
+using Eras.Application.Services;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+using static Eras.Domain.Entities.EvaluationConstants;
+
+namespace Eras.Infrastructure.Persistence.PostgreSQL.Jobs;
+
+public class EvaluationStatusSyncJob : BackgroundService
+{
+   private readonly IServiceScopeFactory _scopeFactory;
+   private readonly ILogger<EvaluationStatusSyncJob> _logger;
+    private readonly TimeSpan _interval = TimeSpan.FromHours(1);
+
+    public EvaluationStatusSyncJob(IServiceScopeFactory scopeFactory,
+       ILogger<EvaluationStatusSyncJob> logger)
+   {
+       _scopeFactory = scopeFactory;
+       _logger = logger;
+   }
+
+   protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+   {
+       while (!stoppingToken.IsCancellationRequested)
+       {
+           await Task.Delay(_interval, stoppingToken);
+           await RunAsync(stoppingToken);
+       }
+   }
+
+   private async Task RunAsync(CancellationToken ct)
+   {
+       await using var scope = _scopeFactory.CreateAsyncScope();
+       var repository = scope.ServiceProvider.GetRequiredService<IEvaluationRepository>();
+       var updater = scope.ServiceProvider.GetRequiredService<EvaluationStatusUpdater>();
+
+       var expiredStatuses = new[]
+       {
+           EvaluationStatus.Ready.ToString(),
+           EvaluationStatus.InProgress.ToString()
+       };
+
+       var evaluations = await repository.GetExpiredWithPendingStatusAsync(
+           expiredStatuses, DateTime.UtcNow);
+
+       foreach (var evaluation in evaluations)
+       {
+           await updater.UpdateStatusAsync(evaluation);
+           _logger.LogInformation(
+               "Evaluation {Id} status synced to {Status}", evaluation.Id, evaluation.Status);
+       }
+   }
+}

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Mappers/EvaluationMapper.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Mappers/EvaluationMapper.cs
@@ -11,7 +11,7 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Mappers
             {
                 Id = Entity.Id,
                 Name = Entity.Name,
-                Status = Entity.CurrentStatus,
+                Status = Entity.Status,
                 PollName = Entity.PollName,
                 Country = Entity.Country,
                 StartDate = Entity.StartDate,

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/EvaluationRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/EvaluationRepository.cs
@@ -60,7 +60,7 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
             {
                 Id = Entity.Id,
                 Name = Entity.Name,
-                Status = Entity.CurrentStatus,
+                Status = Entity.Status,
                 StartDate = Entity.StartDate,
                 EndDate = Entity.EndDate,
                 Audit = Entity.Audit,
@@ -73,7 +73,7 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
 
         public new Task<Evaluation?> GetByIdAsync(int EvalId)
         {
-            EvaluationEntity? ev = _context.Evaluations.FirstOrDefault(E => E.Id == EvalId);
+            EvaluationEntity? ev = _context.Evaluations.AsNoTracking().FirstOrDefault(E => E.Id == EvalId);
             if (ev == null)
             {
                 return Task.FromResult<Evaluation?>(null);
@@ -91,7 +91,7 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
             Evaluation evaluation = ev.ToDomain();
             evaluation.Polls = polls;
             evaluation.PollInstances = pollIntances;
-            evaluation.Status = ev.CurrentStatus;
+            evaluation.Status = ev.Status;
             return Task.FromResult<Evaluation?>(evaluation);
         }
 
@@ -134,7 +134,7 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
             {
                 Id = e.Id,
                 Name = e.Name,
-                Status = e.CurrentStatus,
+                Status = e.Status,
                 StartDate = e.StartDate,
                 EndDate = e.EndDate,
                 Audit = e.Audit,
@@ -154,6 +154,29 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
                 .Where(e => e.StartDate >= DateTime.SpecifyKind(startDate, DateTimeKind.Utc)
                         && e.StartDate <= DateTime.SpecifyKind(endDate, DateTimeKind.Utc))
                 .CountAsync();
+        }
+
+        public async Task<IEnumerable<Evaluation>> GetExpiredWithPendingStatusAsync(IEnumerable<string> status, DateTime endDateBefore) 
+        {
+            var entities = await _context.Evaluations
+                .Include(e => e.EvaluationPolls)
+                    .ThenInclude(p => p.Poll)
+                .Include(e => e.PollInstances)
+                    .ThenInclude(pi => pi.Answers)
+                .Where(e => status.Contains(e.Status) && e.EndDate < endDateBefore)
+                .ToListAsync();
+
+            return entities.Select(e => e.ToDomain());
+
+        }
+
+        public async Task UpdateStatusAsync(int evaluationId, string status)
+        {
+            await _context.Evaluations
+                .Where(e => e.Id == evaluationId)
+                .ExecuteUpdateAsync(e => e
+                    .SetProperty(x => x.Status, status)
+                    .SetProperty(x => x.Audit.ModifiedAt, DateTime.UtcNow));
         }
     }
 }


### PR DESCRIPTION
## Description

The root cause was that the evaluation did not contain imported data, so the issue could be resolved by importing the data correctly. However, the status was reading the polls directly, and they do not align with the specifications:

- Pending: Evaluation is pending poll assignment.
- Ready: Evaluation has at least one poll assigned and is ready to start.
- InProgress: Evaluation has at least one answered poll instance.
- Completed: Evaluation has at least one answered poll instance and the deadline has passed.
- Uncompleted: Evaluation has no answered poll instances and the deadline has passed.

In order to update every status of evaluation processes and stored the correct status, the process of importData and createEvaluation can publish an event. In addition, a background job has been added to periodically synchronize evaluation statuses every hour

> [!Important]
> Since this change, the existing evaluations may contain outdated status information because they were created before the status synchronization mechanism was introduced. 
During testing, re-importing legacy evaluation data exposed issues related to the vErasCalculationByPoll view that could not be resolved as part of this change. Therefore, it is recommended to remove legacy evaluation records and recreate them using the updated import process. This will ensure that evaluation statuses are calculated and displayed correctly going forward.

## Type of change

- [X] Bug fix
- [ ] Feature
- [X] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues

#424 

