### PR TITLE
hotfix: increase answer_text max length

### DIFF
--- a/src/Eras.Application/Dtos/AnswerDTO.cs
+++ b/src/Eras.Application/Dtos/AnswerDTO.cs
@@ -6,7 +6,7 @@ namespace Eras.Application.DTOs;
 
 public class AnswerDTO
 {
-    [StringLength(500, MinimumLength = 0, ErrorMessage = "Answer must be between 0 and 500 characters.")]
+    [StringLength(1000, MinimumLength = 0, ErrorMessage = "Answer must be between 0 and 500 characters.")]
     [NoSqlInjection]
     public string Answer { get; set; } = string.Empty;
 

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Configurations/AnswerConfiguration.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Configurations/AnswerConfiguration.cs
@@ -22,7 +22,7 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Configurations
             Builder.HasKey(Answer => Answer.Id);
             Builder.Property(Answer => Answer.AnswerText)
                 .HasColumnName("answer_text")
-                .HasMaxLength(500)
+                .HasMaxLength(1000)
                 .IsRequired();
             Builder.Property(Answer => Answer.RiskLevel)
                 .HasColumnName("risk_level")

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260617202357_UpdateAnswerTextMaxLength.Designer.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260617202357_UpdateAnswerTextMaxLength.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Eras.Infrastructure.Persistence.PostgreSQL;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260617202357_UpdateAnswerTextMaxLength")]
+    partial class UpdateAnswerTextMaxLength
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260617202357_UpdateAnswerTextMaxLength.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260617202357_UpdateAnswerTextMaxLength.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Eras.Infrastructure.Persistence.PostgreSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateAnswerTextMaxLength : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "answer_text",
+                table: "answers",
+                type: "character varying(1000)",
+                maxLength: 1000,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"DROP VIEW IF EXISTS vErasCalculationByPoll;");
+            migrationBuilder.Sql(@"DROP VIEW IF EXISTS vErasEvaluationDetails;");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "answer_text",
+                table: "answers",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(1000)",
+                oldMaxLength: 1000);
+            var viewsPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Persistence", "PostgreSQL", "Views" ,"Ups");
+            using StreamReader calcReader = new StreamReader(Path.Combine(viewsPath,"vErasCalculationByPoll.sql"));
+            var calcViewScript = calcReader.ReadToEnd();
+            migrationBuilder.Sql(calcViewScript);
+
+            using StreamReader evalReader = new StreamReader(Path.Combine(viewsPath,"vErasEvaluationDetails.sql"));
+            var evalReaderScript = evalReader.ReadToEnd();
+            migrationBuilder.Sql(evalReaderScript);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Increased max length for Answers.answer_text from 500 to 1000.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


