### PR TITLE
520 bug dev interventions multiple documents can be added when editing

### DIFF
--- a/src/Eras.Application/Features/RemissionManagement/Handlers/UploadInterventionAttachmentsCommandHandler.cs
+++ b/src/Eras.Application/Features/RemissionManagement/Handlers/UploadInterventionAttachmentsCommandHandler.cs
@@ -1,6 +1,7 @@
 using Eras.Application.Contracts.Infrastructure;
 using Eras.Application.Contracts.Persistence.AssessmentManagement;
 using Eras.Application.Models;
+using Eras.Domain.Entities.AssessmentManagement;
 
 using MediatR;
 
@@ -44,6 +45,15 @@ public sealed class UploadInterventionAttachmentsCommandHandler
 
         IReadOnlyCollection<string> existingHashes =
             await _repository.GetAttachmentHashesAsync(request.InterventionId, cancellationToken);
+
+        int maxNewFiles = InterventionConstants.MaxAttachments - existingHashes.Count;
+        if (maxNewFiles <= 0)
+            throw new InvalidOperationException(
+                $"This intervention already has the maximum of {InterventionConstants.MaxAttachments} documents.");
+
+        if (request.Files.Count > maxNewFiles)
+            throw new InvalidOperationException(
+                $"Only {maxNewFiles} more document(s) can be added (maximum {InterventionConstants.MaxAttachments} per intervention).");
 
         List<string> savedPaths = [];
         List<string> savedHashes = [];

--- a/src/Eras.Domain/Entities/AssessmentManagement/InterventionConstants.cs
+++ b/src/Eras.Domain/Entities/AssessmentManagement/InterventionConstants.cs
@@ -1,0 +1,6 @@
+namespace Eras.Domain.Entities.AssessmentManagement;
+
+public static class InterventionConstants
+{
+    public const int MaxAttachments = 5;
+}

--- a/src/Eras.Domain/Entities/AssessmentManagement/Validators/InterventionValidator.cs
+++ b/src/Eras.Domain/Entities/AssessmentManagement/Validators/InterventionValidator.cs
@@ -32,6 +32,10 @@ public sealed class InterventionValidator : AbstractValidator<Intervention>
             .NotEmpty()
             .MaximumLength(1000);
 
+        RuleFor(x => x.Attachments)
+            .Must(attachments => attachments.Count <= InterventionConstants.MaxAttachments)
+            .WithMessage($"An intervention cannot have more than {InterventionConstants.MaxAttachments} attached documents.");
+
         RuleFor(x => x.RiskLevel)
              .GreaterThanOrEqualTo(0)
             .LessThanOrEqualTo(5);

--- a/test/Eras.Application.Tests/Features/Assessments/Commands/UploadInterventionAttachmentsCommandHandlerTests.cs
+++ b/test/Eras.Application.Tests/Features/Assessments/Commands/UploadInterventionAttachmentsCommandHandlerTests.cs
@@ -227,4 +227,104 @@ public class UploadInterventionAttachmentsCommandHandlerTests
                 It.IsAny<IReadOnlyCollection<string>>()),
             Times.Never);
     }
