### PR TITLE
feat: add unit tests to increase the code coverage for controllers already created

### DIFF
--- a/test/Eras.Api.Tests/Controllers/CohortsControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/CohortsControllerTests.cs
@@ -1,4 +1,5 @@
 using Eras.Api.Controllers;
+using Eras.Application.Utils;
 
 using MediatR;
 
@@ -28,6 +29,45 @@ public class CohortsControllerTests
     {
         // Act
         IActionResult result = await _controller.GetCohortsAsync(null, false);
+
+        // Assert
+        OkObjectResult okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(StatusCodes.Status200OK, okResult.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetCohorts_WithPollUuid_AndReturnsOkResultAsync()
+    {
+        // Act
+        IActionResult result = await _controller.GetCohortsAsync("NotNull", false);
+
+        // Assert
+        OkObjectResult okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(StatusCodes.Status200OK, okResult.StatusCode);
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetCohortsDetails_ReturnsOkResultAsync()
+    {
+        // Arrange
+        Pagination pagination = new Pagination();
+        // Act
+        IActionResult result = await _controller.GetCohortsDetailsAsync(pagination);
+
+        // Assert
+        OkObjectResult okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(StatusCodes.Status200OK, okResult.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetCohortsSummary_ReturnsOkResultAsync()
+    {
+        // Arrange
+        Pagination pagination = new Pagination();
+
+        // Act
+        IActionResult result = await _controller.GetCohortsSummaryAsync(pagination, 1);
 
         // Assert
         OkObjectResult okResult = Assert.IsType<OkObjectResult>(result);

--- a/test/Eras.Api.Tests/Controllers/CosmicLatteControllerTest.cs
+++ b/test/Eras.Api.Tests/Controllers/CosmicLatteControllerTest.cs
@@ -2,6 +2,7 @@
 using Eras.Application.Contracts.Services;
 using Eras.Application.Dtos;
 using Eras.Application.DTOs;
+using Eras.Application.DTOs.CosmicLatte;
 using Eras.Application.Features.Configurations.Queries.GetConfiguration;
 using Eras.Application.Services;
 using Eras.Domain.Entities;
@@ -17,6 +18,8 @@ namespace Eras.Api.Tests.Controllers
     public class CosmicLatteControllerTest
     {
         Mock<ICosmicLatteAPIService> mockService = new();
+        Mock<IImportJobService> mockImportJobService = new();
+        Mock<IFeatureFlagService> mockFeatureFlagService = new();
         private CosmicLatteController controller;
 
         public CosmicLatteControllerTest()
@@ -34,23 +37,23 @@ namespace Eras.Api.Tests.Controllers
                 });
 
             mockService.Setup(service => service.GetAllPollsPreview(
-         It.Is<string>(name => name == "Encuesta"),
-         It.IsAny<string>(),
-         It.IsAny<string>(),
-         It.IsAny<string>(),
-         It.IsAny<string>()
-         )).ReturnsAsync(new List<PollDTO> { new PollDTO() });
+                It.Is<string>(name => name == "Encuesta"),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()
+                )).ReturnsAsync(new List<PollDTO> { new PollDTO() });
 
             mockService.Setup(service => service.GetAllPollsPreview(
-            It.Is<string>(name => name == "Name not found"),
-            It.IsAny<string>(),
-            It.IsAny<string>(),
-            It.IsAny<string>(),
-            It.IsAny<string>()
-            )).ReturnsAsync(new List<PollDTO>());
+                It.Is<string>(name => name == "Name not found"),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()
+                )).ReturnsAsync(new List<PollDTO>());
 
-            var mockImportJobService = new Mock<IImportJobService>();
-            var mockFeatureFlagService = new Mock<IFeatureFlagService>();
+            mockImportJobService = new Mock<IImportJobService>();
+            mockFeatureFlagService = new Mock<IFeatureFlagService>();
 
             controller = new CosmicLatteController(
                 mockMediator.Object,
@@ -76,6 +79,344 @@ namespace Eras.Api.Tests.Controllers
             var okResult = Assert.IsType<OkObjectResult>(result);
             var polls = okResult.Value as List<PollDTO>;
             Assert.Empty(polls ?? []);
+        }
+
+        [Fact]
+        public async Task GetPreviewPollsAsync_Should_Return_BadRequest_WhenNameIsTooLongAsync()
+        {
+            var name = new string('A', 101);
+            var result = await controller.GetPreviewPollsAsync(name, "", "", 1);
+            var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal(400, badRequest.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetPreviewPollsAsync_Should_Return_BadRequest_ArgumentExceptionAsync()
+        {
+            mockService
+                .Setup(x => x.GetAllPollsPreview(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .ThrowsAsync(new ArgumentException("Invalid configuration"));
+            var result = await controller.GetPreviewPollsAsync("Poll", "", "", 1);
+            var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task GetPreviewPollsAsync_Should_Return_MaxLengthError_WhenEvaluationNotFoundAsync()
+        {
+            var name = new string('A', 100);
+            mockService
+                .Setup(x => x.GetAllPollsPreview(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .ThrowsAsync(new ArgumentException("Evaluation not found"));
+            var result = await controller.GetPreviewPollsAsync(name, "", "", 1);
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task GetPreviewPollsAsync_Should_Return_BadReques_InvalidCastExceptionAsync()
+        {
+            mockService
+                .Setup(x => x.GetAllPollsPreview(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .ThrowsAsync(new InvalidCastException());
+            var result = await controller.GetPreviewPollsAsync("Poll", "", "", 1);
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task GetPreviewPollsAsync_Should_Return_InternalServerErrorAsync()
+        {
+            mockService
+                .Setup(x => x.GetAllPollsPreview(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .ThrowsAsync(new Exception("Something failed"));
+            var result = await controller.GetPreviewPollsAsync("Poll", "", "", 1);
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(500, objectResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task IsCosmicLatteApiHealthyAsync_Should_Return_500Async()
+        {
+            mockService
+                .Setup(x => x.CosmicApiIsHealthy(It.IsAny<string>(), It.IsAny<string>()))
+                .ThrowsAsync(new Exception("Error"));
+            var result = await controller.IsCosmicLatteApiHealthyAsync(1);
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(500, objectResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task SavePreviewPollsAsync_Should_Return_OkResultWithFlagAsync()
+        {
+            mockFeatureFlagService
+                .Setup(x => x.UseEnhancedEvaluationImport())
+                .ReturnsAsync(true);
+            mockImportJobService
+                .Setup(x => x.QueueImportAsync(It.IsAny<List<PollDTO>>(), 5))
+                .ReturnsAsync(123);
+            var result = await controller.SavePreviewPollsAsync(It.IsAny<List<PollDTO>>(), 1);
+            var okResult = Assert.IsType<AcceptedResult>(result);
+            Assert.IsType<AcceptedResult>(result);
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public async Task SavePreviewPollsAsync_Should_Return_OkResultAWithFlagOffAsync()
+        {
+            mockFeatureFlagService
+                .Setup(x => x.UseEnhancedEvaluationImport())
+                .ReturnsAsync(false);
+            mockService
+                .Setup(x => x.SavePreviewPolls(It.IsAny<List<PollDTO>>(), 5))
+                .ReturnsAsync(new CreatedPollDTO { 
+                    Id = 1,
+                    FinishedAt = DateTime.UtcNow,
+                    IdCosmicLatte = "",
+                    Uuid = "",
+                    Version = "1.0.0",
+                    Name = "name",
+                    studentDTOs = [],
+                });
+            var result = await controller.SavePreviewPollsAsync(It.IsAny<List<PollDTO>>(), 1);
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.NotNull(result);
+            Assert.IsType<OkObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task StartExtraction_Should_Return_OkResultAsync()
+        {
+            mockImportJobService
+                .Setup(x => x.StartExtractionAsync("", 1, "", "", 5))
+                .ReturnsAsync(1);
+            var result = await controller.StartExtractionAsync(new StartExtractionRequest
+            {
+                EvaluationSetName = "",
+                ConfigurationId = 1,
+                EvaluationId = 5,
+            });
+            var okResult = Assert.IsType<AcceptedResult>(result);
+            Assert.NotNull(result);
+            Assert.IsType<AcceptedResult>(result);
+        }
+
+        [Fact]
+        public async Task StartExtractionAsync_Should_Return_BadRequest_WhenArgumentExceptionAsync()
+        {
+            var request = new StartExtractionRequest
+            {
+                EvaluationSetName = "Evaluation",
+                ConfigurationId = 1,
+                StartDate = "2024-01-01",
+                EndDate = "2024-12-31",
+                EvaluationId = 5
+            };
+            mockImportJobService
+                .Setup(x => x.StartExtractionAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<int>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<int>()))
+                .ThrowsAsync(new ArgumentException("Error"));
+            var result = await controller.StartExtractionAsync(request);
+            var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal(400, badRequest.StatusCode);
+        }
+
+        [Fact]
+        public async Task ConfirmImport_Should_Return_BadRequest_WhenEmptyRequestAsync()
+        {
+            var request = new ConfirmImportRequest
+            {
+                ItemIds = new List<int>()
+            };
+            var result = await controller.ConfirmImportAsync(1, request);
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task ConfirmImport_Should_Return_BadRequest_WhenNotFoundJobAsync()
+        {
+            mockImportJobService
+                .Setup(x => x.ConfirmImportAsync(1, It.IsAny<List<int>>()))
+                .ReturnsAsync(false);
+            var request = new ConfirmImportRequest{ ItemIds = new List<int>([1])};
+            var result = await controller.ConfirmImportAsync(1, request);
+            Assert.IsType<NotFoundObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task ConfirmImport_Should_Return_AcceptedRequestAsync()
+        {
+            mockImportJobService
+                .Setup(x => x.ConfirmImportAsync(1, It.IsAny<List<int>>()))
+                .ReturnsAsync(true);
+            var request = new ConfirmImportRequest { ItemIds = new List<int>([1]) };
+            var result = await controller.ConfirmImportAsync(1, request);
+            Assert.IsType<AcceptedResult>(result);
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public async Task RetryImportItemsAsync_Should_Return_BadRequest_WhenEmptyRequestAsync()
+        {
+            var request = new RetryImportItemsRequest
+            {
+                ItemIds = new List<int>()
+            };
+            var result = await controller.RetryImportItemsAsync(1, request);
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task RetryImportItemsAsync_Should_Return_BadRequest_WhenNotFoundJobAsync()
+        {
+            mockImportJobService
+                .Setup(x => x.RetryItemsAsync(1, It.IsAny<List<int>>()))
+                .ReturnsAsync(false);
+            var request = new RetryImportItemsRequest { ItemIds = new List<int>([1]) };
+            var result = await controller.RetryImportItemsAsync(1, request);
+            Assert.IsType<NotFoundObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task RetryImportItemsAsync_Should_Return_AcceptedRequestAsync()
+        {
+            mockImportJobService
+                .Setup(x => x.RetryItemsAsync(1, It.IsAny<List<int>>()))
+                .ReturnsAsync(true);
+            var request = new RetryImportItemsRequest { ItemIds = new List<int>([1]) };
+            var result = await controller.RetryImportItemsAsync(1, request);
+            Assert.IsType<AcceptedResult>(result);
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public async Task GetImportItemsAsync_Should_Return_BadRequest_WhenNotFoundJobAsync()
+        {
+            mockImportJobService
+                .Setup(x => x.GetStatusAsync(1))
+                .ReturnsAsync((ImportJobStatusDTO?)null);
+            var result = await controller.GetImportItemsAsync(1);
+            Assert.IsType<NotFoundObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task GetImportItemsAsync_Should_Return_AcceptedRequestAsync()
+        {
+            mockImportJobService
+                .Setup(x => x.GetStatusAsync(1))
+                .ReturnsAsync(new ImportJobStatusDTO
+                {
+                    ImportJobId = 1,
+                    EvaluationId = 2,
+                    Status = "",
+                    TotalCount = 10,
+                    ProcessedCount = 2,
+                    ExtractedCount = 2,
+                    RetryCount = 6,
+                    CreatedAtUtc = DateTime.Now,
+                    UpdatedAtUtc = DateTime.Now,
+                });
+            mockImportJobService
+               .Setup(x => x.GetItemsAsync(1))
+               .ReturnsAsync([new ImportJobItemDTO
+               {
+                   Id = 1,
+                   ImportJobId = 2,
+                   StudentEmail = "",
+                   StudentName = "",
+                   Status = "",
+                   RetryCount = 2,
+                   IsAlreadyImported = false,
+               }]);
+            var result = await controller.GetImportItemsAsync(1);
+
+            Assert.IsType<OkObjectResult>(result);
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public async Task GetImportStatusAsync_Should_Return_BadRequest_WhenNotFoundJobAsync()
+        {
+            mockImportJobService
+                .Setup(x => x.GetStatusAsync(1))
+                .ReturnsAsync((ImportJobStatusDTO?)null);
+            var result = await controller.GetImportStatusAsync(1);
+            Assert.IsType<NotFoundObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task GetImportStatusAsync_Should_Return_AcceptedRequestAsync()
+        {
+            mockImportJobService
+                .Setup(x => x.GetStatusAsync(1))
+                .ReturnsAsync( new ImportJobStatusDTO
+                {
+                    ImportJobId = 1, 
+                    EvaluationId = 2,
+                    Status = "",
+                    TotalCount = 10,
+                    ProcessedCount = 2,
+                    ExtractedCount = 2,
+                    RetryCount = 6,
+                    CreatedAtUtc = DateTime.Now,
+                    UpdatedAtUtc = DateTime.Now,
+                });
+            var result = await controller.GetImportStatusAsync(1);
+            Assert.IsType<OkObjectResult>(result);
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public async Task GetPollsNameListAsync_Should_Return_BadRequest_ForInvalidCastExceptionAsync()
+        {
+            mockService
+                .Setup(x => x.GetPollsNameList(It.IsAny<string>(), It.IsAny<string>()))
+                .ThrowsAsync(new InvalidCastException(""));
+            var result = await controller.GetPollsNameListAsync(1);
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task GetPollsNameListAsync_Should_Return_BadRequest_WhenExceptionRaisedAsync()
+        {
+            mockService
+                .Setup(x => x.GetPollsNameList(It.IsAny<string>(), It.IsAny<string>()))
+                .ThrowsAsync(new Exception("Error"));
+            var result = await controller.GetPollsNameListAsync(1);
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(500, objectResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetPollsNameListAsync_Should_Return_OkRequestAsync()
+        {
+            mockService
+                .Setup(x => x.GetPollsNameList(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync([new PollDataItem("", "", "","")]);
+            var result = await controller.GetPollsNameListAsync(1);
+            Assert.IsType<OkObjectResult>(result);
+            Assert.NotNull(result);
         }
     }
 }

--- a/test/Eras.Api.Tests/Controllers/DashboardControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/DashboardControllerTests.cs
@@ -1,0 +1,61 @@
+﻿using Eras.Api.Controllers;
+using Eras.Application.DTOs;
+using Eras.Application.Features.Dashboard.Queries.GetDashboardKpis;
+using Eras.Application.Models.Response.Common;
+
+using MediatR;
+
+using Microsoft.AspNetCore.Mvc;
+
+using Moq;
+
+namespace Eras.Api.Tests.Controllers;
+
+public class DashboardControllerTests
+{
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly DashboardController _controller;
+
+    public DashboardControllerTests()
+    {
+        _mediatorMock = new Mock<IMediator>();
+        _controller = new DashboardController(_mediatorMock.Object);
+    }
+
+    [Fact]
+    public async Task GetKpis_Should_Return_Ok_WithSuccessQueryAsync()
+    {
+        // Arrange
+        var dashboardDTO = new DashboardKpiDto() { 
+                TotalEvaluations = new KpiMetricDto { PercentageChange = 20, Value = 2 }, 
+                TotalPollsAnswered = new KpiMetricDto { PercentageChange = 20, Value = 2 }, 
+                TotalStudents = new KpiMetricDto { PercentageChange = 20, Value = 2 }};
+        var commandResponse = new GetQueryResponse<DashboardKpiDto>(dashboardDTO, "Success", true);
+        _mediatorMock
+            .Setup(M => M.Send(It.IsAny<GetDashboardKpisQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(commandResponse);
+        // Act
+        var result = await _controller.GetKpis();
+        // Assert
+        Assert.IsType<OkObjectResult>(result);
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetKpis_Should_Return_BadRequest_When_Query_Fails()
+    {
+        // Arrange
+        var response = new GetQueryResponse<DashboardKpiDto>(
+            null,
+            "Error retrieving KPIs",
+            false);
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<GetDashboardKpisQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+        // Act
+        var result = await _controller.GetKpis();
+        // Assert
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal(response, badRequest.Value);
+    }
+}

--- a/test/Eras.Api.Tests/Controllers/ErrorFilterTests.cs
+++ b/test/Eras.Api.Tests/Controllers/ErrorFilterTests.cs
@@ -1,0 +1,110 @@
+﻿using Eras.Api.Filters;
+using Eras.Error;
+using Eras.Error.Bussiness;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using Xunit;
+
+namespace Eras.Api.Tests.Controllers;
+
+public class ErrorFilterTests
+{
+    private readonly Mock<ILogger<Exception>> _loggerMock;
+    private readonly ErrorFilter _filter;
+
+    public ErrorFilterTests()
+    {
+        _loggerMock = new Mock<ILogger<Exception>>();
+        _filter = new ErrorFilter(_loggerMock.Object);
+    }
+
+    [Fact]
+    public void OnActionExecuted_DoesNothing_WhenExceptionIsNull()
+    {
+        // Arrange
+        var context = CreateActionExecutedContext();
+        context.Exception = null;
+
+        // Act
+        _filter.OnActionExecuted(context);
+
+        // Assert
+        Assert.False(context.ExceptionHandled);
+        Assert.Null(context.Result);
+    }
+
+    [Fact]
+    public void OnActionExecuted_Handles_IErasException()
+    {
+        // Arrange
+        IErasException exception = new BussinessException("Invalid request");
+        var context = CreateActionExecutedContext();
+        context.Exception = (Exception)exception;
+
+        // Act
+        _filter.OnActionExecuted(context);
+
+        // Assert
+        Assert.True(context.ExceptionHandled);
+        var result = Assert.IsType<ObjectResult>(context.Result);
+        Assert.Equal(exception.FriendlyMessage, result.Value);
+        Assert.Equal(exception.StatusCode, result.StatusCode);
+    }
+
+    [Fact]
+    public void OnActionExecuted_Wraps_NormalException_InCriticalException()
+    {
+        // Arrange
+        var exception = new Exception("Unexpected error");
+        var context = CreateActionExecutedContext();
+        context.Exception = exception;
+
+        // Act
+        _filter.OnActionExecuted(context);
+
+        // Assert
+        Assert.True(context.ExceptionHandled);
+        var result = Assert.IsType<ObjectResult>(context.Result);
+        Assert.NotNull(result.Value);
+        Assert.NotNull(result.StatusCode);
+    }
+
+    [Fact]
+    public void OnActionExecuting_DoesNothing()
+    {
+        // Arrange
+        var context = new ActionExecutingContext(
+            new ActionContext(
+                new DefaultHttpContext(),
+                new RouteData(),
+                new ActionDescriptor()),
+            new List<IFilterMetadata>(),
+            new Dictionary<string, object?>(),
+            new object());
+
+        // Act
+        _filter.OnActionExecuting(context);
+
+        // Assert
+        Assert.True(true);
+    }
+
+    private static ActionExecutedContext CreateActionExecutedContext()
+    {
+        return new ActionExecutedContext(
+            new ActionContext(
+                new DefaultHttpContext(),
+                new RouteData(),
+                new ActionDescriptor()),
+            new List<IFilterMetadata>(),
+            new object());
+    }
+}

--- a/test/Eras.Api.Tests/Controllers/EvaluationControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/EvaluationControllerTests.cs
@@ -1,8 +1,15 @@
 ﻿using Eras.Api.Controllers;
 using Eras.Application.DTOs;
 using Eras.Application.Features.Evaluations.Commands;
+using Eras.Application.Features.Evaluations.Commands.DeleteEvaluation;
+using Eras.Application.Features.Evaluations.Commands.UpdateEvaluation;
+using Eras.Application.Features.Evaluations.Queries;
+using Eras.Application.Features.Evaluations.Queries.GetAll;
+using Eras.Application.Features.Evaluations.Queries.GetByDateRange;
 using Eras.Application.Mappers;
+using Eras.Application.Models.Response;
 using Eras.Application.Models.Response.Common;
+using Eras.Application.Utils;
 using Eras.Domain.Entities;
 
 using MediatR;
@@ -39,6 +46,112 @@ namespace Eras.Api.Tests.Controllers
 
             Assert.NotNull(result);
             Assert.Equal(200, result.StatusCode);
+        }
+
+        [Fact]
+        public async Task UpdateEvaluation_Should_Return_Ok_When_Ids_MatchAsync()
+        {
+            var dto = new EvaluationDTO
+            {
+                Id = 1,
+                Name = "Updated Evaluation",
+                StartDate = DateTime.UtcNow,
+                EndDate = DateTime.UtcNow.AddDays(1)
+            };
+            var response = new CreateCommandResponse<Evaluation>(
+                dto.ToDomain(),
+                "Updated",
+                true);
+            _mockMediator
+                .Setup(x => x.Send(It.IsAny<UpdateEvaluationCommand>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(response);
+            var result = await _controller.UpdateEvaluationAsync(1, dto);
+            var ok = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(200, ok.StatusCode);
+        }
+
+        [Fact]
+        public async Task UpdateEvaluation_Should_Return_BadRequest_WhenIdsDoNotMatchAsync()
+        {
+            var dto = new EvaluationDTO {
+                Id = 2,
+                Name = "Evaluation",
+                StartDate = DateTime.Now,
+                EndDate= DateTime.Now,
+            };
+            var result = await _controller.UpdateEvaluationAsync(1, dto);
+            var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal(400, badRequest.StatusCode);
+            _mockMediator.Verify(
+                x => x.Send(It.IsAny<UpdateEvaluationCommand>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task DeleteEvaluation_Should_Return_OkAsync()
+        {
+            _mockMediator
+                .Setup(x => x.Send(It.IsAny<DeleteEvaluationCommand>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new BaseResponse("Deleted", true));
+            var result = await _controller.DeleteEvaluationAsync(1);
+            var ok = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(200, ok.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetEvaluationDetailsAsync_Should_ReturnOk_WhenFoundAsync()
+        {
+            var response = new GetQueryResponse<Evaluation>(
+                new Evaluation(),
+                "Success",
+                true);
+            _mockMediator
+                .Setup(X => X.Send(It.IsAny<GetEvaluationSummaryQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(response);
+            var result = await _controller.GetEvaluationDetailsAsync(1);
+            Assert.IsType<OkObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task GetEvaluationDetails_Should_Return_NotFound_WhenBodyIsNullAsync()
+        {
+            var response = new GetQueryResponse<Evaluation>(
+                null,
+                "Not found",
+                false);
+            _mockMediator
+                .Setup(x => x.Send(It.IsAny<GetEvaluationSummaryQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(response);
+            var result = await _controller.GetEvaluationDetailsAsync(1);
+            Assert.IsType<NotFoundObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task GetAllEvaluation_Should_Return_OkAsync()
+        {
+            var page = new PagedResult<Evaluation>(0, new List<Evaluation>());
+            _mockMediator
+                .Setup(x => x.Send(It.IsAny<GetAllEvaluationsQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(page);
+
+            var result = await _controller.GetAllEvaluationsAsync(new Pagination());
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(page, ok.Value);
+        }
+
+        [Fact]
+        public async Task GetAllEvaluationsByDateRange_Should_Return_OkAsync()
+        {
+            var evaluations = new List<Evaluation>{new Evaluation()};
+            _mockMediator
+                .Setup(x => x.Send(It.IsAny<GetEvaluationsByDateRangeQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(evaluations);
+            var result = await _controller.GetAllEvaluationsByDateRangeAsync(
+                DateTime.UtcNow,
+                DateTime.UtcNow.AddDays(1));
+            var ok = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(evaluations, ok.Value);
         }
     }
 }

--- a/test/Eras.Api.Tests/Controllers/EvaluationDetailsControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/EvaluationDetailsControllerTests.cs
@@ -1,17 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Eras.Api.Controllers;
+﻿using Eras.Api.Controllers;
+using Eras.Application.DTOs;
+using Eras.Application.Features.EvaluationDetails.Queries.GetStudentsByEvaluationId;
+using Eras.Application.Features.EvaluationDetails.Queries.GetStudentsByFilters;
 using Eras.Application.Features.EvaluationDetails.Queries.GetStudentsRecentAlerts;
 using Eras.Application.Models.Response.Controllers.EvaluationDetailsController;
 using Eras.Application.Utils;
 
 using MediatR;
 
-using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
@@ -53,5 +49,89 @@ public class EvaluationDetailsControllerTests
         _mockMediator.Verify(X => X.Send(
             It.IsAny<GetStudentsRecentAlertsQuery>(),
             It.IsAny<CancellationToken>()),Times.Once);
-     }
+    }
+
+    [Fact]
+    public async Task StudentsByFilterAsync_Should_Return_SuccessAsync()
+    {
+        // Arrange
+        var pagination = new Pagination();
+        var expectedResult = new PagedResult<StudentsByFiltersResponse>(2, new List<StudentsByFiltersResponse> { new(), new() });
+        _mockMediator
+            .Setup(X => X.Send(It.IsAny<GetStudentsByFiltersQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResult);
+
+        // Act
+        var result = await _controller.StudentsByFilterAsync("", 1, [""], [1], [1], [1], pagination);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var value = Assert.IsType<PagedResult<StudentsByFiltersResponse>>(okResult.Value);
+        Assert.Equal(expectedResult, value);
+
+        _mockMediator.Verify(X => X.Send(
+            It.IsAny<GetStudentsByFiltersQuery>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task StudentsByFilterAsync_Should_Return_NotFound_WhenResponseIsNullAsync()
+    {
+        // Arrange
+        _mockMediator
+            .Setup(x => x.Send(It.IsAny<StudentsByFiltersResponse>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PagedResult<StudentsByFiltersResponse>?)null);
+        // Act
+        var result = await _controller.StudentsByFilterAsync("", 1, [""], [1], [1], [1], new Pagination());
+        // Assert
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task StudentsByEvaluationIdAsync_Should_Return_SuccessAsync()
+    {
+        // Arrange
+        var expectedResult = new List<StudentsByFiltersResponse>{
+            new StudentsByFiltersResponse() {
+                Id = 2,
+                Name = "",
+                Email = "",
+                AnswerId = 2,
+                AnswerText = "",
+                RiskLevel = 2
+            }
+        };
+        _mockMediator
+            .Setup(X => X.Send(It.IsAny<GetStudentsByEvaluationIdQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResult);
+
+        // Act
+        var result = await _controller.StudentsByEvaluationIdAsync(1, [""], [1], [1], [1]);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(expectedResult, okResult.Value);
+
+        _mockMediator.Verify(X => X.Send(
+            It.IsAny<GetStudentsByEvaluationIdQuery>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task StudentsByEvaluationIdAsync_Should_Return_NotFound_WhenResponseIsNullAsync()
+    {
+        // Arrange
+        _mockMediator
+            .Setup(x => x.Send(It.IsAny<GetStudentsByEvaluationIdQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<StudentsByFiltersResponse>?)null);
+        // Act
+        var result = await _controller.StudentsByEvaluationIdAsync(
+            1,
+            new List<string> { "" },
+            new List<int> { 1 },
+            new List<int> { 10 },
+            new List<decimal> { 0.25m });
+        // Assert
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
 }

--- a/test/Eras.Api.Tests/Controllers/HeatMapControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/HeatMapControllerTests.cs
@@ -1,8 +1,16 @@
 ﻿using Eras.Api.Controllers;
+using Eras.Application.DTOs.HeatMap;
+using Eras.Application.Features.HeatMap.Queries.GetHeatMapByPollIdAndVariableIds;
 using Eras.Application.Features.HeatMap.Queries.GetHeatMapDataByAllComponents;
+using Eras.Application.Features.HeatMap.Queries.GetHeatMapDetailsByCohort;
+using Eras.Application.Features.HeatMap.Queries.GetHeatMapDetailsByComponent;
+using Eras.Application.Features.HeatMap.Queries.GetHeatMapSummary;
+using Eras.Application.Features.HeatMap.Queries.GetHeatMapSummaryByFilters;
 using Eras.Application.Models.Response;
 using Eras.Application.Models.Response.Common;
 using Eras.Application.Models.Response.HeatMap;
+using Eras.Domain.Entities;
+
 using MediatR;
 
 using Microsoft.AspNetCore.Mvc;
@@ -61,5 +69,150 @@ public class HeatMapControllerTests
         BadRequestObjectResult badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
         Assert.IsAssignableFrom<BaseResponse>(badRequestResult.Value);
         Assert.IsType<GetQueryResponse<IEnumerable<HeatMapByComponentsResponseVm>>>(badRequestResult.Value);
+    }
+
+    [Fact]
+    public async Task GetHeatMapSummaryAsync_ReturnsOk_WhenSuccessAsync()
+    {
+        string pollUUID = "example-correct-uuid";
+        var fakeResponse = new GetQueryResponse<HeatMapSummaryResponseVm>(
+            null, "Success", true
+        );
+
+        _mediatorMock
+            .Setup(Med => Med.Send(It.IsAny<GetHeatMapSummaryQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(fakeResponse);
+
+        IActionResult result = await _controller.GetHeatMapSummaryAsync(pollUUID);
+
+        OkObjectResult okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.IsAssignableFrom<BaseResponse>(okResult.Value);
+        Assert.IsType<GetQueryResponse<HeatMapSummaryResponseVm>>(okResult.Value);
+    }
+
+    [Fact]
+    public async Task GetHeatMapSummaryAsync_ReturnsBadRequest_WhenFailureAsync()
+    {
+        var pollUUID = "example-invalid-uuid";
+        var fakeResponse = new GetQueryResponse<HeatMapSummaryResponseVm>(
+            null, "Invalid request", false
+        );
+
+        _mediatorMock
+            .Setup(Med => Med.Send(It.IsAny<GetHeatMapSummaryQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(fakeResponse);
+
+        IActionResult result = await _controller.GetHeatMapSummaryAsync(pollUUID);
+
+        BadRequestObjectResult badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.IsAssignableFrom<BaseResponse>(badRequestResult.Value);
+        Assert.IsType<GetQueryResponse<HeatMapSummaryResponseVm>>(badRequestResult.Value);
+    }
+
+    [Fact]
+    public async Task GetHeatMapSummaryByFilters_ReturnsOk_WhenSuccessAsync()
+    {
+        var fakeResponse = new GetQueryResponse<HeatMapSummaryResponseVm>(
+            null, "Success", true
+        );
+
+        _mediatorMock
+            .Setup(Med => Med.Send(It.IsAny<GetHeatMapSummaryByFiltersQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(fakeResponse);
+
+        IActionResult result = await _controller.GetHeatMapSummaryByFiltersAsync(2, 5);
+
+        OkObjectResult okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.IsAssignableFrom<BaseResponse>(okResult.Value);
+        Assert.IsType<GetQueryResponse<HeatMapSummaryResponseVm>>(okResult.Value);
+    }
+
+    [Fact]
+    public async Task GetHeatMapSummaryByFilters_ReturnsBadRequest_WhenFailureAsync()
+    {
+        var fakeResponse = new GetQueryResponse<HeatMapSummaryResponseVm>(
+            null, "Invalid request", false
+        );
+
+        _mediatorMock
+            .Setup(Med => Med.Send(It.IsAny<GetHeatMapSummaryByFiltersQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(fakeResponse);
+
+        IActionResult result = await _controller.GetHeatMapSummaryByFiltersAsync(1, 2);
+
+        BadRequestObjectResult badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.IsAssignableFrom<BaseResponse>(badRequestResult.Value);
+        Assert.IsType<GetQueryResponse<HeatMapSummaryResponseVm>>(badRequestResult.Value);
+    }
+
+    [Fact]
+    public async Task GetStudentHeatMapDetailsByComponent_ReturnsOk_WhenSuccessAsync()
+    {
+        var fakeResponse = new List<StudentHeatMapDetailDto>
+        {
+            new StudentHeatMapDetailDto
+            {
+                 StudentId = 1,
+                StudentName = "",
+                RiskLevel = 2,
+                ComponentName = "Test",
+            }
+        };
+        _mediatorMock
+            .Setup(Med => Med.Send(It.IsAny<GetHeatMapDetailsByComponentQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(fakeResponse);
+
+        IActionResult result = await _controller.GetStudentHeatMapDetailsByComponentAsync("Component", 5);
+
+        OkObjectResult okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.IsType<List<StudentHeatMapDetailDto>>(okResult.Value);
+    }
+
+    [Fact]
+    public async Task GetStudentHeatMapDetailsByCohort_ReturnsOk_WhenSuccessAsync()
+    {
+        var fakeResponse = new List<StudentHeatMapDetailDto>
+        {
+            new StudentHeatMapDetailDto
+            {
+                 StudentId = 1,
+                StudentName = "",
+                RiskLevel = 2,
+                ComponentName = "Test",
+            }
+        };
+        _mediatorMock
+            .Setup(Med => Med.Send(It.IsAny<GetHeatMapDetailsByCohortQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(fakeResponse);
+
+        IActionResult result = await _controller.GetStudentHeatMapDetailsByCohortAsync("Cohort", 5);
+
+        OkObjectResult okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.IsType<List<StudentHeatMapDetailDto>>(okResult.Value);
+    }
+
+    [Fact]
+    public async Task GetHeatMapDataByPollUuidAndVariableIdsAsync_ReturnsOk_WhenSuccessAsync()
+    {
+        var fakeResponse = new List<HeatMapBaseData>
+        {
+            new HeatMapBaseData
+            {
+                Name = "",
+                Data = new List<Serie>{},
+            }
+        };
+        _mediatorMock
+            .Setup(Med => Med.Send(It.IsAny<GetHeatMapByPollIdAndVariableIdsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(fakeResponse);
+        var request = new HeatMapBaseDataRequestDto
+        {
+            pollInstanceUuid = "1",
+            VariablesIds = new List<int> { 1, 2, 3 }
+        };
+        IActionResult result = await _controller.GetHeatMapDataByPollUuidAndVariableIdsAsync(request);
+
+        OkObjectResult okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.IsType<List<HeatMapBaseData>>(okResult.Value);
     }
 }


### PR DESCRIPTION
## Description

Unit test to increase the code coverage for:

- Dashboard controller
- Evaluations controller
- Evaluation details controller
- Cohorts controller
- Cosmic latte controller
- Heatmap controller
- Error filter

<img width="1752" height="273" alt="image" src="https://github.com/user-attachments/assets/8e0fc1ad-264c-412e-8302-91565ebd4264" />


## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [x] Others: Unit tests

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


