### PR TITLE
feat: add update assessment handler to restrict student removal involved in intervention

### DIFF
--- a/src/Eras.Api/Controllers/AssessmentManagement/AssessmentsController.cs
+++ b/src/Eras.Api/Controllers/AssessmentManagement/AssessmentsController.cs
@@ -92,8 +92,18 @@ public class AssessmentsController(IMediator Mediator, ILogger<AssessmentsContro
         if (dto.Id == default)
             return BadRequest("Route id must match payload id.");
 
-        var response = await Mediator.Send(new UpdateRemissionCommand(dto with { Id = id }), cancellationToken);
-        return Ok(response);
+        try
+        {
+            var response = await Mediator.Send(new UpdateRemissionCommand(dto with { Id = id }), cancellationToken);
+            return Ok(response);
+        }
+        catch (OperationCanceledException ex)
+        {
+            return Conflict(new
+            {
+                message = ex.Message
+            });
+        }
     }
 
     [HttpDelete("{id:int}")]

--- a/src/Eras.Application/Contracts/Persistence/AssessmentManagement/IAssessmentRepository.cs
+++ b/src/Eras.Application/Contracts/Persistence/AssessmentManagement/IAssessmentRepository.cs
@@ -26,4 +26,6 @@ public interface IAssessmentRepository : IBaseRepository<Assessment>
 
     Task<Intervention?> GetInterventionByIdAsync(int interventionId);
     Task RemoveAttachmentAsync(int interventionId, string relativePath);
+
+    Task<IEnumerable<Intervention>> GetInterventionsContainingStudentAsync(Assessment entity, IReadOnlyCollection<int> studentToRemoveIds);
 }

--- a/src/Eras.Application/Contracts/Persistence/AssessmentManagement/IBaseRepository{T}.cs
+++ b/src/Eras.Application/Contracts/Persistence/AssessmentManagement/IBaseRepository{T}.cs
@@ -9,6 +9,7 @@ public interface IBaseRepository<T>
 
     Task<T?> GetByIdAsync(Guid id);
     Task<T?> GetByIdAsync(int id);
+    Task<T?> GetByIdNoTrackingAsync(int id);
     Task<IEnumerable<T>> GetAllAsync();
     Task<IEnumerable<T>> GetPagedAsync(int page, int pageSize);
     Task<int> CountAsync();

--- a/src/Eras.Application/Features/RemissionManagement/Handlers/UpdateRemissionCommandHandler.cs
+++ b/src/Eras.Application/Features/RemissionManagement/Handlers/UpdateRemissionCommandHandler.cs
@@ -10,6 +10,8 @@ using FluentValidation;
 
 using MediatR;
 
+using Microsoft.Extensions.Logging;
+
 namespace Eras.Application.Features.RemissionManagement.Handlers;
 
 public sealed class UpdateRemissionCommandHandler
@@ -19,29 +21,46 @@ public sealed class UpdateRemissionCommandHandler
     private readonly IMapper<Assessment, AssessmentDto> _toDtoMapper;
     private readonly IValidator<Assessment> _validator;
     private readonly IAssessmentRepository _repository;
+    private readonly ILogger<UpdateRemissionCommandHandler> _logger;
 
     public UpdateRemissionCommandHandler(
         IMapper<AssessmentDto, Assessment> toDomainMapper,
         IMapper<Assessment, AssessmentDto> toDtoMapper,
         IValidator<Assessment> validator,
-        IAssessmentRepository repository)
+        IAssessmentRepository repository,
+        ILogger<UpdateRemissionCommandHandler> logger)
     {
         _toDomainMapper = toDomainMapper;
         _toDtoMapper = toDtoMapper;
         _validator = validator;
         _repository = repository;
+        _logger = logger;
     }
 
     public async Task<AssessmentDto> Handle(
         UpdateRemissionCommand request,
         CancellationToken cancellationToken)
     {
-        Assessment entity = _toDomainMapper.Map(request.Remission);
+            Assessment entity = _toDomainMapper.Map(request.Remission);
 
-        await ValidationHelper.ValidateAndThrowAsync(_validator, entity, cancellationToken);
+            await ValidationHelper.ValidateAndThrowAsync(_validator, entity, cancellationToken);
 
-        Assessment persisted = await _repository.UpdateAsync(entity);
+            Assessment existing = await _repository.GetByIdNoTrackingAsync(entity.Id);
 
-        return _toDtoMapper.Map(persisted);
+            var removedStudentIds = existing.StudentIds.Except(entity.StudentIds).ToList();
+
+            if (removedStudentIds.Count > 0)
+            {
+                var affectedInterventions = await _repository.GetInterventionsContainingStudentAsync(existing, removedStudentIds);
+                if (affectedInterventions.ToList().Count > 0)
+                {
+                    _logger.LogError("Error updating assessment: Some students cannot be removed. Since they have interventions related.");
+                    throw new Exception($"Error updating assessment: Some students cannot be removed. Since they have interventions related.");
+                }
+            }
+
+            Assessment persisted = await _repository.UpdateAsync(entity);
+
+            return _toDtoMapper.Map(persisted);
     }
 }

