### PR TITLE
Refactor: Update status of assessments and interventions

### DIFF
--- a/src/Eras.Application/DTOs/AssessmentManagement/InterventionDto.cs
+++ b/src/Eras.Application/DTOs/AssessmentManagement/InterventionDto.cs
@@ -28,7 +28,7 @@ public abstract record InterventionDto
     public IReadOnlyDictionary<int, bool> Attendance { get; init; } = new Dictionary<int, bool>();
 
     public InterventionMode Mode { get; init; }
-    public InterventionStatus Status { get; init; } = InterventionStatus.Created;
+    public InterventionStatus Status { get; init; } = InterventionStatus.Remitted;
     public string? Remarks { get; init; }
     public IReadOnlyCollection<string> Attachments { get; init; } = Array.Empty<string>();
     public double? RiskLevel { get; init; }

--- a/src/Eras.Domain/Entities/AssessmentManagement/AssessmentStatus.cs
+++ b/src/Eras.Domain/Entities/AssessmentManagement/AssessmentStatus.cs
@@ -2,10 +2,7 @@
 
 public enum AssessmentStatus
 {
-    Created = 0,
-    Remitted = 1,
-    OnHold = 2,
-    InProgress = 3,
-    Resolved = 4,
-    Rejected = 5
+    Remitted = 0,
+    InProgress = 1,
+    Finalized = 2
 }

--- a/src/Eras.Domain/Entities/AssessmentManagement/Intervention.cs
+++ b/src/Eras.Domain/Entities/AssessmentManagement/Intervention.cs
@@ -15,7 +15,7 @@ public abstract class Intervention : BaseEntity
     public IReadOnlyDictionary<int, bool> Attendance { get; init; } = new Dictionary<int, bool>();
 
     public InterventionMode Mode { get; init; }
-    public InterventionStatus Status { get; init; } = InterventionStatus.Created;
+    public InterventionStatus Status { get; init; } = InterventionStatus.Remitted;
     public string? Remarks { get; init; }
 
     public abstract InterventionKind Kind { get; }

--- a/src/Eras.Domain/Entities/AssessmentManagement/InterventionStatus.cs
+++ b/src/Eras.Domain/Entities/AssessmentManagement/InterventionStatus.cs
@@ -2,9 +2,7 @@ namespace Eras.Domain.Entities.AssessmentManagement;
 
 public enum InterventionStatus
 {
-    Created,
-    InProgress,
-    OnHold,
     Remitted,
-    Resolved
+    InProgress,
+    Finalized
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Configurations/AssessmentManagement/InterventionConfiguration.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Configurations/AssessmentManagement/InterventionConfiguration.cs
@@ -45,7 +45,7 @@ public sealed class InterventionConfiguration : IEntityTypeConfiguration<Interve
         builder.Property(e => e.Status)
             .HasColumnName("status")
             .HasConversion<string>()
-            .HasDefaultValue(InterventionStatus.Created);
+            .HasDefaultValue(InterventionStatus.Remitted);
 
         builder.Property(e => e.Remarks)
             .HasColumnName("remarks")

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260706165707_RenameStatusesInterventionsAssessment.Designer.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260706165707_RenameStatusesInterventionsAssessment.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Eras.Infrastructure.Persistence.PostgreSQL;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260706165707_RenameStatusesInterventionsAssessment")]
+    partial class RenameStatusesInterventionsAssessment
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -196,7 +199,7 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Migrations
                     b.UseTphMappingStrategy();
                 });
 
