### PR TITLE
fix: analytics charts loading and risk average calculation logic

### DIFF
--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
@@ -202,18 +202,27 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
 
         List<ErasCalculationsByPollDTO> results = await reportQuery.ToListAsync();
 
-        var avgByComponent = results
+        var filteredResultsForMath = results.Where(A => 
+            A.AnswerText != "-" && 
+            A.AnswerText != "" && 
+            !string.IsNullOrEmpty(A.AnswerText) &&
+            !A.AnswerText.Equals("None", StringComparison.OrdinalIgnoreCase) &&
+            !A.AnswerText.Equals("Ninguno", StringComparison.OrdinalIgnoreCase) &&
+            !A.AnswerText.Equals("Ninguna", StringComparison.OrdinalIgnoreCase)
+        ).ToList();
+
+        var avgByComponent = filteredResultsForMath
             .GroupBy(A => A.ComponentName)
             .ToDictionary(
                 g => g.Key,
-                g => g.First().ComponentAverageRisk
+                g => (decimal)Math.Round(g.Average(x => (double)x.AnswerRisk), 2)
             );
 
-        var avgByQuestion = results
+        var avgByQuestion = filteredResultsForMath
             .GroupBy(A => new { A.ComponentName, A.Position, A.Question })
             .ToDictionary(
                 g => g.Key,
-                g => g.First().VariableAverageRisk
+                g => (decimal)Math.Round(g.Average(x => (double)x.AnswerRisk), 2)
             );
 
         List<AvgReportComponent> report = [.. results
@@ -239,8 +248,8 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
                             .GroupBy(A => A.AnswerText)
                             .OrderByDescending(A => A.Count())
                             .FirstOrDefault()?.Key ?? "-",
-                        AverageRisk = avgByComponent.TryGetValue(AnsPerComp.Key, out var qCompAvg) ? qCompAvg : 0,
-                        AnswersDetails = [.. AnsPerVar          // <- todas las respuestas visibles
+                        AverageRisk = AnsPerVar.First().VariableAverageRisk,
+                        AnswersDetails = [.. AnsPerVar
                             .GroupBy(A => A.AnswerText)
                             .Select(AnsGroup => new AnswerDetails
                             {
@@ -305,11 +314,11 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
         List<ErasCalculationsByPollDTO> results = await reportQuery.ToListAsync();
 
         var avgByComponent = results
-            .GroupBy(A => A.ComponentName)
-            .ToDictionary(
-                g => g.Key,
-                g => g.First().ComponentAverageRisk
-            );
+    .GroupBy(A => A.ComponentName)
+    .ToDictionary(
+        g => g.Key,
+        g => (decimal)Math.Round(g.Average(x => (double)x.AnswerRisk), 2)
+    );
 
         var avgByQuestion = results
             .GroupBy(A => new { A.ComponentName, A.Position, A.Question })

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Views/Ups/vErasCalculationByPoll.sql
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Views/Ups/vErasCalculationByPoll.sql
@@ -2,99 +2,60 @@ DROP VIEW IF EXISTS vErasCalculationByPoll;
 CREATE VIEW vErasCalculationByPoll AS
 WITH ResolvedAnswers AS (
     SELECT 
-        a."Id",
-        a.poll_instance_id,
-        a.poll_variable_id,
-        a.answer_text,
-        a.risk_level,
-        a.version_date,
-        a.version_number,
-        a.created_at,
-        a.created_by,
-        a.modified_by,
-        a.updated_at
+        a."Id", a.poll_instance_id, a.poll_variable_id, a.answer_text, a.risk_level, a.version_number
     FROM answers a
     JOIN poll_instances pi ON pi."Id" = a.poll_instance_id
     WHERE pi."SourcePollInstanceId" IS NULL
-
     UNION ALL
-
     SELECT
-        a."Id",
-        pi."Id" AS poll_instance_id,
-        a.poll_variable_id,
-        a.answer_text,
-        a.risk_level,
-        a.version_date,
-        a.version_number,
-        a.created_at,
-        a.created_by,
-        a.modified_by,
-        a.updated_at
+        a."Id", pi."Id" AS poll_instance_id, a.poll_variable_id, a.answer_text, a.risk_level, a.version_number
     FROM poll_instances pi
     JOIN answers a ON a.poll_instance_id = pi."SourcePollInstanceId"
     WHERE pi."SourcePollInstanceId" IS NOT NULL
 ),
 PercentageCalc AS (
     SELECT
-        a.poll_variable_id,
-        answer_text,
-        ROUND(
-            (COUNT(answer_text) * 100.0) /
-            SUM(COUNT(answer_text)) OVER (PARTITION BY a.poll_variable_id),
-            2
-        ) AS answer_percentage,
+        a.poll_variable_id, answer_text,
+        ROUND((COUNT(answer_text) * 100.0) / SUM(COUNT(answer_text)) OVER (PARTITION BY a.poll_variable_id), 2) AS answer_percentage,
         COUNT(answer_text) AS answer_count
     FROM ResolvedAnswers a
-    WHERE a.answer_text NOT IN ('-', '', 'None', 'none', 'Ninguno', 'ninguno', 'Ninguna', 'ninguna')
-  AND a.answer_text IS NOT NULL
+    WHERE a.answer_text NOT IN ('-', '', 'None', 'none', 'Ninguno', 'ninguno', 'Ninguna', 'ninguna') AND a.answer_text IS NOT NULL
     GROUP BY a.poll_variable_id, answer_text
 ),
 RiskAverageByComponent AS (
     SELECT
-        pv.poll_id,
-        c."name" AS component_name,
+        pv.poll_id, c."name" AS component_name,
         ROUND(AVG(a.risk_level),2) AS average_risk
     FROM ResolvedAnswers a
     JOIN poll_variable pv ON a.poll_variable_id = pv."Id"
     JOIN variables v ON pv.variable_id = v."Id"
     JOIN components c ON v.component_id = c."Id"
-    WHERE a.answer_text NOT IN ('-', '', 'None', 'none', 'Ninguno', 'ninguno', 'Ninguna', 'ninguna')
-  AND a.answer_text IS NOT NULL
+    WHERE a.answer_text NOT IN ('-', '', 'None', 'none', 'Ninguno', 'ninguno', 'Ninguna', 'ninguna') AND a.answer_text IS NOT NULL
     GROUP BY pv.poll_id, c."name"
 ),
 RiskAverageByVariable AS (
     SELECT
         v."Id" AS variable_id,
-        v."name" AS variable_name,
         ROUND(AVG(a.risk_level),2) AS average_risk
     FROM ResolvedAnswers a
     JOIN poll_variable pv ON a.poll_variable_id = pv."Id"
     JOIN variables v ON pv.variable_id = v."Id"
-    WHERE a.answer_text NOT IN ('-', '', 'None', 'none', 'Ninguno', 'ninguno', 'Ninguna', 'ninguna')
-  AND a.answer_text IS NOT NULL
-    GROUP BY v."Id", v."name"
+    WHERE a.answer_text NOT IN ('-', '', 'None', 'none', 'Ninguno', 'ninguno', 'Ninguna', 'ninguna') AND a.answer_text IS NOT NULL
+    GROUP BY v."Id"
 ),
 RiskCountByPollInstance AS (
     SELECT
-        a.poll_instance_id,
-        s."name" AS student_name,
-        s."email" AS student_email,
+        a.poll_instance_id, s."name" AS student_name, s."email" AS student_email,
         SUM(a.risk_level) AS poll_instance_risk_sum,
         COUNT(a.risk_level) AS poll_instance_answers_count
     FROM ResolvedAnswers a
-    JOIN poll_variable pv ON a.poll_variable_id = pv."Id"
-    JOIN variables v ON pv.variable_id = v."Id"
     JOIN poll_instances pi2 ON pi2."Id" = a.poll_instance_id
     JOIN students s ON s."Id" = pi2."StudentId"
-    WHERE a.answer_text NOT IN ('-', '', 'None', 'none', 'Ninguno', 'ninguno', 'Ninguna', 'ninguna')
-  AND a.answer_text IS NOT NULL
     GROUP BY a.poll_instance_id, s."name", s."email"
 ),
 RiskAvgByCohortComponent AS (
     SELECT
-        sc.cohort_id,
-        c."Id" AS component_id,
+        sc.cohort_id, c."Id" AS component_id,
         ROUND(AVG(a.risk_level),2) AS average_risk_by_cohort_component
     FROM ResolvedAnswers a
     JOIN poll_variable pv ON pv."Id" = a.poll_variable_id
@@ -102,8 +63,6 @@ RiskAvgByCohortComponent AS (
     JOIN components c ON c."Id" = v.component_id
     JOIN poll_instances pi ON pi."Id" = a.poll_instance_id
     JOIN student_cohort sc ON sc.student_id = pi."StudentId"
-    WHERE a.answer_text NOT IN ('-', '', 'None', 'none', 'Ninguno', 'ninguno', 'Ninguna', 'ninguna')
-  AND a.answer_text IS NOT NULL
     GROUP BY sc.cohort_id, c."Id"
 )
 SELECT
@@ -120,15 +79,15 @@ SELECT
     rcbi.student_name,
     rcbi.student_email,
     a.risk_level AS answer_risk,
-    rcbi.poll_instance_risk_sum,
-    rcbi.poll_instance_answers_count,
-    rac.average_risk AS component_average_risk,
-    rav.average_risk AS variable_average_risk,
-    pc.answer_count,
-    pc.answer_percentage,
+    COALESCE(rcbi.poll_instance_risk_sum, 0) AS poll_instance_risk_sum,
+    COALESCE(rcbi.poll_instance_answers_count, 0) AS poll_instance_answers_count,
+    COALESCE(rac.average_risk, 0) AS component_average_risk,
+    COALESCE(rav.average_risk, 0) AS variable_average_risk,
+    COALESCE(pc.answer_count, 0) AS answer_count,
+    COALESCE(pc.answer_percentage, 0) AS answer_percentage,
     sc.cohort_id,
     coh."name" AS cohort_name,
-    racbc.average_risk_by_cohort_component,
+    COALESCE(racbc.average_risk_by_cohort_component, 0) AS average_risk_by_cohort_component,
     a.version_number AS poll_version
 FROM ResolvedAnswers a
 JOIN poll_variable pv ON a.poll_variable_id = pv."Id"
@@ -144,10 +103,10 @@ LEFT JOIN RiskAverageByVariable rav ON v."Id" = rav.variable_id
 LEFT JOIN RiskCountByPollInstance rcbi ON a.poll_instance_id = rcbi.poll_instance_id
 LEFT JOIN RiskAvgByCohortComponent racbc ON racbc.cohort_id = sc.cohort_id AND racbc.component_id = c."Id"
 GROUP BY
-    p."Id", poll_uuid, v.component_id, component_name, a.poll_variable_id,
-    question, v.position, a.answer_text, a.poll_instance_id, sc.student_id,
-    rcbi.student_name, rcbi.student_email, pc.answer_count, pc.answer_percentage,
+    p."Id", p."uuid", v.component_id, c."name", a.poll_variable_id,
+    v."name", v.position, a.answer_text, a.poll_instance_id, sc.student_id,
+    rcbi.student_name, rcbi.student_email, a.risk_level, 
     rcbi.poll_instance_risk_sum, rcbi.poll_instance_answers_count,
-    rac.average_risk, rav.average_risk, sc.cohort_id, coh."name",
-    racbc.average_risk_by_cohort_component, c."name", a.risk_level, poll_version
+    rac.average_risk, rav.average_risk, pc.answer_count, pc.answer_percentage,
+    sc.cohort_id, coh."name", racbc.average_risk_by_cohort_component, a.version_number
 ORDER BY a.poll_variable_id, pc.answer_percentage DESC;


### PR DESCRIPTION
## Description

Resolved 400 Bad Request error in poll reports caused by NULL values in AnswerPercentage column.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


