### PR TITLE
Fix bug the recent alerts table is not displayed

### DIFF
--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepository.cs
@@ -129,6 +129,7 @@ public class ErasEvaluationDetailsViewRepository : BaseRepository<Domain.Entitie
     private async Task<IEnumerable<GetStudentsRecentAlertsResponse>> GetRecentAlertsWithoutPagination()
     {
         var prevItems = await _context.ErasEvaluationDetailsView
+            .Where(e => e.Status == "Completed" || e.Status == "InProgress")
             .Select(e => new
             {
                 e.StudentId,

--- a/test/Eras.Api.Tests/Controllers/EvaluationDetailsControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/EvaluationDetailsControllerTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Eras.Api.Controllers;
+using Eras.Application.Features.EvaluationDetails.Queries.GetStudentsRecentAlerts;
+using Eras.Application.Models.Response.Controllers.EvaluationDetailsController;
+using Eras.Application.Utils;
+
+using MediatR;
+
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+namespace Eras.Api.Tests.Controllers;
+
+public class EvaluationDetailsControllerTests
+{
+    private readonly Mock<IMediator> _mockMediator;
+    private readonly Mock<ILogger<EvaluationsController>> _mockLogger;
+    private readonly EvaluationDetailsController _controller;
+
+    public EvaluationDetailsControllerTests()
+    {
+        _mockMediator = new Mock<IMediator>();
+        _mockLogger = new Mock<ILogger<EvaluationsController>>();
+        _controller = new EvaluationDetailsController(_mockMediator.Object, _mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task GetRecentAlertsOfStudentsAsync_Should_Return_SuccessAsync()
+    {
+        // Arrange
+        var pagination = new Pagination();
+        var expectedResult = new PagedResult<GetStudentsRecentAlertsResponse>(2, new List<GetStudentsRecentAlertsResponse>{ new (), new () }); 
+        _mockMediator
+            .Setup(X => X.Send(It.IsAny<GetStudentsRecentAlertsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResult);
+
+        // Act
+        var result = await _controller.GetRecentAlertsOfStudentsAsync(pagination);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var value = Assert.IsType<PagedResult<GetStudentsRecentAlertsResponse>>(okResult.Value);
+        Assert.Equal(expectedResult, value);
+
+        _mockMediator.Verify(X => X.Send(
+            It.IsAny<GetStudentsRecentAlertsQuery>(),
+            It.IsAny<CancellationToken>()),Times.Once);
+     }
+}

--- a/test/Eras.Application.Tests/Features/Evaluations/Queries/GetStudentsRecentAlertsQueryHandlerTest.cs
+++ b/test/Eras.Application.Tests/Features/Evaluations/Queries/GetStudentsRecentAlertsQueryHandlerTest.cs
@@ -61,8 +61,28 @@ public class GetStudentsRecentAlertsQueryHandlerTest
         _mockRepository.Setup(Repo => Repo.CountRecentAlerts()).ReturnsAsync(2);
         // Act
         var result = await _handler.Handle(query, CancellationToken.None);
+        _mockRepository.Verify(x => x.GetRecentAlertsStudentAsync(It.IsAny<int>(), It.IsAny<int>()),Times.Once);
 
+        _mockRepository.Verify(x => x.CountRecentAlerts(),Times.Once);
         // Assert
         Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public async Task Handle_Should_Return_Empty_With_Exception()
+    {
+        // Arrange
+        var query = new GetStudentsRecentAlertsQuery(new Utils.Pagination());
+        _mockRepository
+            .Setup(x => x.GetRecentAlertsStudentAsync(It.IsAny<int>(), It.IsAny<int>()))
+            .ThrowsAsync(new Exception("Error occurs"));
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(0, result.Count);
+        Assert.Empty(result.Items);
     }
 }

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepositoryTest.cs
@@ -1,0 +1,235 @@
+﻿using Eras.Application.Contracts.Persistence;
+using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using MockQueryable.Moq;
+
+using Moq;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+
+public class ErasEvaluationDetailsViewRepositoryTest
+{
+    private Mock<AppDbContext> _mockContext;
+    private IErasEvaluationDetailsViewRepository? _repository;
+
+    public ErasEvaluationDetailsViewRepositoryTest()
+    {
+        _mockContext = new Mock<AppDbContext>(new DbContextOptions<AppDbContext>());
+    }
+
+    [Fact]
+    public async Task GetRecentAlertsStudentAsync_Should_Return_First_Page()
+    {
+        // Arrange
+        var data = new List<ErasEvaluationDetailsViewEntity>
+            {
+                new()
+                {
+                    StudentId = 1,
+                    StudentName = "Student 1",
+                    EvaluationName= "Test",
+                    Status = "Completed",
+                    StudentEmail = "test@m",
+                    AnswerText = "Test",
+                    ComponentName = "Academic",
+                    PollName = "A",
+                    PollUuid = "A",
+                    VariableName = "A",
+                    RiskLevel = 3
+                },
+                new()
+                {
+                    StudentId = 2,
+                    StudentName = "Student 2",
+                    EvaluationName= "Test 2",
+                    Status = "InProgress",
+                    StudentEmail = "test@m",
+                    AnswerText = "Test",
+                    ComponentName = "Academic",
+                    PollName = "A",
+                    PollUuid = "A",
+                    VariableName = "A",
+                    RiskLevel = 1
+                },
+                new()
+                {
+                    StudentId = 3,
+                    StudentName = "Student 3",
+                    EvaluationName= "Test 3",
+                    Status = "Completed",
+                    StudentEmail = "test@m",
+                    AnswerText = "Test",
+                    ComponentName = "Academic",
+                    PollName = "A",
+                    PollUuid = "A",
+                    VariableName = "A",
+                    RiskLevel = 1,
+                }
+            }.AsQueryable().BuildMockDbSet();
+
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _mockContext = new Mock<AppDbContext>(options);
+
+        _mockContext
+            .Setup(c => c.ErasEvaluationDetailsView)
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = (await _repository.GetRecentAlertsStudentAsync(1, 2)).ToList();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count);
+        Assert.Equal("1", result[0].StudentId);
+        Assert.Equal("2", result[1].StudentId);
+    }
+    [Fact]
+    public async Task GetRecentAlertsStudentAsync_Should_Return_Second_Page()
+    {
+        // Arrange
+        var data = new List<ErasEvaluationDetailsViewEntity>
+            {
+                 new()
+                {
+                    StudentId = 1,
+                    StudentName = "Student 1",
+                    EvaluationName= "Test",
+                    Status = "Completed",
+                    StudentEmail = "test@m",
+                    AnswerText = "Test",
+                    ComponentName = "Academic",
+                    PollName = "A",
+                    PollUuid = "A",
+                    VariableName = "A",
+                    RiskLevel=1
+                },
+                new()
+                {
+                    StudentId = 2,
+                    StudentName = "Student 2",
+                    EvaluationName= "Test 2",
+                    Status = "Completed",
+                    StudentEmail = "test@m",
+                    AnswerText = "Test",
+                    ComponentName = "Academic",
+                    PollName = "A",
+                    PollUuid = "A",
+                    VariableName = "A",
+                    RiskLevel = 2
+                },
+                new()
+                {
+                    StudentId = 3,
+                    StudentName = "Student 3",
+                    EvaluationName= "Test 3",
+                    Status = "Completed",
+                    StudentEmail = "test@m",
+                    AnswerText = "Test",
+                    ComponentName = "Academic",
+                    PollName = "A",
+                    PollUuid = "A",
+                    VariableName = "A",
+                    RiskLevel=2
+                },
+                new() {
+                    StudentId = 4,
+                    StudentName = "Student 4",
+                    EvaluationName= "Test 4",
+                    Status = "Completed",
+                    StudentEmail = "test@m",
+                    AnswerText = "Test",
+                    ComponentName = "Academic",
+                    PollName = "A",
+                    PollUuid = "A",
+                    VariableName = "A",
+                    RiskLevel=3
+                }
+            }.AsQueryable().BuildMockDbSet();
+
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _mockContext = new Mock<AppDbContext>(options);
+
+        _mockContext
+            .Setup(c => c.ErasEvaluationDetailsView)
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = (await _repository.GetRecentAlertsStudentAsync(2, 2)).ToList();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count);
+        Assert.Equal("2", result[0].StudentId);
+        Assert.Equal("3", result[1].StudentId);
+    }
+
+    [Fact]
+    public async Task GetRecentAlertsStudentAsync_Should_Return_Empty_When_Evaluations_AreNot_Completed_InProgresss()
+    {
+        // Arrange
+        var data = new List<ErasEvaluationDetailsViewEntity>
+            {
+                 new()
+                 {
+                     StudentId = 1,
+                     StudentName = "Student 1",
+                     EvaluationName= "Test",
+                     Status = "Pending",
+                     StudentEmail = "test@m",
+                     AnswerText = "Test",
+                     ComponentName = "Academic",
+                     PollName = "A",
+                     PollUuid = "A",
+                     VariableName = "A",
+                 },
+                 new()
+                 {
+                     StudentId = 2,
+                     StudentName = "Student 2",
+                     EvaluationName= "Test 2",
+                     Status = "Pending",
+                     StudentEmail = "test@m",
+                     AnswerText = "Test",
+                     ComponentName = "Academic",
+                     PollName = "A",
+                     PollUuid = "A",
+                     VariableName = "A",
+                 }
+            }.AsQueryable().BuildMockDbSet();
+
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: "RecentAlertsTest_Empty")
+            .Options;
+
+        _mockContext = new Mock<AppDbContext>(options);
+
+        _mockContext
+            .Setup(c => c.ErasEvaluationDetailsView)
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = await _repository.GetRecentAlertsStudentAsync(1, 2);
+        var resultLength = await _repository.CountRecentAlerts();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(0, resultLength);
+        Assert.Empty(result);
+    }
+}


### PR DESCRIPTION
## Description

The root cause of the issue is related to evaluation processes without students, or the value is null for them. I added a condition to only perform over evaluations with InProgress or Completed statuses.
Added unit tests for:
* GetRecentAlertsWithoutPagination => Test in Infrastructure
* CountRecentAlerts => Test in Infrastructure
* GetStudentsRecentAlertsQueryHandler => Test in Application
* GetRecentAlertsOfStudentsAsync => Test in Api

Those tests have achieved 100% on code coverage (line coverage, branch coverage)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [x] Have the requirements been met?
- [x] Is the code easy to read?
- [x] Do unit tests pass?
- [x] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues

JU-DEV-Bootcamps/ERAS#526