### PR TITLE
refactor: remove required attribute from EvaluationDTO fields

### DIFF
--- a/src/Eras.Application/DTOs/EvaluationDTO.cs
+++ b/src/Eras.Application/DTOs/EvaluationDTO.cs
@@ -18,7 +18,6 @@ public class EvaluationDTO
     [DataType(DataType.DateTime)]
     public required DateTime EndDate { get; set; }
 
-    [Required(ErrorMessage = "Poll name is required")]
     [StringLength(100, ErrorMessage = "Poll name must be less than 100 characters.")]
     public string PollName { get; set; } = string.Empty;
 

--- a/test/Eras.Application.Tests/DTOs/EvaluationDTOValidationTest.cs
+++ b/test/Eras.Application.Tests/DTOs/EvaluationDTOValidationTest.cs
@@ -69,20 +69,6 @@ public class EvaluationDTOValidationTests
         Assert.Contains(nameof(EvaluationDTO.Name), results.First().MemberNames);
     }
 
-    [Theory]
-    [ClassData(typeof(RequiredStringTestData))]
-    public void PollName_Required_FailsWhenMissing(string InvalidPollName)
-    {
-        EvaluationDTO dto = CreateValidDTO();
-        dto.PollName = InvalidPollName;
-
-        IList<ValidationResult> results = ValidationTestHelper.Validate(dto);
-    
-        Assert.Single(results);
-        Assert.Equal("Poll name is required", results.First().ErrorMessage);
-        Assert.Contains(nameof(EvaluationDTO.PollName), results.First().MemberNames);
-    }
-
     [Fact]
     public void PollName_Fails_WhenLengthTooLong()
     {


### PR DESCRIPTION
## Description

- Remove [Required] attribute from pollName field of EvaluationDTO
- Related to [Feature/fe 528/enable poll name late selection- #990](https://github.com/JU-DEV-Bootcamps/ERAS-FE/pull/990)

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues
Related to [Feature/fe 528/enable poll name late selection- #990](https://github.com/JU-DEV-Bootcamps/ERAS-FE/pull/990)
