### PR TITLE
feat: add unit tests for handlers and methods related to attachments

### DIFF
--- a/src/Eras.Domain/Entities/AssessmentManagement/Intervention.cs
+++ b/src/Eras.Domain/Entities/AssessmentManagement/Intervention.cs
@@ -2,7 +2,7 @@
 
 namespace Eras.Domain.Entities.AssessmentManagement;
 
-public abstract class Intervention : BaseEntity
+public class Intervention : BaseEntity
 {
     public required DateTime DateUtc { get; init; }
     public string? Activity { get; init; }
@@ -18,7 +18,7 @@ public abstract class Intervention : BaseEntity
     public InterventionStatus Status { get; init; } = InterventionStatus.Remitted;
     public string? Remarks { get; init; }
 
-    public abstract InterventionKind Kind { get; }
+    public virtual InterventionKind Kind { get; }
 
     public IReadOnlyCollection<string> Attachments { get; init; } = Array.Empty<string>();
 

--- a/test/Eras.Application.Tests/Features/Assessments/Commands/DeleteInterventionAttachmentCommandHandlerTests.cs
+++ b/test/Eras.Application.Tests/Features/Assessments/Commands/DeleteInterventionAttachmentCommandHandlerTests.cs
@@ -1,0 +1,143 @@
+﻿using System.Net.Mail;
+
+using Eras.Application.Contracts.Infrastructure;
+using Eras.Application.Contracts.Persistence.AssessmentManagement;
+using Eras.Application.Features.RemissionManagement;
+using Eras.Application.Features.RemissionManagement.Handlers;
+using Eras.Domain.Entities.AssessmentManagement;
+
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+namespace Eras.Application.Tests.Features.Assessments.Commands;
+
+public class DeleteInterventionAttachmentCommandHandlerTests
+{
+    private readonly Mock<IAssessmentRepository> _mockRepository;
+    private readonly Mock<IFileStorageService> _mockFileStorage;
+    private readonly Mock<ILogger<DeleteInterventionAttachmentCommandHandler>> _mockLogger;
+    private readonly DeleteInterventionAttachmentCommandHandler _handler;
+
+    public DeleteInterventionAttachmentCommandHandlerTests()
+    {
+        _mockRepository = new Mock<IAssessmentRepository>();
+        _mockLogger = new Mock<ILogger<DeleteInterventionAttachmentCommandHandler>>();
+        _mockFileStorage = new Mock<IFileStorageService>();
+        _handler = new DeleteInterventionAttachmentCommandHandler(
+            _mockRepository.Object,
+            _mockFileStorage.Object,
+            _mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task Handle_Should_Delete_File_When_Is_ValidAsync()
+    {
+        // Arrange
+        var command = new DeleteInterventionAttachmentCommand(1, "report.pdf");
+        var intervention = new Intervention
+        {
+            DateUtc = DateTime.UtcNow,
+            StudentIds = [1, 2],
+            Mode = InterventionMode.InPlace,
+            Attachments = new List<string> { "interventions/1/report.pdf" }.AsReadOnly(),
+            AttachmentHashes = new List<string> { "HASH1" }.AsReadOnly()
+        };
+        var interventionExpected = new Intervention
+        {
+            DateUtc = DateTime.UtcNow,
+            StudentIds = [1, 2],
+            Mode = InterventionMode.InPlace,
+            Attachments = new List<string>().AsReadOnly(),
+            AttachmentHashes = new List<string> ().AsReadOnly()
+        };
+        _mockRepository
+            .Setup(x => x.GetInterventionByIdAsync(1))
+            .ReturnsAsync(intervention);
+
+        _mockFileStorage
+            .Setup(x => x.DeleteAsync("interventions/1/report.pdf"));
+
+        _mockRepository
+            .Setup(x => x.RemoveAttachmentAsync(1, "interventions/1/report.pdf"));
+
+        //Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        _mockRepository.Verify(
+            x => x.GetInterventionByIdAsync(1),
+            Times.Once);
+
+        _mockFileStorage.Verify(
+            x => x.DeleteAsync("interventions/1/report.pdf"),
+            Times.Exactly(1));
+
+        _mockRepository.Verify(
+            x => x.RemoveAttachmentAsync(1, "interventions/1/report.pdf"),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_Should_Throw_Exception_When_Intervention_Is_NullAsync()
+    {
+        // Arrange
+        var command = new DeleteInterventionAttachmentCommand(1, "report.pdf");
+
+        // Act
+        var exception = await Assert.ThrowsAsync<KeyNotFoundException>(
+            () => _handler.Handle(command, CancellationToken.None));
+
+        // Assert
+        Assert.Equal("Intervention '1' not found.", exception.Message);
+
+        _mockRepository.Verify(
+            x => x.GetInterventionByIdAsync(1),
+            Times.Once);
+
+        _mockFileStorage.Verify(
+            x => x.DeleteAsync("interventions/1/report.pdf"),
+            Times.Never);
+
+        _mockRepository.Verify(
+            x => x.RemoveAttachmentAsync(1, "interventions/1/report.pdf"),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_Should_Throw_Exception_When_Attachment_Not_ExistsAsync()
+    {
+        // Arrange
+        var command = new DeleteInterventionAttachmentCommand(1, "report.pdf");
+        var intervention = new Intervention
+        {
+            DateUtc = DateTime.UtcNow,
+            StudentIds = [1, 2],
+            Mode = InterventionMode.InPlace,
+            Attachments = new List<string>().AsReadOnly(),
+            AttachmentHashes = new List<string>().AsReadOnly()
+        };
+        
+        _mockRepository
+            .Setup(x => x.GetInterventionByIdAsync(1))
+            .ReturnsAsync(intervention);
+
+        // Act
+        var exception = await Assert.ThrowsAsync<KeyNotFoundException>(
+            () => _handler.Handle(command, CancellationToken.None));
+
+        // Assert
+        Assert.Equal("Attachment 'report.pdf' not found in intervention '1'.", exception.Message);
+        _mockRepository.Verify(
+            x => x.GetInterventionByIdAsync(1),
+            Times.Once);
+
+        _mockFileStorage.Verify(
+            x => x.DeleteAsync("interventions/1/report.pdf"),
+            Times.Never);
+
+        _mockRepository.Verify(
+            x => x.RemoveAttachmentAsync(1, "interventions/1/report.pdf"),
+            Times.Never);
+    }
+}

--- a/test/Eras.Application.Tests/Features/Assessments/Commands/UploadInterventionAttachmentsCommandHandlerTests.cs
+++ b/test/Eras.Application.Tests/Features/Assessments/Commands/UploadInterventionAttachmentsCommandHandlerTests.cs
@@ -1,0 +1,230 @@
+﻿using System.Security.Cryptography;
+using System.Text;
+
+using Eras.Application.Contracts.Infrastructure;
+using Eras.Application.Contracts.Persistence.AssessmentManagement;
+using Eras.Application.Features.RemissionManagement;
+using Eras.Application.Features.RemissionManagement.Handlers;
+using Eras.Application.Models;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using Moq;
+
+namespace Eras.Application.Tests.Features.Assessments.Commands;
+
+public class UploadInterventionAttachmentsCommandHandlerTests
+{
+    private readonly Mock<IAssessmentRepository> _mockRepository;
+    private readonly Mock<IFileStorageService> _mockFileStorage;
+    private readonly Mock<IOptions<FileStorageSettings>> _mockSettings;
+    private readonly Mock<ILogger<UploadInterventionAttachmentsCommandHandler>> _mockLogger;
+    private readonly UploadInterventionAttachmentsCommandHandler _handler;
+
+    public UploadInterventionAttachmentsCommandHandlerTests()
+    {
+        _mockRepository = new Mock<IAssessmentRepository>();
+        _mockFileStorage = new Mock<IFileStorageService>();
+        _mockSettings = new Mock<IOptions<FileStorageSettings>>();
+        _mockLogger = new Mock<ILogger<UploadInterventionAttachmentsCommandHandler>>();
+
+        _mockSettings
+            .Setup(x => x.Value)
+            .Returns(new FileStorageSettings { AllowedExtensions = [".pdf", ".png", ".jpg"], BasePath = "" });
+
+        _handler = new UploadInterventionAttachmentsCommandHandler(
+            _mockRepository.Object,
+            _mockFileStorage.Object,
+            _mockSettings.Object,
+            _mockLogger.Object);
+    }
+
+    private static (Stream Stream, string FileName) CreateFile(string fileName, string content)
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes(content);
+        return (new MemoryStream(bytes), fileName);
+    }
+
+    private static string ComputeHash(string content)
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes(content);
+        byte[] hashBytes = SHA256.HashData(bytes);
+        return Convert.ToHexString(hashBytes);
+    }
+
+    [Fact]
+    public async Task Handle_Should_Save_Files_And_Return_Paths_When_ValidAsync()
+    {
+        // Arrange
+        var file1 = CreateFile("report.pdf", "content-1");
+        var file2 = CreateFile("photo.png", "content-2");
+
+        var command = new UploadInterventionAttachmentsCommand(1, [file1, file2]);
+
+        _mockRepository
+            .Setup(x => x.GetAttachmentHashesAsync(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyCollection<string>)new List<string>());
+
+        _mockFileStorage
+            .Setup(x => x.SaveAsync(It.IsAny<Stream>(), "report.pdf", $"interventions/1"))
+            .ReturnsAsync($"interventions/1/report.pdf");
+
+        _mockFileStorage
+            .Setup(x => x.SaveAsync(It.IsAny<Stream>(), "photo.png", $"interventions/1"))
+            .ReturnsAsync($"interventions/1/photo.png");
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains($"interventions/1/report.pdf", result);
+        Assert.Contains($"interventions/1/photo.png", result);
+
+        _mockFileStorage.Verify(
+            x => x.SaveAsync(It.IsAny<Stream>(), It.IsAny<string>(), $"interventions/1"),
+            Times.Exactly(2));
+
+        _mockRepository.Verify(
+            x => x.AddAttachmentsAsync(
+                1,
+                It.Is<IReadOnlyCollection<string>>(paths => paths.Count == 2),
+                It.Is<IReadOnlyCollection<string>>(hashes => hashes.Count == 2)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_Should_Skip_Duplicate_Files_Based_On_HashAsync()
+    {
+        // Arrange
+        var interventionId = 2;
+        var duplicateContent = "duplicate-content";
+        var newContent = "new-content";
+
+        var duplicateFile = CreateFile("duplicate.pdf", duplicateContent);
+        var newFile = CreateFile("new.pdf", newContent);
+
+        var command = new UploadInterventionAttachmentsCommand(interventionId, [duplicateFile, newFile]);
+
+        var existingHashes = new List<string> { ComputeHash(duplicateContent) };
+
+        _mockRepository
+            .Setup(x => x.GetAttachmentHashesAsync(interventionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyCollection<string>)existingHashes);
+
+        _mockFileStorage
+            .Setup(x => x.SaveAsync(It.IsAny<Stream>(), "new.pdf", $"interventions/{interventionId}"))
+            .ReturnsAsync($"interventions/{interventionId}/new.pdf");
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Contains($"interventions/{interventionId}/new.pdf", result);
+
+        _mockFileStorage.Verify(
+            x => x.SaveAsync(It.IsAny<Stream>(), "duplicate.pdf", It.IsAny<string>()),
+            Times.Never);
+
+        _mockFileStorage.Verify(
+            x => x.SaveAsync(It.IsAny<Stream>(), "new.pdf", $"interventions/{interventionId}"),
+            Times.Once);
+
+        _mockRepository.Verify(
+            x => x.AddAttachmentsAsync(
+                interventionId,
+                It.Is<IReadOnlyCollection<string>>(paths => paths.Count == 1),
+                It.Is<IReadOnlyCollection<string>>(hashes => hashes.Count == 1)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_Should_Throw_InvalidOperationException_When_Extension_Not_AllowedAsync()
+    {
+        // Arrange
+        var interventionId = 1;
+        var file = CreateFile("notallowed.exe", "content");
+
+        // Act
+        var command = new UploadInterventionAttachmentsCommand(interventionId, [file]);
+
+        // Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _handler.Handle(command, CancellationToken.None));
+
+        Assert.Equal("Extension '.exe' is not allowed.", exception.Message);
+
+        _mockRepository.Verify(
+            x => x.GetAttachmentHashesAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        _mockFileStorage.Verify(
+            x => x.SaveAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_Should_Throw_InvalidOperationException_When_Files_Already_UploadedAsync()
+    {
+        // Arrange
+        var interventionId = 1;
+        var content = "already-uploaded-content";
+        var file = CreateFile("existing.pdf", content);
+        var command = new UploadInterventionAttachmentsCommand(interventionId, [file]);
+
+        var existingHashes = new List<string> { ComputeHash(content) };
+
+        // Act
+        _mockRepository
+            .Setup(x => x.GetAttachmentHashesAsync(interventionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyCollection<string>)existingHashes);
+
+        // Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _handler.Handle(command, CancellationToken.None));
+
+        Assert.Equal("All files have already been uploaded to this intervention.", exception.Message);
+
+        _mockFileStorage.Verify(
+            x => x.SaveAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>()),
+            Times.Never);
+
+        _mockRepository.Verify(
+            x => x.AddAttachmentsAsync(
+                It.IsAny<int>(),
+                It.IsAny<IReadOnlyCollection<string>>(),
+                It.IsAny<IReadOnlyCollection<string>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_Should_Return_Empty_When_No_Files_ProvidedAsync()
+    {
+        // Arrange
+        var interventionId = 1;
+        var command = new UploadInterventionAttachmentsCommand(interventionId, []);
+
+        _mockRepository
+            .Setup(x => x.GetAttachmentHashesAsync(interventionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyCollection<string>)new List<string>());
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.Empty(result);
+
+        _mockFileStorage.Verify(
+            x => x.SaveAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>()),
+            Times.Never);
+
+        _mockRepository.Verify(
+            x => x.AddAttachmentsAsync(
+                It.IsAny<int>(),
+                It.IsAny<IReadOnlyCollection<string>>(),
+                It.IsAny<IReadOnlyCollection<string>>()),
+            Times.Never);
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Entities/TestIntervention.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Entities/TestIntervention.cs
@@ -5,5 +5,5 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Entities;
 
 internal sealed class TestIntervention : Intervention
 {
-    public override InterventionKind Kind => InterventionKind.Group; // pick any valid enum value
+    public override InterventionKind Kind => InterventionKind.Group;
 }

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/AssessmentRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/AssessmentRepositoryTest.cs
@@ -4,7 +4,6 @@ using Eras.Infrastructure.Persistence.PostgreSQL.Repositories.AssessmentManageme
 using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Entities;
 
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.Extensions.Logging;
 
 using MockQueryable.Moq;
@@ -158,7 +157,7 @@ public class AssessmentRepositoryTest
     }
 
     [Fact]
-    public async Task GetInterventionsContainingStudent_Should_ReturnEmpty_When_StudentIdsListIsEmpty()
+    public async Task GetInterventionsContainingStudent_Should_ReturnEmpty_When_StudentIdsListIsEmptyAsync()
     {
         // Arrange
         var interventions = new List<Intervention> { BuildIntervention(1, 1, 2) };
@@ -183,7 +182,7 @@ public class AssessmentRepositoryTest
     }
 
     [Fact]
-    public async Task GetByStatus_Should_ReturnListofRemitted()
+    public async Task GetByStatus_Should_ReturnListofRemittedAsync()
     {
         // Arrange
         var assessments = new List<Assessment>
@@ -224,7 +223,7 @@ public class AssessmentRepositoryTest
     }
 
     [Fact]
-    public async Task GetByStatus_Should_ReturnEmptyList()
+    public async Task GetByStatus_Should_ReturnEmptyListAsync()
     {
         // Arrange
         var assessments = new List<Assessment>
@@ -260,6 +259,288 @@ public class AssessmentRepositoryTest
 
         // Assert
         Assert.Equal(0, result.Count());
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task AddAttachmentsAsync_Should_SaveAttachmentAsync()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        await using var context = new AppDbContext(options);
+
+        var intervention = new TestIntervention
+        {
+            DateUtc = DateTime.UtcNow,
+            StudentIds = [1, 2],
+            Mode = InterventionMode.InPlace,
+            Attachments = new List<string>().AsReadOnly(),
+            AttachmentHashes = new List<string>().AsReadOnly()
+        };
+
+        var assessment = new Assessment
+        {
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = "Any",
+            Service = "Smth",
+            StudentIds = [1, 2],
+            Status = AssessmentStatus.InProgress,
+            Interventions = new List<Intervention> { intervention }
+        };
+
+        context.Set<Assessment>().Add(assessment);
+        await context.SaveChangesAsync();
+        var repository = new AssessmentRepository(context, _mockLogger.Object);
+
+        var newPaths = new List<string> { "interventions/1/file1.pdf" };
+        var newHashes = new List<string> { "HASH123" };
+
+        // Act
+        await repository.AddAttachmentsAsync(intervention.Id, newPaths, newHashes);
+
+        // Assert
+        Intervention updated = await context.Set<Intervention>().FirstAsync(i => i.Id == intervention.Id);
+        Assert.Single(updated.Attachments);
+        Assert.Contains("interventions/1/file1.pdf", updated.Attachments);
+        Assert.Single(updated.AttachmentHashes);
+        Assert.Contains("HASH123", updated.AttachmentHashes);
+    }
+
+    [Fact]
+    public async Task AddAttachmentsAsync_Should_ThrowKeyNotFoundException_When_InterventionNotFoundAsync()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        await using var context = new AppDbContext(options);
+        var repository = new AssessmentRepository(context, _mockLogger.Object);
+
+        // Assert
+        var exception = await Assert.ThrowsAsync<KeyNotFoundException>(
+            () => repository.AddAttachmentsAsync(999, ["interventions/999/file.pdf"], ["HASH"]));
+
+        Assert.Equal("Intervention '999' not found.", exception.Message);
+    }
+
+    [Fact]
+    public async Task RemoveAttachmentAsync_Should_RemoveMatchingAttachmentAsync()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        await using var context = new AppDbContext(options);
+
+        var intervention = new TestIntervention
+        {
+            DateUtc = DateTime.UtcNow,
+            StudentIds = [1, 2],
+            Mode = InterventionMode.InPlace,
+            Attachments = new List<string>
+        {
+            "interventions/1/file1.pdf",
+            "interventions/1/file2.png"
+        }.AsReadOnly(),
+            AttachmentHashes = new List<string> { "HASH1", "HASH2" }.AsReadOnly()
+        };
+
+        var assessment = new Assessment
+        {
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = "Any",
+            Service = "Smth",
+            StudentIds = [1, 2],
+            Status = AssessmentStatus.InProgress,
+            Interventions = new List<Intervention> { intervention }
+        };
+
+        context.Set<Assessment>().Add(assessment);
+        await context.SaveChangesAsync();
+
+        var repository = new AssessmentRepository(context, _mockLogger.Object);
+
+        // Act
+        await repository.RemoveAttachmentAsync(intervention.Id, "interventions/1/file1.pdf");
+
+        // Assert
+        Intervention updated = await context.Set<Intervention>().FirstAsync(i => i.Id == intervention.Id);
+        Assert.Single(updated.Attachments);
+        Assert.Contains("interventions/1/file2.png", updated.Attachments);
+        Assert.Single(updated.AttachmentHashes);
+        Assert.Contains("HASH2", updated.AttachmentHashes);
+    }
+
+    [Fact]
+    public async Task RemoveAttachmentAsync_Should_MatchByFileName_CaseInsensitiveAsync()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        await using var context = new AppDbContext(options);
+
+        var intervention = new TestIntervention
+        {
+            DateUtc = DateTime.UtcNow,
+            StudentIds = [1, 2],
+            Mode = InterventionMode.InPlace,
+            Attachments = new List<string> { "interventions/1/File1.PDF" }.AsReadOnly(),
+            AttachmentHashes = new List<string> { "HASH1" }.AsReadOnly()
+        };
+
+        var assessment = new Assessment
+        {
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = "Any",
+            Service = "Smth",
+            StudentIds = [1, 2],
+            Status = AssessmentStatus.InProgress,
+            Interventions = new List<Intervention> { intervention }
+        };
+
+        context.Set<Assessment>().Add(assessment);
+        await context.SaveChangesAsync();
+
+        var repository = new AssessmentRepository(context, _mockLogger.Object);
+
+        // Act
+        await repository.RemoveAttachmentAsync(intervention.Id, "somewhere-else/file1.pdf");
+
+        // Assert
+        Intervention updated = await context.Set<Intervention>().FirstAsync(i => i.Id == intervention.Id);
+        Assert.Empty(updated.Attachments);
+        Assert.Empty(updated.AttachmentHashes);
+    }
+
+    [Fact]
+    public async Task RemoveAttachmentAsync_Should_NotModifyList_When_FileNameNotFoundAsync()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        await using var context = new AppDbContext(options);
+
+        var intervention = new TestIntervention
+        {
+            DateUtc = DateTime.UtcNow,
+            StudentIds = [1, 2],
+            Mode = InterventionMode.InPlace,
+            Attachments = new List<string> { "interventions/1/file1.pdf" }.AsReadOnly(),
+            AttachmentHashes = new List<string> { "HASH1" }.AsReadOnly()
+        };
+
+        var assessment = new Assessment
+        {
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = "Any",
+            Service = "Smth",
+            StudentIds = [1, 2],
+            Status = AssessmentStatus.InProgress,
+            Interventions = new List<Intervention> { intervention }
+        };
+
+        context.Set<Assessment>().Add(assessment);
+        await context.SaveChangesAsync();
+
+        var repository = new AssessmentRepository(context, _mockLogger.Object);
+
+        // Act
+        await repository.RemoveAttachmentAsync(intervention.Id, "does-not-exist.pdf");
+
+        // Assert 
+        Intervention updated = await context.Set<Intervention>().FirstAsync(i => i.Id == intervention.Id);
+        Assert.Single(updated.Attachments);
+        Assert.Contains("interventions/1/file1.pdf", updated.Attachments);
+        Assert.Single(updated.AttachmentHashes);
+        Assert.Contains("HASH1", updated.AttachmentHashes);
+    }
+
+    [Fact]
+    public async Task RemoveAttachmentAsync_Should_ThrowException_When_InterventionNotFoundAsync()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        await using var context = new AppDbContext(options);
+        var repository = new AssessmentRepository(context, _mockLogger.Object);
+
+        // Act 
+        var exception = await Assert.ThrowsAsync<KeyNotFoundException>(
+            () => repository.RemoveAttachmentAsync(999, "interventions/999/file.pdf"));
+        //Assert
+        Assert.Equal("Intervention '999' not found.", exception.Message);
+    }
+
+    [Fact]
+    public async Task GetAttachmentHashesAsync_Should_ReturnHashes_When_InterventionExistsAsync()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        await using var context = new AppDbContext(options);
+
+        var intervention = new TestIntervention
+        {
+            DateUtc = DateTime.UtcNow,
+            StudentIds = [1, 2],
+            Mode = InterventionMode.InPlace,
+            Attachments = new List<string> { "interventions/1/file1.pdf", "interventions/1/file2.png" }.AsReadOnly(),
+            AttachmentHashes = new List<string> { "HASH1", "HASH2" }.AsReadOnly()
+        };
+
+        var assessment = new Assessment
+        {
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = "Any",
+            Service = "Smth",
+            StudentIds = [1, 2],
+            Status = AssessmentStatus.InProgress,
+            Interventions = new List<Intervention> { intervention }
+        };
+
+        context.Set<Assessment>().Add(assessment);
+        await context.SaveChangesAsync();
+
+        var repository = new AssessmentRepository(context, _mockLogger.Object);
+
+        // Act
+        var result = await repository.GetAttachmentHashesAsync(intervention.Id, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains("HASH1", result);
+        Assert.Contains("HASH2", result);
+    }
+
+    [Fact]
+    public async Task GetAttachmentHashesAsync_Should_ReturnEmpty_When_InterventionNotFoundAsync()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        await using var context = new AppDbContext(options);
+        var repository = new AssessmentRepository(context, _mockLogger.Object);
+
+        // Act
+        var result = await repository.GetAttachmentHashesAsync(999, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
         Assert.Empty(result);
     }
 }


### PR DESCRIPTION
## Description

- Updated abstract to class for entity: Intervention in order to make testable configuration
- Added unit tests for methods and handlers related to attachments:
  -  DeleteInterventionAttachmentCommandHandler
  - UploadInterventionAttachmentsCommandHandler
  - AddAttachmentsAsync
  - RemoveAttachmentAsync
  - GetAttachmentHashesAsync
Code coverage increased in 
  -  DeleteInterventionAttachmentCommandHandler
  - UploadInterventionAttachmentsCommandHandler
  - AssessmentRepository

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [x] Have the requirements been met?
- [x] Is the code easy to read?
- [x] Do unit tests pass?
- [x] Is the code formatted correctly?

## C# Checklist

- [x] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [x] Does the code handle exceptions correctly
- [x] Is the code subject to concurrency issues? Are shared objects properly protected?
- [x] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [x] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [x] Are internal vs private vs public classes and methods used the right way?

## Related Issues