--- a/src/Eras.Application/Features/RemissionManagement/Handlers/UpdateRemissionCommandHandler.cs
+++ b/src/Eras.Application/Features/RemissionManagement/Handlers/UpdateRemissionCommandHandler.cs
@@ -54,8 +54,8 @@ public sealed class UpdateRemissionCommandHandler
                 var affectedInterventions = await _repository.GetInterventionsContainingStudentAsync(existing, removedStudentIds);
                 if (affectedInterventions.ToList().Count > 0)
                 {
-                    _logger.LogError("Error updating assessment: Some students cannot be removed. Since they have interventions related.");
-                    throw new Exception($"Error updating assessment: Some students cannot be removed. Since they have interventions related.");
+                    _logger.LogError("Cannot update assessment {AssessmentId}: student(s) {StudentIds} have related interventions.", entity.Id, string.Join(",", removedStudentIds));
+                    throw new OperationCanceledException($"Error updating assessment: Some students cannot be removed. Since they have interventions related.");
                 }
             }
 

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/AssessmentRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/AssessmentRepository.cs
@@ -1,6 +1,7 @@
 ﻿using Eras.Application.Contracts.Persistence.AssessmentManagement;
 using Eras.Domain.Entities;
 using Eras.Domain.Entities.AssessmentManagement;
+using Eras.Error.Critical;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -169,5 +170,29 @@ public sealed class AssessmentRepository(AppDbContext context, ILogger<Assessmen
             .CurrentValue = updatedHashes.AsReadOnly();
 
         await _context.SaveChangesAsync();
+    }
+
+    public async Task<IEnumerable<Intervention>> GetInterventionsContainingStudentAsync(Assessment entity, IReadOnlyCollection<int> studentToRemoveIds)
+    {
+        try
+        {
+            var assessment = await _context.Set<Assessment>()
+                .AsNoTracking()
+                .Include(a => a.Interventions)
+                .FirstOrDefaultAsync(a => a.Id == entity.Id);
+
+            if (assessment == null)
+            {
+                return new List<Intervention>();
+            }
+
+            return assessment.Interventions
+                .Where(i => i.StudentIds.Any(studentToRemoveIds.Contains))
+                .ToList();
+        }
+        catch (Exception e)
+        {
+            throw new DatabaseCustomException(e);
+        }
     }
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/AssessmentRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/AssessmentRepository.cs
@@ -192,7 +192,7 @@ public sealed class AssessmentRepository(AppDbContext context, ILogger<Assessmen
         }
         catch (Exception e)
         {
-            throw new DatabaseCustomException(e);
+            throw;
         }
     }
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/BaseRepository{T}.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/BaseRepository{T}.cs
@@ -1,4 +1,6 @@
-﻿namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories.AssessmentManagement;
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories.AssessmentManagement;
 
 public class BaseRepository<T>(AppDbContext context) : BaseRepository<T, T>(context, x => x, x => x)
     where T: class