-            modelBuilder.Entity("Eras.Domain.Entities.FeatureFlag", b =>
+            modelBuilder.Entity("Eras.Domain.Entities.FeatureFlagManagement.FeatureFlag", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260706165707_RenameStatusesInterventionsAssessment.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260706165707_RenameStatusesInterventionsAssessment.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Eras.Infrastructure.Persistence.PostgreSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class RenameStatusesInterventionsAssessment : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "status",
+                table: "Interventions",
+                defaultValue: "Remitted",
+                oldDefaultValue: "Created");
+            migrationBuilder.Sql(@"
+                UPDATE remissions
+                SET status = 'Remitted'
+                WHERE status = 'Created';
+
+                UPDATE remissions
+                SET status = 'Finalized'
+                WHERE status = 'Resolved';
+            ");
+
+            migrationBuilder.Sql(@"
+                UPDATE ""Interventions""
+                SET status = 'Remitted'
+                WHERE status = 'Created';
+
+                UPDATE ""Interventions""
+                SET status = 'Finalized'
+                WHERE status = 'Resolved';
+            ");
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "status",
+                table: "Interventions",
+                defaultValue: "Created",
+                oldDefaultValue: "Remitted");
+            migrationBuilder.Sql(@"
+                UPDATE remissions
+                SET status = 'Created'
+                WHERE status = 'Remitted';
+
+                UPDATE remissions
+                SET status = 'Resolved'
+                WHERE status = 'Finalized';
+            ");
+
+            migrationBuilder.Sql(@"
+                UPDATE ""Interventions""
+                SET status = 'Created'
+                WHERE status = 'Remitted';
+
+                UPDATE ""Interventions""
+                SET status = 'Resolved'
+                WHERE status = 'Finalized';
+            ");
+        }
+    }
+}

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260706165707_RenameStatusesInterventionsAssessment.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260706165707_RenameStatusesInterventionsAssessment.cs
@@ -23,6 +23,10 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Migrations
                 UPDATE remissions
                 SET status = 'Finalized'
                 WHERE status = 'Resolved';
+
+                UPDATE remissions
+                SET status = 'InProgress'
+                WHERE status IN ('OnHold', 'Rejected');
             ");
 
             migrationBuilder.Sql(@"
@@ -33,6 +37,10 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Migrations
                 UPDATE ""Interventions""
                 SET status = 'Finalized'
                 WHERE status = 'Resolved';
+
+                UPDATE ""Interventions""
+                SET status = 'InProgress'
+                WHERE status IN ('OnHold', 'Rejected');
             ");
 
         }

--- a/test/Eras.Application.Tests/Features/Assessments/Commands/AddInterventionCommandHandlerTests.cs
+++ b/test/Eras.Application.Tests/Features/Assessments/Commands/AddInterventionCommandHandlerTests.cs
@@ -100,9 +100,7 @@ public class AddInterventionCommandHandlerTests
         _mockIndividualMapper.Verify(m => m.Map(dto), Times.Once);
         _mockRepository.Verify(r => r.AddInterventionAsync(1, mappedIntervention), Times.Once);
 
-        //_mockGroupMapper.Verify(
-        //    m => m.Map(It.IsAny<GroupInterventionDto>()),
-        //    Times.Never);
+        _mockGroupMapper.Verify(m => m.Map(It.IsAny<GroupInterventionDto>()), Times.Never);
     }
 
     [Fact]
@@ -170,5 +168,7 @@ public class AddInterventionCommandHandlerTests
         _mockRepository.Verify(r => r.GetByIdWithInterventionsAsync(1), Times.Once);
         _mockGroupMapper.Verify(m => m.Map(dto), Times.Once);
         _mockRepository.Verify(r => r.AddInterventionAsync(1, mappedIntervention), Times.Once);
+
+        _mockIndividualMapper.Verify(m => m.Map(It.IsAny<IndividualInterventionDto>()), Times.Never);
     }
 }

