### PR TITLE
fix: update message regarding count of createdStudents and updatedStudents

### DIFF
--- a/src/Eras.Application/Features/Students/Commands/CreateStudent/CreateStudentsCommandHandler.cs
+++ b/src/Eras.Application/Features/Students/Commands/CreateStudent/CreateStudentsCommandHandler.cs
@@ -70,9 +70,6 @@ namespace Eras.Application.Features.Students.Commands.CreateStudent
                         }
                         else if (studentCreatedOrChanged.Success)
                         {
-                            if (studentCreatedOrChanged.SuccessfullImports == 0)
-                                updatedStudents.Add(studentCreatedOrChanged.Entity!);
-
                             bool studentAlreadyHasDetail = studentCreatedOrChanged.Entity!.StudentDetail?.Id != 0;
                             
                             if (!HasDefaultDetailData(dto) && !studentAlreadyHasDetail)
@@ -81,8 +78,14 @@ namespace Eras.Application.Features.Students.Commands.CreateStudent
                                     await CreateStudentDetailAsync(studentCreatedOrChanged.Entity!, dto);
                                 studentCreatedOrChanged.Entity!.StudentDetail = createdStudentDetail.Entity!;
                             }
-
-                            createdStudents.Add(studentCreatedOrChanged.Entity);
+                            if (studentCreatedOrChanged.SuccessfullImports == 0)
+                            {
+                                updatedStudents.Add(studentCreatedOrChanged.Entity!);
+                            }
+                            else
+                            {
+                                createdStudents.Add(studentCreatedOrChanged.Entity);
+                            }
                         }
                     } else
                     {

--- a/src/Eras.Application/Features/Students/Commands/UpdateStudent/UpdateStudentCommandHandler.cs
+++ b/src/Eras.Application/Features/Students/Commands/UpdateStudent/UpdateStudentCommandHandler.cs
@@ -36,7 +36,7 @@ namespace Eras.Application.Features.Students.Commands.UpdateStudent
 
                 Student student = Request.StudentDTO.ToDomain();
                 Student studentUpdated = await _studentRepository.UpdateAsync(student);
-                return new CreateCommandResponse<Student>(studentUpdated, 1, "Success", true);
+                return new CreateCommandResponse<Student>(studentUpdated, 0, "Success", true);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Description

The message of updated students was changed by updatedStudents by the code number 0 in UpdateStudentCommandHandler, and the students details are working for both cases.

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues

#448 