+
+    [Fact]
+    public async Task Handle_Should_Throw_InvalidOperationException_When_Already_At_MaxAsync()
+    {
+        var interventionId = 3;
+        var file = CreateFile("extra.pdf", "extra-content");
+        var command = new UploadInterventionAttachmentsCommand(interventionId, [file]);
+
+        var existingHashes = new List<string> { "h1", "h2", "h3", "h4", "h5" };
+
+        _mockRepository
+            .Setup(x => x.GetAttachmentHashesAsync(interventionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyCollection<string>)existingHashes);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _handler.Handle(command, CancellationToken.None));
+
+        Assert.Equal(
+            "This intervention already has the maximum of 5 documents.",
+            exception.Message);
+
+        _mockFileStorage.Verify(
+            x => x.SaveAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>()),
+            Times.Never);
+
+        _mockRepository.Verify(
+            x => x.AddAttachmentsAsync(
+                It.IsAny<int>(),
+                It.IsAny<IReadOnlyCollection<string>>(),
+                It.IsAny<IReadOnlyCollection<string>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_Should_Throw_InvalidOperationException_When_New_Files_Exceed_Remaining_SlotsAsync()
+    {
+        var interventionId = 4;
+        var file1 = CreateFile("a.pdf", "content-a");
+        var file2 = CreateFile("b.pdf", "content-b");
+        var file3 = CreateFile("c.pdf", "content-c");
+        var command = new UploadInterventionAttachmentsCommand(interventionId, [file1, file2, file3]);
+
+        var existingHashes = new List<string> { "h1", "h2", "h3" };
+
+        _mockRepository
+            .Setup(x => x.GetAttachmentHashesAsync(interventionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyCollection<string>)existingHashes);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _handler.Handle(command, CancellationToken.None));
+
+        Assert.Equal(
+            "Only 2 more document(s) can be added (maximum 5 per intervention).",
+            exception.Message);
+
+        _mockFileStorage.Verify(
+            x => x.SaveAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<string>()),
+            Times.Never);
+
+        _mockRepository.Verify(
+            x => x.AddAttachmentsAsync(
+                It.IsAny<int>(),
+                It.IsAny<IReadOnlyCollection<string>>(),
+                It.IsAny<IReadOnlyCollection<string>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_Should_Save_Files_When_Exactly_Reaching_MaxAsync()
+    {
+        var interventionId = 5;
+        var file1 = CreateFile("d.pdf", "content-d");
+        var file2 = CreateFile("e.pdf", "content-e");
+        var command = new UploadInterventionAttachmentsCommand(interventionId, [file1, file2]);
+
+        var existingHashes = new List<string> { "h1", "h2", "h3" };
+
+        _mockRepository
+            .Setup(x => x.GetAttachmentHashesAsync(interventionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyCollection<string>)existingHashes);
+
+        _mockFileStorage
+            .Setup(x => x.SaveAsync(It.IsAny<Stream>(), "d.pdf", $"interventions/{interventionId}"))
+            .ReturnsAsync($"interventions/{interventionId}/d.pdf");
+
+        _mockFileStorage
+            .Setup(x => x.SaveAsync(It.IsAny<Stream>(), "e.pdf", $"interventions/{interventionId}"))
+            .ReturnsAsync($"interventions/{interventionId}/e.pdf");
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.Equal(2, result.Count);
+
+        _mockRepository.Verify(
+            x => x.AddAttachmentsAsync(
+                interventionId,
+                It.Is<IReadOnlyCollection<string>>(paths => paths.Count == 2),
+                It.Is<IReadOnlyCollection<string>>(hashes => hashes.Count == 2)),
+            Times.Once);
+    }
 }

--- a/test/Eras.Domain.Tests/Entities/Validators/InterventionValidatorTests.cs
+++ b/test/Eras.Domain.Tests/Entities/Validators/InterventionValidatorTests.cs
@@ -1,0 +1,115 @@
+using Eras.Domain.Entities.AssessmentManagement;
+using Eras.Domain.Entities.AssessmentManagement.Validators;
+
+using FluentValidation.TestHelper;
+
+namespace Eras.Domain.Tests.Entities.AssessmentManagement.Validators;
+
+public class InterventionValidatorTests
+{
+    private readonly InterventionValidator _validator = new();
+
+    private static Intervention CreateValidIntervention(
+        List<string>? attachments = null,
+        List<int>? studentIds = null,
+        int? riskLevel = null)
+    {
+        return new Intervention
+        {
+            DateUtc = DateTime.UtcNow,
+            Activity = "Activity",
+            Area = "Area",
+            Professional = "Professional",
+            Comments = "Some comments",
+            StudentIds = studentIds ?? new List<int> { 1 },
+            Remarks = "Some remarks",
+            Attachments = attachments ?? new List<string> { "file1.pdf" },
+            RiskLevel = riskLevel ?? 2,
+        };
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_Attachments_Are_Within_Max()
+    {
+        var intervention = CreateValidIntervention(
+            new List<string> { "a.pdf", "b.pdf", "c.pdf" });
+
+        var result = _validator.TestValidate(intervention);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Attachments);
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_Attachments_Are_Empty()
+    {
+        var intervention = CreateValidIntervention(new List<string>());
+
+        var result = _validator.TestValidate(intervention);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Attachments);
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_Attachments_Are_Exactly_At_Max()
+    {
+        var intervention = CreateValidIntervention(
+            new List<string> { "a.pdf", "b.pdf", "c.pdf", "d.pdf", "e.pdf" });
+
+        var result = _validator.TestValidate(intervention);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.Attachments);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Attachments_Exceed_Max()
+    {
+        var intervention = CreateValidIntervention(
+            new List<string> { "a.pdf", "b.pdf", "c.pdf", "d.pdf", "e.pdf", "f.pdf" });
+
+        var result = _validator.TestValidate(intervention);
+
+        result.ShouldHaveValidationErrorFor(x => x.Attachments)
+            .WithErrorMessage("An intervention cannot have more than 5 attached documents.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_An_Individual_Attachment_Is_Empty()
+    {
+        var intervention = CreateValidIntervention(
+            new List<string> { "a.pdf", "" });
+
+        var result = _validator.TestValidate(intervention);
+
+        result.ShouldHaveValidationErrorFor("Attachments[1]");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_StudentIds_Is_Empty()
+    {
+        var intervention = CreateValidIntervention(studentIds: new List<int>());
+
+        var result = _validator.TestValidate(intervention);
+
+        result.ShouldHaveValidationErrorFor(x => x.StudentIds);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_RiskLevel_Is_Out_Of_Range()
+    {
+        var intervention = CreateValidIntervention(riskLevel: 6);
+
+        var result = _validator.TestValidate(intervention);
+
+        result.ShouldHaveValidationErrorFor(x => x.RiskLevel);
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_When_Intervention_Is_Fully_Valid()
+    {
+        var intervention = CreateValidIntervention();
+
+        var result = _validator.TestValidate(intervention);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}


### PR DESCRIPTION
## Description

- Add InterventionConstants.MaxAttachments (5)
- Validate total attachment count in InterventionValidator
- Check existing + incoming file count in

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


