### PR TITLE
fix: deduplicate poll instances per student

### DIFF
--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Views/Ups/vErasCalculationByPoll.sql
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Views/Ups/vErasCalculationByPoll.sql
@@ -1,17 +1,25 @@
 DROP VIEW IF EXISTS vErasCalculationByPoll;
 CREATE VIEW vErasCalculationByPoll AS
-WITH ResolvedAnswers AS (
+WITH LatestPollInstancePerStudent AS (
+    SELECT DISTINCT ON (pi."StudentId", pi."uuid")
+        pi."Id"
+    FROM poll_instances pi
+    ORDER BY pi."StudentId", pi."uuid", pi."FinishedAt" DESC
+),
+ResolvedAnswers AS (
     SELECT 
         a."Id", a.poll_instance_id, a.poll_variable_id, a.answer_text, a.risk_level, a.version_number
     FROM answers a
     JOIN poll_instances pi ON pi."Id" = a.poll_instance_id
     WHERE pi."SourcePollInstanceId" IS NULL
+      AND pi."Id" IN (SELECT "Id" FROM LatestPollInstancePerStudent)
     UNION ALL
     SELECT
         a."Id", pi."Id" AS poll_instance_id, a.poll_variable_id, a.answer_text, a.risk_level, a.version_number
     FROM poll_instances pi
     JOIN answers a ON a.poll_instance_id = pi."SourcePollInstanceId"
     WHERE pi."SourcePollInstanceId" IS NOT NULL
+      AND pi."Id" IN (SELECT "Id" FROM LatestPollInstancePerStudent)
 ),
 PercentageCalc AS (
     SELECT


### PR DESCRIPTION
## Description

- Tooltip emails show each student exactly once, under their most recent answer
- Answer percentages are recalculated based on unique students only
- Total student count per question is accurate

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