--- a/test/Eras.Application.Tests/Features/Assessments/Commands/AddInterventionCommandHandlerTests.cs
+++ b/test/Eras.Application.Tests/Features/Assessments/Commands/AddInterventionCommandHandlerTests.cs
@@ -1,0 +1,174 @@
+﻿
+using Eras.Application.Contracts.Persistence.AssessmentManagement;
+using Eras.Application.DTOs.AssessmentManagement;
+using Eras.Application.Features.RemissionManagement;
+using Eras.Application.Features.RemissionManagement.Handlers;
+using Eras.Application.Mappers.AssessmentManagement;
+using Eras.Domain.Entities.AssessmentManagement;
+
+using Moq;
+
+namespace Eras.Application.Tests.Features.Assessments.Commands;
+
+internal sealed class TestIntervention : Intervention
+{
+    public override InterventionKind Kind => InterventionKind.Individual;
+}
+
+public class AddInterventionCommandHandlerTests
+{
+    private readonly Mock<IAssessmentRepository> _mockRepository;
+    private readonly Mock<IMapper<IndividualInterventionDto, IndividualIntervention>> _mockIndividualMapper;
+    private readonly Mock<IMapper<GroupInterventionDto, GroupIntervention>> _mockGroupMapper;
+    private readonly AddInterventionCommandHandler _handler;
+
+    public AddInterventionCommandHandlerTests()
+    {
+        _mockRepository = new Mock<IAssessmentRepository>();
+        _mockIndividualMapper = new Mock<IMapper<IndividualInterventionDto, IndividualIntervention>>();
+        _mockGroupMapper = new Mock<IMapper<GroupInterventionDto, GroupIntervention>>();
+        _handler = new AddInterventionCommandHandler(
+            _mockRepository.Object,
+            _mockIndividualMapper.Object,
+            _mockGroupMapper.Object);
+    }
+
+    [Fact]
+    public async Task HandleAddIndividualIntervention()
+    {
+        // Arrange
+        var dto = new IndividualInterventionDto
+        {
+            DateUtc = DateTime.UtcNow,
+            Status = InterventionStatus.Remitted,
+            StudentIds = [1],
+            Activity = "Interview"
+        };
+
+        var command = new AddInterventionCommand(1, dto);
+
+        var assessment = new Assessment
+        {
+            Id = 1,
+            CreatedBy = "",
+            Service = "",
+            Status = AssessmentStatus.Remitted,
+            StudentIds = [1, 2]
+        };
+
+        var mappedIntervention = new IndividualIntervention
+        {
+            DateUtc = dto.DateUtc,
+            Status = dto.Status,
+            StudentIds = dto.StudentIds,
+            Activity = dto.Activity
+        };
+
+        var persisted = new IndividualIntervention
+        {
+            Id = 10,
+            DateUtc = dto.DateUtc,
+            Status = dto.Status,
+            StudentIds = dto.StudentIds,
+            Activity = dto.Activity
+        };
+
+        _mockRepository
+            .Setup(r => r.GetByIdWithInterventionsAsync(1))
+            .ReturnsAsync(assessment);
+
+        _mockIndividualMapper
+            .Setup(m => m.Map(dto))
+            .Returns(mappedIntervention);
+
+        _mockRepository
+            .Setup(r => r.AddInterventionAsync(1, mappedIntervention))
+            .ReturnsAsync(persisted);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsType<IndividualInterventionDto>(result);
+
+        Assert.Equal(10, result.Id);
+        Assert.Equal(dto.Activity, result.Activity);
+        Assert.Equal(dto.Status, result.Status);
+
+        _mockRepository.Verify(r => r.GetByIdWithInterventionsAsync(1), Times.Once);
+        _mockIndividualMapper.Verify(m => m.Map(dto), Times.Once);
+        _mockRepository.Verify(r => r.AddInterventionAsync(1, mappedIntervention), Times.Once);
+
+        //_mockGroupMapper.Verify(
+        //    m => m.Map(It.IsAny<GroupInterventionDto>()),
+        //    Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAddGroupIntervention()
+    {
+        // Arrange
+        var dto = new GroupInterventionDto
+        {
+            DateUtc = DateTime.UtcNow,
+            Status = InterventionStatus.Remitted,
+            StudentIds = [1, 2],
+            Activity = "Interview"
+        };
+
+        var command = new AddInterventionCommand(1, dto);
+
+        var assessment = new Assessment {
+            Id = 1,
+            CreatedBy = "",
+            Service = "",
+            Status = AssessmentStatus.Remitted,
+            StudentIds = [1, 2]
+        };
+
+        var mappedIntervention = new GroupIntervention
+        {
+            DateUtc = dto.DateUtc,
+            Status = dto.Status,
+            StudentIds = dto.StudentIds,
+            Activity = dto.Activity
+        };
+
+        var persisted = new GroupIntervention
+        {
+            Id = 11,
+            DateUtc = dto.DateUtc,
+            Status = dto.Status,
+            StudentIds = dto.StudentIds,
+            Activity = dto.Activity
+        };
+
+        _mockRepository
+            .Setup(r => r.GetByIdWithInterventionsAsync(1))
+            .ReturnsAsync(assessment);
+
+        _mockGroupMapper
+            .Setup(m => m.Map(dto))
+            .Returns(mappedIntervention);
+
+        _mockRepository
+            .Setup(r => r.AddInterventionAsync(1, mappedIntervention))
+            .ReturnsAsync(persisted);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsType<GroupInterventionDto>(result);
+
+        Assert.Equal(11, result.Id);
+        Assert.Equal(dto.Activity, result.Activity);
+        Assert.Equal(dto.Status, result.Status);
+
+        _mockRepository.Verify(r => r.GetByIdWithInterventionsAsync(1), Times.Once);
+        _mockGroupMapper.Verify(m => m.Map(dto), Times.Once);
+        _mockRepository.Verify(r => r.AddInterventionAsync(1, mappedIntervention), Times.Once);
+    }
+}

--- a/test/Eras.Application.Tests/Features/Assessments/Commands/CreateRemissionCommandHandlerTests.cs
+++ b/test/Eras.Application.Tests/Features/Assessments/Commands/CreateRemissionCommandHandlerTests.cs
@@ -1,0 +1,117 @@
+﻿
+using Eras.Application.Contracts.Persistence.AssessmentManagement;
+using Eras.Application.DTOs.AssessmentManagement;
+using Eras.Application.Features.Answers.Commands.CreateAnswer;
+using Eras.Application.Features.RemissionManagement;
+using Eras.Application.Features.RemissionManagement.Handlers;
+using Eras.Application.Mappers.AssessmentManagement;
+using Eras.Domain.Entities.AssessmentManagement;
+
+using FluentValidation;
+
+using Moq;
+
+namespace Eras.Application.Tests.Features.Assessments.Commands;
+
+public class CreateRemissionCommandHandlerTests
+{
+    private readonly Mock<IMapper<AssessmentDto, Assessment>> _toDomainMapper;
+    private readonly Mock<IMapper<Assessment, AssessmentDto>> _toDtoMapper;
+    private readonly Mock<IValidator<Assessment>> _validator;
+    private readonly Mock<IAssessmentRepository> _mockRepository;
+    private readonly CreateRemissionCommandHandler _handler;
+
+    public CreateRemissionCommandHandlerTests()
+    {
+        _mockRepository = new Mock<IAssessmentRepository>();
+        _validator = new Mock<IValidator<Assessment>>();
+        _toDomainMapper = new Mock<IMapper<AssessmentDto, Assessment>>();
+        _toDtoMapper = new Mock<IMapper<Assessment, AssessmentDto>>();
+        _handler = new CreateRemissionCommandHandler(
+            _toDomainMapper.Object,
+            _toDtoMapper.Object,
+            _validator.Object,
+            _mockRepository.Object);
+    }
+
+    [Fact]
+    public async Task HandleCreateRemissionAsync()
+    {
+        //ARRANGE
+        List<StudentProfileDto> studentsData = new() {
+            new StudentProfileDto{
+                Id = 10,
+                Name = "A",
+                Email = "",
+                AvgRiskLevel = 2.3,
+            },
+            new StudentProfileDto{
+                Id = 2,
+                Name = "B",
+                Email = "bb",
+                AvgRiskLevel = 4.3,
+            }
+        };
+        var dto = new AssessmentDto
+        {
+            Id = 1,
+            StudentIds = [10, 2],
+            CreatedBy = "me",
+            Service = "",
+            AssignedProfessional = "AB",
+            Students = studentsData,
+            Comments = "...",
+            Objective = "Goal",
+            Diagnosis = "Nothing",
+            Status = AssessmentStatus.Remitted,
+        };
+        var command = new CreateRemissionCommand(dto);
+
+        var mappedEntity = new Assessment
+        {
+            Id = 1,
+            StudentIds = [10, 2],
+            CreatedBy = "me",
+            Service = "",
+            AssignedProfessional = "AB",
+            Comments = "...",
+            Objective = "Goal",
+            Diagnosis = "Nothing",
+            Status = AssessmentStatus.Remitted,
+        };
+        var persistedEntity = mappedEntity;
+        var expectedDto = new AssessmentDto
+        {
+            Id = 1,
+            StudentIds = [10, 2],
+            CreatedBy = "me",
+            Service = "",
+            AssignedProfessional = "AB",
+            Students = studentsData,
+            Comments = "...",
+            Objective = "Goal",
+            Diagnosis = "Nothing",
+            Status = AssessmentStatus.Remitted,
+        };
+
+        _toDomainMapper.Setup(m => m.Map(dto)).Returns(mappedEntity);
+        _validator
+            .Setup(v => v.ValidateAsync(It.IsAny<Assessment>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FluentValidation.Results.ValidationResult());
+        _mockRepository.Setup(r => r.AddAsync(mappedEntity)).ReturnsAsync(persistedEntity);
+        _toDtoMapper.Setup(m => m.Map(persistedEntity)).Returns(expectedDto);
+
+        //ACT
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        //ASSERT
+        Assert.NotNull(result);
+        Assert.Equal(expectedDto.Id, result.Id);
+        Assert.Equal(expectedDto.CreatedBy, result.CreatedBy);
+        Assert.Equal(expectedDto.Service, result.Service);
+        Assert.Equal(expectedDto.Status, result.Status);
+
+
+    }
+
+}

--- a/test/Eras.Application.Tests/Features/Assessments/Commands/UpdateRemissionCommandHandlerTests.cs
+++ b/test/Eras.Application.Tests/Features/Assessments/Commands/UpdateRemissionCommandHandlerTests.cs
@@ -46,10 +46,10 @@ public class UpdateRemissionCommandHandlerTests
         var dto = new AssessmentDto
         {
             Id = 1,
-            StudentIds = [1, 2],
+            StudentIds = [1, 2, 3],
             CreatedBy = "",
             Service = "",
-            Status = AssessmentStatus.OnHold,
+            Status = AssessmentStatus.Remitted,
         };
         var command = new UpdateRemissionCommand(dto);
 
@@ -58,8 +58,8 @@ public class UpdateRemissionCommandHandlerTests
             Id = 1,
             CreatedBy = "Any",
             Service = "Smth",
-            Status = AssessmentStatus.OnHold,
-            StudentIds = [1, 2]
+            Status = AssessmentStatus.Remitted,
+            StudentIds = [1, 2, 3]
         };
 
         var existingEntity = new Assessment
@@ -67,17 +67,17 @@ public class UpdateRemissionCommandHandlerTests
             Id = 1,
             CreatedBy = "Any",
             Service = "Smth",
-            Status = AssessmentStatus.OnHold,
+            Status = AssessmentStatus.Remitted,
             StudentIds = [1, 2]
         };
 
         var persistedEntity = mappedEntity;
         var expectedDto = new AssessmentDto { 
             Id = 1, 
-            StudentIds = [1, 2], 
+            StudentIds = [1, 2, 3], 
             CreatedBy = "",
             Service = "",
-            Status= AssessmentStatus.OnHold,
+            Status= AssessmentStatus.Remitted,
         };
 
         _toDomainMapper.Setup(m => m.Map(dto)).Returns(mappedEntity);