@@ -17,6 +19,17 @@ public class BaseRepository<T>(AppDbContext context) : BaseRepository<T, T>(cont
         T? persistenceEntity = await _context.Set<T>().FindAsync(id);
         if (persistenceEntity is T found)
         {
+            return found;
+        }
+        return null;
+    }
+
+    public async Task<T?> GetByIdNoTrackingAsync(int id)
+    {
+        T? persistenceEntity = await _context.Set<T>().FindAsync(id);
+        if (persistenceEntity is T found)
+        {
+            _context.Entry(persistenceEntity).State = EntityState.Detached;
             return found;
         }
         return null;

--- a/test/Eras.Application.Tests/Features/Assessments/Commands/UpdateRemissionCommandHandlerTests.cs
+++ b/test/Eras.Application.Tests/Features/Assessments/Commands/UpdateRemissionCommandHandlerTests.cs
@@ -1,0 +1,101 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+using Eras.Application.Contracts.Persistence.AssessmentManagement;
+using Eras.Application.DTOs.AssessmentManagement;
+using Eras.Application.Features.RemissionManagement;
+using Eras.Application.Features.RemissionManagement.Handlers;
+using Eras.Application.Mappers.AssessmentManagement;
+using Eras.Domain.Entities.AssessmentManagement;
+
+using FluentValidation;
+using FluentValidation.Results;
+
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+namespace Eras.Application.Tests.Features.Assessments.Commands;
+
+public class UpdateRemissionCommandHandlerTests
+{
+    private readonly Mock<ILogger<UpdateRemissionCommandHandler>> _mockLogger;
+    private readonly Mock<IMapper<AssessmentDto, Assessment>> _toDomainMapper;
+    private readonly Mock<IMapper<Assessment, AssessmentDto>> _toDtoMapper;
+    private readonly Mock<IValidator<Assessment>> _validator;
+    private readonly UpdateRemissionCommandHandler _handler;
+    private readonly Mock<IAssessmentRepository> _mockRepository;
+
+    public UpdateRemissionCommandHandlerTests()
+    {
+        _mockRepository = new Mock<IAssessmentRepository>();
+        _mockLogger = new Mock<ILogger<UpdateRemissionCommandHandler>>();
+        _validator = new Mock<IValidator<Assessment>>();
+        _toDomainMapper = new Mock<IMapper<AssessmentDto, Assessment>>();
+        _toDtoMapper = new Mock<IMapper<Assessment, AssessmentDto>>();
+        _handler = new UpdateRemissionCommandHandler(
+            _toDomainMapper.Object,
+            _toDtoMapper.Object,
+            _validator.Object, 
+            _mockRepository.Object, 
+            _mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task HandleUpdateRemissionAsync()
+    {
+        var dto = new AssessmentDto
+        {
+            Id = 1,
+            StudentIds = [1, 2],
+            CreatedBy = "",
+            Service = "",
+            Status = AssessmentStatus.OnHold,
+        };
+        var command = new UpdateRemissionCommand(dto);
+
+        var mappedEntity = new Assessment
+        {
+            Id = 1,
+            CreatedBy = "Any",
+            Service = "Smth",
+            Status = AssessmentStatus.OnHold,
+            StudentIds = [1, 2]
+        };
+
+        var existingEntity = new Assessment
+        {
+            Id = 1,
+            CreatedBy = "Any",
+            Service = "Smth",
+            Status = AssessmentStatus.OnHold,
+            StudentIds = [1, 2]
+        };
+
+        var persistedEntity = mappedEntity;
+        var expectedDto = new AssessmentDto { 
+            Id = 1, 
+            StudentIds = [1, 2], 
+            CreatedBy = "",
+            Service = "",
+            Status= AssessmentStatus.OnHold,
+        };
+
+        _toDomainMapper.Setup(m => m.Map(dto)).Returns(mappedEntity);
+        _validator
+            .Setup(v => v.ValidateAsync(It.IsAny<Assessment>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FluentValidation.Results.ValidationResult());
+        _mockRepository.Setup(r => r.GetByIdNoTrackingAsync(1)).ReturnsAsync(existingEntity);
+        _mockRepository.Setup(r => r.UpdateAsync(mappedEntity)).ReturnsAsync(persistedEntity);
+        _toDtoMapper.Setup(m => m.Map(persistedEntity)).Returns(expectedDto);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expectedDto.Id, result.Id);
+        _mockRepository.Verify(r => r.GetInterventionsContainingStudentAsync(
+            It.IsAny<Assessment>(), It.IsAny<IReadOnlyCollection<int>>()), Times.Never);
+        _mockRepository.Verify(r => r.UpdateAsync(mappedEntity), Times.Once);
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Entities/TestIntervention.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Entities/TestIntervention.cs
@@ -1,0 +1,9 @@
+﻿
+using Eras.Domain.Entities.AssessmentManagement;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Entities;
+
+internal sealed class TestIntervention : Intervention
+{
+    public override InterventionKind Kind => InterventionKind.Group; // pick any valid enum value
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/AssessmentRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/AssessmentRepositoryTest.cs
@@ -1,0 +1,184 @@
+﻿using Eras.Domain.Entities.AssessmentManagement;
+using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories.AssessmentManagement;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Entities;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+using MockQueryable.Moq;
+
+using Moq;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+
+public class AssessmentRepositoryTest
+{
+    private Mock<AppDbContext> _mockContext;
+    private readonly Mock<ILogger<AssessmentRepository>> _mockLogger;
+    private AssessmentRepository _repository;
+
+    public AssessmentRepositoryTest()
+    {
+        _mockContext = new Mock<AppDbContext>(new DbContextOptions<AppDbContext>());
+        _mockLogger = new Mock<ILogger<AssessmentRepository>>();
+        _repository = new AssessmentRepository(_mockContext.Object, _mockLogger.Object);
+    }
+
+    private static TestIntervention BuildIntervention(int id, params int[] studentIds)
+    {
+        return new TestIntervention
+        {
+            Id = id,
+            DateUtc = DateTime.UtcNow,
+            StudentIds = studentIds,
+            Mode = InterventionMode.InPlace
+        };
+    }
+
+    private void SetupAssessments(params Assessment[] assessments)
+    {
+        var mockSet = assessments.AsQueryable().BuildMockDbSet();
+        _mockContext.Setup(c => c.Set<Assessment>()).Returns(mockSet.Object);
+    }
+
+    [Fact]
+    public void GetInterventionsContainingStudent_Should_Return()
+    {
+        // Arrange
+        var interventions = new List<Intervention>
+        {
+            BuildIntervention(1, 1, 2),
+            BuildIntervention(2, 3, 4)
+        };
+        
+        var assessment = new Assessment
+        {
+            Id = 1,
+            CreatedBy = "Any",
+            Service = "Smth",
+            Status = AssessmentStatus.OnHold,
+            StudentIds = [1, 2, 3, 4],
+            Interventions = interventions
+        };
+        SetupAssessments(assessment);
+
+        // Act
+        var result = _repository.GetInterventionsContainingStudentAsync(assessment, [1]);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result.Result);
+        Assert.Equal(1, result.Result.First().Id);
+    }
+
+    [Fact]
+    public void GetInterventionsContainingStudent_ShouldReturn_MultipleMatches()
+    {
+        // Arrange
+        var interventions = new List<Intervention>
+        {
+            BuildIntervention(1, 1, 2),
+            BuildIntervention(2, 2, 3),
+            BuildIntervention(3, 4, 5)
+        };
+
+        var assessment = new Assessment
+        {
+            Id = 1,
+            CreatedBy = "Any",
+            Service = "Smth",
+            Status = AssessmentStatus.OnHold,
+            StudentIds = [1, 2, 3],
+            Interventions = interventions
+        };
+
+        SetupAssessments(assessment);
+
+        // Act
+        var result = _repository.GetInterventionsContainingStudentAsync(assessment, [2]);
+
+        // Assert
+        Assert.Equal(2, result.Result.Count());
+        Assert.Contains(result.Result, i => i.Id == 1);
+        Assert.Contains(result.Result, i => i.Id == 2);
+    }
+
+    [Fact]
+    public void GetInterventionsContainingAnyStudent_Should_ReturnEmpty_When_NoMatch()
+    {
+        // Arrange
+        var interventions = new List<Intervention>
+        {
+            BuildIntervention(1, 1, 2)
+        };
+        var assessment = new Assessment
+        {
+            Id = 1,
+            CreatedBy = "Any",
+            Service = "Smth",
+            Status = AssessmentStatus.OnHold,
+            StudentIds = [1, 2, 3],
+            Interventions = interventions
+        };
+
+        SetupAssessments(assessment);
+
+        // Act
+        var result = _repository.GetInterventionsContainingStudentAsync(assessment, [3]);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result.Result);
+    }
+
+    [Fact]
+    public void GetInterventionsContainingStudentAsync_Should_ReturnEmpty_When_AssessmentHasNoInterventions()
+    {
+        // Arrange
+        var assessment = new Assessment
+        {
+            Id = 1,
+            CreatedBy = "Any",
+            Service = "Smth",
+            Status = AssessmentStatus.OnHold,
+            StudentIds = [1, 2],
+            Interventions = new List<Intervention>()
+        };
+
+        SetupAssessments(assessment);
+
+        // Act
+        var result = _repository.GetInterventionsContainingStudentAsync(assessment, [1]);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result.Result);
+    }
+
+    [Fact]
+    public async Task GetInterventionsContainingStudent_Should_ReturnEmpty_When_StudentIdsListIsEmpty()
+    {
+        // Arrange
+        var interventions = new List<Intervention> { BuildIntervention(1, 1, 2) };
+        var assessment = new Assessment
+        {
+            Id = 1,
+            CreatedBy = "Any",
+            Service = "Smth",
+            Status = AssessmentStatus.OnHold,
+            StudentIds = [1, 2],
+            Interventions = interventions
+        };
+
+        SetupAssessments(assessment);
+
+        // Act
+        var result = await _repository.GetInterventionsContainingStudentAsync(assessment, []);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+}


### PR DESCRIPTION
## Description

- The update assessment handler now verifies before removing the students which are involved to an intervention already created.
- An exception is raised to show the update has not been completed.
- A new method in repository was added to know if the students belong to an intervention of the same assessment.
- The unit tests for those methods were added.

## Type of change

- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [X] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


