### PR TITLE
hotfix: allow empty string in answers

### DIFF
--- a/src/Eras.Application/Dtos/AnswerDTO.cs
+++ b/src/Eras.Application/Dtos/AnswerDTO.cs
@@ -6,8 +6,7 @@ namespace Eras.Application.DTOs;
 
 public class AnswerDTO
 {
-    [Required(ErrorMessage = "Answer text is required.")]
-    [StringLength(500, MinimumLength = 1, ErrorMessage = "Answer must be between 1 and 500 characters.")]
+    [StringLength(500, MinimumLength = 0, ErrorMessage = "Answer must be between 0 and 500 characters.")]
     [NoSqlInjection]
     public string Answer { get; set; } = string.Empty;
 


### PR DESCRIPTION
## Description



## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