@@ -94,6 +94,67 @@ public class UpdateRemissionCommandHandlerTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal(expectedDto.Id, result.Id);
+        _mockRepository.Verify(r => r.GetInterventionsContainingStudentAsync(
+            It.IsAny<Assessment>(), It.IsAny<IReadOnlyCollection<int>>()), Times.Never);
+        _mockRepository.Verify(r => r.UpdateAsync(mappedEntity), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleUpdateRemissionStatusAsync()
+    {
+        var dto = new AssessmentDto
+        {
+            Id = 1,
+            StudentIds = [1, 2],
+            CreatedBy = "",
+            Service = "",
+            Status = AssessmentStatus.InProgress,
+        };
+        var command = new UpdateRemissionCommand(dto);
+
+        var mappedEntity = new Assessment
+        {
+            Id = 1,
+            CreatedBy = "",
+            Service = "",
+            Status = AssessmentStatus.InProgress,
+            StudentIds = [1, 2]
+        };
+
+        var existingEntity = new Assessment
+        {
+            Id = 1,
+            CreatedBy = "",
+            Service = "",
+            Status = AssessmentStatus.Remitted,
+            StudentIds = [1, 2]
+        };
+
+        var persistedEntity = mappedEntity;
+        var expectedDto = new AssessmentDto
+        {
+            Id = 1,
+            StudentIds = [1, 2],
+            CreatedBy = "",
+            Service = "",
+            Status = AssessmentStatus.InProgress,
+        };
+
+        _toDomainMapper.Setup(m => m.Map(dto)).Returns(mappedEntity);
+        _validator
+            .Setup(v => v.ValidateAsync(It.IsAny<Assessment>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FluentValidation.Results.ValidationResult());
+        _mockRepository.Setup(r => r.GetByIdNoTrackingAsync(1)).ReturnsAsync(existingEntity);
+        _mockRepository.Setup(r => r.UpdateAsync(mappedEntity)).ReturnsAsync(persistedEntity);
+        _toDtoMapper.Setup(m => m.Map(persistedEntity)).Returns(expectedDto);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expectedDto.Id, result.Id);
+        Assert.Equal(expectedDto.Status, AssessmentStatus.InProgress);
         _mockRepository.Verify(r => r.GetInterventionsContainingStudentAsync(
             It.IsAny<Assessment>(), It.IsAny<IReadOnlyCollection<int>>()), Times.Never);
         _mockRepository.Verify(r => r.UpdateAsync(mappedEntity), Times.Once);

--- a/test/Eras.Application.Tests/Features/Assessments/Queries/GetRemissionsByStatusQueryHandlerTests.cs
+++ b/test/Eras.Application.Tests/Features/Assessments/Queries/GetRemissionsByStatusQueryHandlerTests.cs
@@ -1,0 +1,125 @@
+﻿
+using Eras.Application.Contracts.Persistence.AssessmentManagement;
+using Eras.Application.DTOs.AssessmentManagement;
+using Eras.Application.Features.RemissionManagement;
+using Eras.Application.Features.RemissionManagement.Handlers;
+using Eras.Application.Mappers.AssessmentManagement;
+using Eras.Domain.Entities.AssessmentManagement;
+
+using Moq;
+
+namespace Eras.Application.Tests.Features.Assessments.Queries;
+
+public class GetRemissionsByStatusQueryHandlerTests
+{
+    private readonly Mock<IAssessmentRepository> _mockRepository;
+    private readonly Mock<IMapper<Assessment, AssessmentDto>> _mockMapper;
+    private readonly GetRemissionsByStatusQueryHandler _handler;
+
+    public GetRemissionsByStatusQueryHandlerTests()
+    {
+        _mockRepository = new Mock<IAssessmentRepository>();
+        _mockMapper = new Mock<IMapper<Assessment, AssessmentDto>>();
+
+        _handler = new GetRemissionsByStatusQueryHandler(
+            _mockRepository.Object,
+            _mockMapper.Object);
+    }
+
+    [Fact]
+    public async Task HandleGetMappedRemissionsAsync()
+    {
+        // Arrange
+        var query = new GetRemissionsByStatusQuery(AssessmentStatus.Remitted);
+
+        var entities = new[]
+        {
+            new Assessment
+            {
+                Id = 1,
+                Status = AssessmentStatus.Remitted,
+                StudentIds = [1],
+                CreatedBy = "User1",
+                Service = "Service1"
+            },
+             new Assessment
+            {
+                Id = 2,
+                Status = AssessmentStatus.Remitted,
+                StudentIds = [1],
+                CreatedBy = "User2",
+                Service = "Service2"
+            }
+        };
+        var dto1 = new AssessmentDto
+        {
+            Id = 1,
+            Status = AssessmentStatus.Remitted,
+            StudentIds = [1],
+            CreatedBy = "User2",
+            Service = "Service2"
+        };
+        var dto2 = new AssessmentDto
+        {
+            Id = 2,
+            Status = AssessmentStatus.Remitted,
+            StudentIds = [1],
+            CreatedBy = "User2",
+            Service = "Service2"
+        };
+
+        _mockRepository
+            .Setup(r => r.GetByStatusAsync(AssessmentStatus.Remitted))
+            .ReturnsAsync(entities);
+
+        _mockMapper
+            .Setup(m => m.Map(entities[0]))
+            .Returns(dto1);
+
+        _mockMapper
+            .Setup(m => m.Map(entities[1]))
+            .Returns(dto2);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count);
+
+        Assert.Contains(result, r => r.Id == dto1.Id);
+        Assert.Contains(result, r => r.Id == dto2.Id);
+
+        _mockRepository.Verify(
+            r => r.GetByStatusAsync(AssessmentStatus.Remitted),
+            Times.Once);
+
+        _mockMapper.Verify(m => m.Map(entities[0]), Times.Once);
+        _mockMapper.Verify(m => m.Map(entities[1]), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnEmptyCollection_WhenRepositoryReturnsNoResults()
+    {
+        // Arrange
+        var query = new GetRemissionsByStatusQuery(AssessmentStatus.Remitted);
+
+        _mockRepository
+            .Setup(r => r.GetByStatusAsync(AssessmentStatus.Remitted))
+            .ReturnsAsync(Array.Empty<Assessment>());
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+        _mockRepository.Verify(
+            r => r.GetByStatusAsync(AssessmentStatus.Remitted),
+            Times.Once);
+
+        _mockMapper.Verify(
+            m => m.Map(It.IsAny<Assessment>()),
+            Times.Never);
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/AssessmentRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/AssessmentRepositoryTest.cs
@@ -4,6 +4,7 @@ using Eras.Infrastructure.Persistence.PostgreSQL.Repositories.AssessmentManageme
 using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Entities;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.Extensions.Logging;
 
 using MockQueryable.Moq;
@@ -57,7 +58,7 @@ public class AssessmentRepositoryTest
             Id = 1,
             CreatedBy = "Any",
             Service = "Smth",
-            Status = AssessmentStatus.OnHold,
+            Status = AssessmentStatus.InProgress,
             StudentIds = [1, 2, 3, 4],
             Interventions = interventions
         };
@@ -88,7 +89,7 @@ public class AssessmentRepositoryTest
             Id = 1,
             CreatedBy = "Any",
             Service = "Smth",
-            Status = AssessmentStatus.OnHold,
+            Status = AssessmentStatus.InProgress,
             StudentIds = [1, 2, 3],
             Interventions = interventions
         };
@@ -117,7 +118,7 @@ public class AssessmentRepositoryTest
             Id = 1,
             CreatedBy = "Any",
             Service = "Smth",
-            Status = AssessmentStatus.OnHold,
+            Status = AssessmentStatus.Remitted,
             StudentIds = [1, 2, 3],
             Interventions = interventions
         };
@@ -141,7 +142,7 @@ public class AssessmentRepositoryTest
             Id = 1,
             CreatedBy = "Any",
             Service = "Smth",
-            Status = AssessmentStatus.OnHold,
+            Status = AssessmentStatus.Remitted,
             StudentIds = [1, 2],
             Interventions = new List<Intervention>()
         };
@@ -166,7 +167,7 @@ public class AssessmentRepositoryTest
             Id = 1,
             CreatedBy = "Any",
             Service = "Smth",
-            Status = AssessmentStatus.OnHold,
+            Status = AssessmentStatus.Remitted,
             StudentIds = [1, 2],
             Interventions = interventions
         };
@@ -181,4 +182,84 @@ public class AssessmentRepositoryTest
         Assert.Empty(result);
     }
 
+    [Fact]
+    public async Task GetByStatus_Should_ReturnListofRemitted()
+    {
+        // Arrange
+        var assessments = new List<Assessment>
+        {
+            new Assessment {
+                 Id = 1,
+                CreatedBy = "",
+                Service = "",
+                Status = AssessmentStatus.Remitted,
+                StudentIds = [1, 2]
+            },
+            new Assessment {
+                 Id = 2,
+                CreatedBy = "",
+                Service = "",
+                Status = AssessmentStatus.InProgress,
+                StudentIds = [5, 8]
+            },
+            new Assessment {
+                 Id = 3,
+                CreatedBy = "",
+                Service = "",
+                Status = AssessmentStatus.Remitted,
+                StudentIds = [10, 20]
+            },
+        };
+
+        var mockSet = assessments.AsQueryable().BuildMockDbSet();
+        _mockContext.Setup(r => r.Set<Assessment>()).Returns(mockSet.Object);
+
+        // Act
+        var result = await _repository.GetByStatusAsync(AssessmentStatus.Remitted);
+
+        // Assert
+        Assert.Equal(2, result.Count());
+        Assert.Contains(result, i => i.Id == 1);
+        Assert.Contains(result, i => i.Id == 3);
+    }
+
+    [Fact]
+    public async Task GetByStatus_Should_ReturnEmptyList()
+    {
+        // Arrange
+        var assessments = new List<Assessment>
+        {
+            new Assessment {
+                 Id = 1,
+                CreatedBy = "",
+                Service = "",
+                Status = AssessmentStatus.InProgress,
+                StudentIds = [1, 2]
+            },
+            new Assessment {
+                 Id = 2,
+                CreatedBy = "",
+                Service = "",
+                Status = AssessmentStatus.InProgress,
+                StudentIds = [5, 8]
+            },
+            new Assessment {
+                 Id = 3,
+                CreatedBy = "",
+                Service = "",
+                Status = AssessmentStatus.Remitted,
+                StudentIds = [10, 20]
+            },
+        };
+
+        var mockSet = assessments.AsQueryable().BuildMockDbSet();
+        _mockContext.Setup(r => r.Set<Assessment>()).Returns(mockSet.Object);
+
+        // Act
+        var result = await _repository.GetByStatusAsync(AssessmentStatus.Finalized);
+
+        // Assert
+        Assert.Equal(0, result.Count());
+        Assert.Empty(result);
+    }
 }


### PR DESCRIPTION
## Description
 
- Replaced the statuses enums for InterventionStatus and AssessmentStatus
- Added a migration to update the existing statuses in database for Created and Resolved (they were replaced by Remitted and Finalized)
- Added unit tests related to Status in UpdateRemission, CreateRemission, GetByStatus, AddInterventions handlers
- Added unit test in assessment repository for getByStatus.
 
## Type of change
 
- [ ] Bug fix
- [ ] Feature
- [X] Refactor
- [ ] Documentation Improvements
- [ ] Others:
 
## Checklist
 
- [X] Have the requirements been met?
- [X] Is the code easy to read?
- [X] Do unit tests pass?
- [X] Is the code formatted correctly?
 
## C# Checklist
 
- [X] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [X] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [X] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [X] Are internal vs private vs public classes and methods used the right way?
 
## Related Issues
 
https://github.com/JU-DEV-Bootcamps/ERAS/issues/524