### PR TITLE
472 enhancement add new unit tests for controllers in api layer

### DIFF
--- a/src/Eras.Api/Controllers/AssessmentManagement/AssessmentsController.cs
+++ b/src/Eras.Api/Controllers/AssessmentManagement/AssessmentsController.cs
@@ -15,7 +15,6 @@ namespace Eras.Api.Controllers.AssessmentManagement;
 [ApiController]
 [Route("api/v1/assessments")]
 [Authorize]
-[ExcludeFromCodeCoverage]
 public class AssessmentsController(IMediator Mediator, ILogger<AssessmentsController> Logger, IOptions<FileStorageSettings> FileStorageOptions, IFileStorageService FileStorage) : ControllerBase 
 {
     private readonly FileStorageSettings _fileStorageSettings = FileStorageOptions.Value;

--- a/src/Eras.Api/Controllers/AuthControllers.cs
+++ b/src/Eras.Api/Controllers/AuthControllers.cs
@@ -11,7 +11,6 @@ namespace Eras.Api.Controllers;
 [AllowAnonymous]
 [Route("api/v1/auth")]
 [ApiController]
-[ExcludeFromCodeCoverage]
 public class AuthController(
     IKeycloakAuthService<TokenResponse> KeycloakAuthService, ILogger<AuthController> Logger) : ControllerBase
 {

--- a/src/Eras.Api/Controllers/ConfigurationsController.cs
+++ b/src/Eras.Api/Controllers/ConfigurationsController.cs
@@ -8,13 +8,11 @@ using Eras.Application.Features.Configurations.Queries.GetUserConfigurations;
 using MediatR;
 
 using Microsoft.AspNetCore.Mvc;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Eras.Api.Controllers;
 
 [ApiController]
 [Route("api/v1/configurations")]
-[ExcludeFromCodeCoverage]
 public class ConfigurationsController(IMediator Mediator, ILogger<ConfigurationsController> Logger) : ControllerBase
 {
     private readonly IMediator _mediator = Mediator;

--- a/src/Eras.Api/Controllers/FeatureFlagController.cs
+++ b/src/Eras.Api/Controllers/FeatureFlagController.cs
@@ -14,7 +14,6 @@ namespace Eras.Api.Controllers;
 [ApiController]
 [Route("api/v1/feature-flags")]
 [Authorize]
-[ExcludeFromCodeCoverage]
 public class FeatureFlagController(IMediator Mediator, ILogger<FeatureFlagController> Logger): ControllerBase
 {
     private readonly IMediator _mediator = Mediator;

--- a/src/Eras.Api/Controllers/JUProfessionalController.cs
+++ b/src/Eras.Api/Controllers/JUProfessionalController.cs
@@ -13,7 +13,6 @@ namespace Eras.Api.Controllers;
 
 [ApiController]
 [Route("api/v1/professionals")]
-[ExcludeFromCodeCoverage]
 public class ProfessionalsController(IMediator Mediator, ILogger<ProfessionalsController> Logger) : ControllerBase
 {
     private readonly IMediator _mediator = Mediator;

--- a/src/Eras.Api/Controllers/JUServiceController.cs
+++ b/src/Eras.Api/Controllers/JUServiceController.cs
@@ -13,7 +13,6 @@ namespace Eras.Api.Controllers;
 
 [ApiController]
 [Route("api/v1/ju_services")]
-[ExcludeFromCodeCoverage]
 public class JUServiceController(IMediator Mediator, ILogger<JUServiceController> Logger) : ControllerBase
 {
     private readonly IMediator _mediator = Mediator;

--- a/src/Eras.Api/Controllers/PollInstancesController.cs
+++ b/src/Eras.Api/Controllers/PollInstancesController.cs
@@ -14,7 +14,6 @@ namespace Eras.Api.Controllers;
 
 [Route("api/v1/poll-instances")]
 [ApiController]
-[ExcludeFromCodeCoverage]
 public class PollInstancesController(IMediator Mediator, ILogger<StudentsController> Logger) : ControllerBase
 {
 

--- a/src/Eras.Api/Controllers/PollsController.cs
+++ b/src/Eras.Api/Controllers/PollsController.cs
@@ -15,7 +15,6 @@ namespace Eras.Api.Controllers;
 
 [ApiController]
 [Route("api/v1/polls")]
-[ExcludeFromCodeCoverage]
 public class PollsController(IMediator Mediator, ILogger<PollsController> Logger) : ControllerBase
 {
     private readonly IMediator _mediator = Mediator;

--- a/src/Eras.Api/Controllers/ReportsController.cs
+++ b/src/Eras.Api/Controllers/ReportsController.cs
@@ -19,7 +19,6 @@ namespace Eras.Api.Controllers;
 [ApiController]
 [Route("api/v1/reports")]
 [Authorize]
-[ExcludeFromCodeCoverage]
 public class ReportsController(IMediator Mediator) : ControllerBase
 {
     private readonly IMediator _mediator = Mediator;

--- a/src/Eras.Api/Controllers/ServiceProvidersController.cs
+++ b/src/Eras.Api/Controllers/ServiceProvidersController.cs
@@ -13,7 +13,6 @@ namespace Eras.Api.Controllers;
 
 [ApiController]
 [Route("api/v1/service-providers")]
-[ExcludeFromCodeCoverage]
 public class ServiceProvidersController(IMediator Mediator, ILogger<ServiceProvidersController> Logger) : ControllerBase
 {
     private readonly IMediator _mediator = Mediator;

--- a/src/Eras.Api/Controllers/StudentsController.cs
+++ b/src/Eras.Api/Controllers/StudentsController.cs
@@ -27,7 +27,6 @@ namespace Eras.Api.Controllers;
 [ApiController]
 [Route("api/v1/students")]
 [Authorize]
-[ExcludeFromCodeCoverage]
 public class StudentsController(IMediator Mediator, ILogger<StudentsController> Logger) : ControllerBase
 {
     private readonly IMediator _mediator = Mediator;

--- a/test/Eras.Api.Tests/Controllers/AssessmentsControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/AssessmentsControllerTests.cs
@@ -1,0 +1,416 @@
+﻿using Eras.Api.Controllers.AssessmentManagement;
+using Eras.Application.Contracts.Infrastructure;
+using Eras.Application.DTOs.AssessmentManagement;
+using Eras.Application.Features.RemissionManagement;
+using Eras.Application.Models;
+using Eras.Domain.Entities.AssessmentManagement;
+
+using MediatR;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using Moq;
+
+namespace Eras.Api.Tests.Controllers;
+
+public class AssessmentsControllerTests
+{
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly Mock<ILogger<AssessmentsController>> _loggerMock;
+    private readonly Mock<IFileStorageService> _storageMock;
+    private readonly AssessmentsController _controller;
+
+    public AssessmentsControllerTests()
+    {
+        _mediatorMock = new Mock<IMediator>();
+        _loggerMock = new Mock<ILogger<AssessmentsController>>();
+        _storageMock = new Mock<IFileStorageService>();
+        IOptions<FileStorageSettings> options = Options.Create(new FileStorageSettings() { AllowedExtensions = [], BasePath = "" });
+
+        _controller = new AssessmentsController(
+            _mediatorMock.Object,
+            _loggerMock.Object,
+            options,
+            _storageMock.Object);
+    }
+
+    [Fact]
+    public async Task GetAll_ReturnsOkAsync()
+    {
+        var dto = new AssessmentDto
+        {
+            Id = 1,
+            CreatedBy = "",
+            Status = AssessmentStatus.Remitted,
+            Service = "",
+            StudentIds = [1, 2],
+        };
+        var response = new List<AssessmentDto> { dto };
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<GetAllRemissionsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        var result = await _controller.GetAll(CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsOkAsync()
+    {
+        var dto = new AssessmentDto { 
+            Id = 1, 
+            CreatedBy = "",
+            Status = AssessmentStatus.Remitted,
+            Service = "",
+            StudentIds = [1, 2],
+        };
+
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<GetRemissionByIdQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(dto);
+
+        var result = await _controller.GetById(1, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsNotFound_WhenNullAsync()
+    {
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<GetRemissionByIdQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AssessmentDto?)null);
+
+        var result = await _controller.GetById(1, CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetByStudentId_ReturnsOkAsync()
+    {
+        var dto = new List<AssessmentDto>{
+            new AssessmentDto {
+                Id = 1,
+                CreatedBy = "",
+                Status = AssessmentStatus.Remitted,
+                Service = "",
+                StudentIds = [1, 2],
+            }
+        };
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<GetRemissionsByStudentIdQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(dto);
+
+        var result = await _controller.GetByStudentId(1, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetByStudentId_ReturnsNotFound_WhenNullAsync()
+    {
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<GetRemissionsByStudentIdQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<AssessmentDto>?)null);
+
+        var result = await _controller.GetById(1, CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetByStatus_ReturnsOkAsync()
+    {
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<GetRemissionsByStatusQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AssessmentDto>());
+
+        var result = await _controller.GetByStatus("Remitted", CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetByStatus_ReturnsNotFound_WhenNullAsync()
+    {
+        var result = await _controller.GetByStatus("StatusIncorrect", CancellationToken.None);
+
+        Assert.IsType<BadRequestObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task Create_ReturnsOkAsync()
+    {
+        var dto = new AssessmentDto {
+            Id = 1,
+            CreatedBy = "",
+            Status = AssessmentStatus.Remitted,
+            Service = "",
+            StudentIds = [1, 2],
+        };
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<CreateRemissionCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(dto);
+
+        var result = await _controller.Create(dto, CancellationToken.None);
+
+        var created = Assert.IsType<CreatedAtActionResult>(result.Result);
+        Assert.Equal(nameof(AssessmentsController.GetById), created.ActionName);
+    }
+
+    [Fact]
+    public async Task Update_ReturnsOkAsync()
+    {
+        var dto = new AssessmentDto
+        {
+            Id = 1,
+            CreatedBy = "",
+            Status = AssessmentStatus.Remitted,
+            Service = "",
+            StudentIds = [1, 2],
+        };
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<UpdateRemissionCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(dto);
+
+        var result = await _controller.Update(5, dto, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task Update_ReturnsBadRequest_WhenNullResponseAsync()
+    {
+        var dto = new AssessmentDto
+        {
+            Id = default,
+            CreatedBy = "",
+            Status = AssessmentStatus.Remitted,
+            Service = "",
+            StudentIds = [1, 2],
+        };
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<UpdateRemissionCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AssessmentDto?)null);
+
+        var result = await _controller.Update(1, dto, CancellationToken.None);
+
+        Assert.IsType<BadRequestObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task Update_ReturnsConflictResponseAsync()
+    {
+        var dto = new AssessmentDto
+        {
+            Id = 1,
+            CreatedBy = "",
+            Status = AssessmentStatus.Remitted,
+            Service = "",
+            StudentIds = [1, 2],
+        };
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<UpdateRemissionCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException("busy"));
+        var result = await _controller.Update(1, dto, CancellationToken.None);
+
+        Assert.IsType<ConflictObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task Delete_ReturnsNoContentResultAsync()
+    {
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<DeleteAssessmentCommand>(), It.IsAny<CancellationToken>()));
+
+        var result = await _controller.Delete(1, CancellationToken.None);
+
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task Delete_FailsAndReturnsNotFoundAsync()
+    {
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<DeleteAssessmentCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new KeyNotFoundException());
+        var result = await _controller.Delete(1, CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task GetInterventions_ReturnsOkAsync()
+    {
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<GetInterventionsByAssessmentQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(It.IsAny<List<InterventionDto>>);
+
+        var result = await _controller.GetInterventions(1, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task AddIntervention_ReturnsCreatedAsync()
+    {
+        var dto = new AddInterventionDto
+        {
+            AssessmentId = 1,
+            Intervention = null,
+        };
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<AddInterventionCommand>(), It.IsAny<CancellationToken>()));
+
+        var result = await _controller.AddIntervention(dto, CancellationToken.None);
+
+        Assert.IsType<CreatedResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task UpsertInterventions_ReturnsConflictResponseAsync()
+    { 
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<UpsertInterventionsCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException("busy"));
+        var result = await _controller.UpsertInterventions(1, It.IsAny<List<InterventionDto>>(), CancellationToken.None);
+
+        Assert.IsType<ConflictObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task UpsertInterventions_ReturnsOkResponseAsync()
+    {
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<UpsertInterventionsCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(It.IsAny<List<InterventionDto>>());
+        var result = await _controller.UpsertInterventions(1, It.IsAny<List<InterventionDto>>(), CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task DeleteIntervention_ReturnsNoContentResultAsync()
+    {
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<DeleteInterventionCommand>(), It.IsAny<CancellationToken>()));
+
+        var result = await _controller.DeleteIntervention(1, 1, CancellationToken.None);
+
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task DeleteIntervention_FailsAndReturnsNotFoundAsync()
+    {
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<DeleteInterventionCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new KeyNotFoundException());
+        var result = await _controller.DeleteIntervention(1, 1, CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task UploadAttachments_FailsAndReturnsNotFoundAsync()
+    {
+        var files = new FormFileCollection();
+        var result = await _controller.UploadAttachments(1, files, CancellationToken.None);
+        Assert.IsType<BadRequestObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task UploadAttachments_ReturnsOkAsync()
+    {
+        var stream = new MemoryStream(new byte[] { 1, 2, 3 });
+        IFormFile file = new FormFile(stream, 0, stream.Length, "file", "test.pdf");
+        var files = new FormFileCollection{file};
+
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<UploadInterventionAttachmentsCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<string> { "test.pdf" });
+
+        var result = await _controller.UploadAttachments(1, files, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task UploadAttachments_FailsAndReturnsConflictAsync()
+    {
+        var stream = new MemoryStream(new byte[] { 1, 2, 3 });
+        IFormFile file = new FormFile(stream, 0, stream.Length, "file", "test.pdf");
+        var files = new FormFileCollection { file };
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<UploadInterventionAttachmentsCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("exists"));
+        var result = await _controller.UploadAttachments(1, files, CancellationToken.None);
+
+        Assert.IsType<ConflictObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task DownloadAttachment_WithUnrecognizedExtensionAsync()
+    {
+        _storageMock
+            .Setup(x => x.ReadAsync(It.IsAny<string>()))
+            .ReturnsAsync(new MemoryStream());
+        var result = await _controller.DownloadAttachment(1, "file.xyz", CancellationToken.None);
+
+        var file = Assert.IsType<FileStreamResult>(result);
+
+        Assert.Equal("application/octet-stream", file.ContentType);
+    }
+
+    [Fact]
+    public async Task DownloadAttachment_ReturnsOkAsync()
+    {
+        _storageMock
+            .Setup(x => x.ReadAsync(It.IsAny<string>()))
+            .ReturnsAsync(new MemoryStream());
+        var result = await _controller.DownloadAttachment(1, "test.pdf", CancellationToken.None);
+        var file = Assert.IsType<FileStreamResult>(result);
+
+        Assert.Equal("application/pdf", file.ContentType); var stream = new MemoryStream(new byte[] { 1, 2, 3 });
+    }
+
+    [Fact]
+    public async Task DownloadAttachment_FailsAndReturnsConflictAsync()
+    {
+        _storageMock
+            .Setup(x => x.ReadAsync(It.IsAny<string>()))
+            .ThrowsAsync(new FileNotFoundException());
+
+        var result = await _controller.DownloadAttachment(1, "missing.pdf", CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task DeleteAttachment_ReturnsOkAsync()
+    {
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<DeleteInterventionAttachmentCommand>(), It.IsAny<CancellationToken>()));
+        var result = await _controller.DeleteAttachment(1, "test.pdf", CancellationToken.None);
+
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task DeleteAttachment_FailsAndReturnsNotFoundAsync()
+    {
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<DeleteInterventionAttachmentCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new KeyNotFoundException());
+
+        var result = await _controller.DeleteAttachment(1, "missing.pdf", CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+}

--- a/test/Eras.Api.Tests/Controllers/AssessmentsControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/AssessmentsControllerTests.cs
@@ -51,7 +51,7 @@ public class AssessmentsControllerTests
         };
         var response = new List<AssessmentDto> { dto };
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<GetAllRemissionsQuery>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<GetAllRemissionsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
 
         var result = await _controller.GetAll(CancellationToken.None);
@@ -71,7 +71,7 @@ public class AssessmentsControllerTests
         };
 
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<GetRemissionByIdQuery>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<GetRemissionByIdQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(dto);
 
         var result = await _controller.GetById(1, CancellationToken.None);
@@ -83,7 +83,7 @@ public class AssessmentsControllerTests
     public async Task GetById_ReturnsNotFound_WhenNullAsync()
     {
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<GetRemissionByIdQuery>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<GetRemissionByIdQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((AssessmentDto?)null);
 
         var result = await _controller.GetById(1, CancellationToken.None);
@@ -104,7 +104,7 @@ public class AssessmentsControllerTests
             }
         };
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<GetRemissionsByStudentIdQuery>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<GetRemissionsByStudentIdQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(dto);
 
         var result = await _controller.GetByStudentId(1, CancellationToken.None);
@@ -116,8 +116,8 @@ public class AssessmentsControllerTests
     public async Task GetByStudentId_ReturnsNotFound_WhenNullAsync()
     {
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<GetRemissionsByStudentIdQuery>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((List<AssessmentDto>?)null);
+            .Setup(X => X.Send(It.IsAny<GetRemissionsByStudentIdQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(It.IsAny<List<AssessmentDto>>());
 
         var result = await _controller.GetById(1, CancellationToken.None);
 
@@ -128,7 +128,7 @@ public class AssessmentsControllerTests
     public async Task GetByStatus_ReturnsOkAsync()
     {
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<GetRemissionsByStatusQuery>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<GetRemissionsByStatusQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<AssessmentDto>());
 
         var result = await _controller.GetByStatus("Remitted", CancellationToken.None);
@@ -155,7 +155,7 @@ public class AssessmentsControllerTests
             StudentIds = [1, 2],
         };
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<CreateRemissionCommand>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<CreateRemissionCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(dto);
 
         var result = await _controller.Create(dto, CancellationToken.None);
@@ -176,7 +176,7 @@ public class AssessmentsControllerTests
             StudentIds = [1, 2],
         };
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<UpdateRemissionCommand>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<UpdateRemissionCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(dto);
 
         var result = await _controller.Update(5, dto, CancellationToken.None);
@@ -196,8 +196,8 @@ public class AssessmentsControllerTests
             StudentIds = [1, 2],
         };
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<UpdateRemissionCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((AssessmentDto?)null);
+            .Setup(X => X.Send(It.IsAny<UpdateRemissionCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(It.IsAny<AssessmentDto>());
 
         var result = await _controller.Update(1, dto, CancellationToken.None);
 
@@ -216,7 +216,7 @@ public class AssessmentsControllerTests
             StudentIds = [1, 2],
         };
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<UpdateRemissionCommand>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<UpdateRemissionCommand>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new OperationCanceledException("busy"));
         var result = await _controller.Update(1, dto, CancellationToken.None);
 
@@ -227,7 +227,7 @@ public class AssessmentsControllerTests
     public async Task Delete_ReturnsNoContentResultAsync()
     {
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<DeleteAssessmentCommand>(), It.IsAny<CancellationToken>()));
+            .Setup(X => X.Send(It.IsAny<DeleteAssessmentCommand>(), It.IsAny<CancellationToken>()));
 
         var result = await _controller.Delete(1, CancellationToken.None);
 
@@ -238,7 +238,7 @@ public class AssessmentsControllerTests
     public async Task Delete_FailsAndReturnsNotFoundAsync()
     {
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<DeleteAssessmentCommand>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<DeleteAssessmentCommand>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new KeyNotFoundException());
         var result = await _controller.Delete(1, CancellationToken.None);
 
@@ -249,7 +249,7 @@ public class AssessmentsControllerTests
     public async Task GetInterventions_ReturnsOkAsync()
     {
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<GetInterventionsByAssessmentQuery>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<GetInterventionsByAssessmentQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(It.IsAny<List<InterventionDto>>);
 
         var result = await _controller.GetInterventions(1, CancellationToken.None);
@@ -263,10 +263,10 @@ public class AssessmentsControllerTests
         var dto = new AddInterventionDto
         {
             AssessmentId = 1,
-            Intervention = null,
+            Intervention = new IndividualInterventionDto() { DateUtc = DateTime.Now, StudentIds = [] },
         };
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<AddInterventionCommand>(), It.IsAny<CancellationToken>()));
+            .Setup(X => X.Send(It.IsAny<AddInterventionCommand>(), It.IsAny<CancellationToken>()));
 
         var result = await _controller.AddIntervention(dto, CancellationToken.None);
 
@@ -277,7 +277,7 @@ public class AssessmentsControllerTests
     public async Task UpsertInterventions_ReturnsConflictResponseAsync()
     { 
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<UpsertInterventionsCommand>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<UpsertInterventionsCommand>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new OperationCanceledException("busy"));
         var result = await _controller.UpsertInterventions(1, It.IsAny<List<InterventionDto>>(), CancellationToken.None);
 
@@ -288,7 +288,7 @@ public class AssessmentsControllerTests
     public async Task UpsertInterventions_ReturnsOkResponseAsync()
     {
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<UpsertInterventionsCommand>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<UpsertInterventionsCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(It.IsAny<List<InterventionDto>>());
         var result = await _controller.UpsertInterventions(1, It.IsAny<List<InterventionDto>>(), CancellationToken.None);
 
@@ -299,7 +299,7 @@ public class AssessmentsControllerTests
     public async Task DeleteIntervention_ReturnsNoContentResultAsync()
     {
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<DeleteInterventionCommand>(), It.IsAny<CancellationToken>()));
+            .Setup(X => X.Send(It.IsAny<DeleteInterventionCommand>(), It.IsAny<CancellationToken>()));
 
         var result = await _controller.DeleteIntervention(1, 1, CancellationToken.None);
 
@@ -310,7 +310,7 @@ public class AssessmentsControllerTests
     public async Task DeleteIntervention_FailsAndReturnsNotFoundAsync()
     {
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<DeleteInterventionCommand>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<DeleteInterventionCommand>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new KeyNotFoundException());
         var result = await _controller.DeleteIntervention(1, 1, CancellationToken.None);
 
@@ -333,7 +333,7 @@ public class AssessmentsControllerTests
         var files = new FormFileCollection{file};
 
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<UploadInterventionAttachmentsCommand>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<UploadInterventionAttachmentsCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<string> { "test.pdf" });
 
         var result = await _controller.UploadAttachments(1, files, CancellationToken.None);
@@ -348,7 +348,7 @@ public class AssessmentsControllerTests
         IFormFile file = new FormFile(stream, 0, stream.Length, "file", "test.pdf");
         var files = new FormFileCollection { file };
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<UploadInterventionAttachmentsCommand>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<UploadInterventionAttachmentsCommand>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("exists"));
         var result = await _controller.UploadAttachments(1, files, CancellationToken.None);
 
@@ -359,7 +359,7 @@ public class AssessmentsControllerTests
     public async Task DownloadAttachment_WithUnrecognizedExtensionAsync()
     {
         _storageMock
-            .Setup(x => x.ReadAsync(It.IsAny<string>()))
+            .Setup(X => X.ReadAsync(It.IsAny<string>()))
             .ReturnsAsync(new MemoryStream());
         var result = await _controller.DownloadAttachment(1, "file.xyz", CancellationToken.None);
 
@@ -372,7 +372,7 @@ public class AssessmentsControllerTests
     public async Task DownloadAttachment_ReturnsOkAsync()
     {
         _storageMock
-            .Setup(x => x.ReadAsync(It.IsAny<string>()))
+            .Setup(X => X.ReadAsync(It.IsAny<string>()))
             .ReturnsAsync(new MemoryStream());
         var result = await _controller.DownloadAttachment(1, "test.pdf", CancellationToken.None);
         var file = Assert.IsType<FileStreamResult>(result);
@@ -384,7 +384,7 @@ public class AssessmentsControllerTests
     public async Task DownloadAttachment_FailsAndReturnsConflictAsync()
     {
         _storageMock
-            .Setup(x => x.ReadAsync(It.IsAny<string>()))
+            .Setup(X => X.ReadAsync(It.IsAny<string>()))
             .ThrowsAsync(new FileNotFoundException());
 
         var result = await _controller.DownloadAttachment(1, "missing.pdf", CancellationToken.None);
@@ -396,7 +396,7 @@ public class AssessmentsControllerTests
     public async Task DeleteAttachment_ReturnsOkAsync()
     {
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<DeleteInterventionAttachmentCommand>(), It.IsAny<CancellationToken>()));
+            .Setup(X => X.Send(It.IsAny<DeleteInterventionAttachmentCommand>(), It.IsAny<CancellationToken>()));
         var result = await _controller.DeleteAttachment(1, "test.pdf", CancellationToken.None);
 
         Assert.IsType<NoContentResult>(result);
@@ -406,7 +406,7 @@ public class AssessmentsControllerTests
     public async Task DeleteAttachment_FailsAndReturnsNotFoundAsync()
     {
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<DeleteInterventionAttachmentCommand>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<DeleteInterventionAttachmentCommand>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new KeyNotFoundException());
 
         var result = await _controller.DeleteAttachment(1, "missing.pdf", CancellationToken.None);

--- a/test/Eras.Api.Tests/Controllers/AuthControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/AuthControllerTests.cs
@@ -1,0 +1,89 @@
+﻿using Eras.Api.Controllers;
+using Eras.Application.Contracts.Infrastructure;
+using Eras.Infrastructure.External.KeycloakClient;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using Xunit;
+
+namespace Eras.Api.Tests.Controllers;
+
+public class AuthControllerTests
+{
+    private readonly Mock<IKeycloakAuthService<TokenResponse>> _authServiceMock;
+    private readonly Mock<ILogger<AuthController>> _loggerMock;
+    private readonly AuthController _controller;
+
+    public AuthControllerTests()
+    {
+        _authServiceMock = new Mock<IKeycloakAuthService<TokenResponse>>();
+        _loggerMock = new Mock<ILogger<AuthController>>();
+
+        _controller = new AuthController(
+            _authServiceMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task LoginAsync_ReturnsOk_WhenCredentialsAreValidAsync()
+    {
+        // Arrange
+        var request = new LoginRequest
+        {
+            Username = "testuser",
+            Password = "password"
+        };
+
+        var token = new TokenResponse
+        {
+            AccessToken = "access-token",
+            ExpiresIn = 2
+        };
+
+        _authServiceMock
+            .Setup(x => x.LoginAsync(request.Username, request.Password))
+            .ReturnsAsync(token);
+
+        // Act
+        IActionResult result = await _controller.LoginAsync(request);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Same(token, okResult.Value);
+
+        _authServiceMock.Verify(
+            x => x.LoginAsync(request.Username, request.Password),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task LoginAsync_ReturnsUnauthorized_WhenLoginFailsAsync()
+    {
+        // Arrange
+        var request = new LoginRequest
+        {
+            Username = "testuser",
+            Password = "wrong-password"
+        };
+
+        var exception = new Exception("Invalid username or password");
+
+        _authServiceMock
+            .Setup(x => x.LoginAsync(request.Username, request.Password))
+            .ThrowsAsync(exception);
+
+        // Act
+        IActionResult result = await _controller.LoginAsync(request);
+
+        // Assert
+        var unauthorizedResult = Assert.IsType<UnauthorizedObjectResult>(result);
+        Assert.Equal(exception.Message, unauthorizedResult.Value);
+
+        _authServiceMock.Verify(
+            x => x.LoginAsync(request.Username, request.Password),
+            Times.Once);
+    }
+}

--- a/test/Eras.Api.Tests/Controllers/ConfigurationsControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/ConfigurationsControllerTests.cs
@@ -1,0 +1,255 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Eras.Api.Tests.Controllers;
+
+using Eras.Api.Controllers;
+using Eras.Application.DTOs;
+using Eras.Application.Features.Configurations.Command.CreateConfiguration;
+using Eras.Application.Features.Configurations.Command.DeleteConfiguration;
+using Eras.Application.Features.Configurations.Command.EditConfiguration;
+using Eras.Application.Features.Configurations.Queries.GetAllConfigurations;
+using Eras.Application.Features.Configurations.Queries.GetUserConfigurations;
+using Eras.Application.Models.Response;
+using Eras.Application.Models.Response.Common;
+using Eras.Domain.Entities;
+
+using MediatR;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using Xunit;
+
+public class ConfigurationsControllerTests
+{
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly Mock<ILogger<ConfigurationsController>> _loggerMock;
+    private readonly ConfigurationsController _controller;
+
+    public ConfigurationsControllerTests()
+    {
+        _mediatorMock = new Mock<IMediator>();
+        _loggerMock = new Mock<ILogger<ConfigurationsController>>();
+
+        _controller = new ConfigurationsController(
+            _mediatorMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task GetConfigurationsAsync_ReturnsOkAsync()
+    {
+        // Arrange
+        var response = new List<Configurations>();
+
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<GetAllConfigurationsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        // Act
+        IActionResult result = await _controller.GetConfigurationsAsync();
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Same(response, ok.Value);
+    }
+
+    [Fact]
+    public async Task GetUserConfigurationsAsync_ReturnsOk()
+    {
+        // Arrange
+        var response = new List<Configurations>();
+
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<GetUserConfigurationsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        // Act
+        IActionResult result = await _controller.GetUserConfigurationsAsync("user1");
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Same(response, ok.Value);
+    }
+
+    [Fact]
+    public async Task CreateConfigurationAsync_ReturnsBadRequest_WhenConfigurationIsNullAsync()
+    {
+        // Act
+        IActionResult result = await _controller.CreateConfigurationAsync(null!);
+
+        // Assert
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal("Configuration cannot be null", badRequest.Value);
+    }
+
+    [Fact]
+    public async Task CreateConfigurationAsync_ReturnsOk_WhenMediatorReturnsSuccessAsync()
+    {
+        // Arrange
+        var dto = new ConfigurationsDTO
+        {
+            ConfigurationName = "Test",
+            BaseURL = "fake/url"
+        };
+        var response = new CreateCommandResponse<Configurations>(new Configurations(), "Success", true);
+
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<CreateConfigurationCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        // Act
+        IActionResult result = await _controller.CreateConfigurationAsync(dto);
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Same(response, ok.Value);
+    }
+
+    [Fact]
+    public async Task CreateConfigurationAsync_ReturnsBadRequest_WhenMediatorReturnsFailureAsync()
+    {
+        // Arrange
+        var dto = new ConfigurationsDTO
+        {
+            ConfigurationName = "Test",
+            BaseURL = "fake/url"
+        };
+        var response = new CreateCommandResponse<Configurations>(new Configurations(), "Error", false);
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<CreateConfigurationCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        // Act
+        IActionResult result = await _controller.CreateConfigurationAsync(dto);
+
+        // Assert
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal(response.Message, badRequest.Value);
+    }
+
+    [Fact]
+    public async Task EditConfigurationAsync_ReturnsBadRequest_WhenConfigurationIsNullAsync()
+    {
+        // Act
+        IActionResult result = await _controller.EditConfigurationAsync(null!);
+
+        // Assert
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal("Configuration cannot be null", badRequest.Value);
+    }
+
+    [Fact]
+    public async Task EditConfigurationAsync_ReturnsOk_WhenMediatorReturnsSuccess()
+    {
+        // Arrange
+        var dto = new ConfigurationsDTO
+        {
+            ConfigurationName = "Test",
+            BaseURL = "fake/url"
+        };
+        var response = new CreateCommandResponse<Configurations>(new Configurations(), "Success", true);
+
+        _mediatorMock
+            .Setup(x => x.Send(
+                It.IsAny<EditConfigurationCommand>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        // Act
+        IActionResult result = await _controller.EditConfigurationAsync(dto);
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Same(response, ok.Value);
+    }
+
+    [Fact]
+    public async Task EditConfigurationAsync_ReturnsBadRequest_WhenMediatorReturnsFailureAsync()
+    {
+        // Arrange
+        var dto = new ConfigurationsDTO
+        {
+            ConfigurationName = "Test",
+            BaseURL = "fake/url"
+        };
+        var response = new CreateCommandResponse<Configurations>(new Configurations(), "Error", false);
+
+        _mediatorMock
+            .Setup(x => x.Send(
+                It.IsAny<EditConfigurationCommand>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        // Act
+        IActionResult result = await _controller.EditConfigurationAsync(dto);
+
+        // Assert
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal(response.Message, badRequest.Value);
+    }
+
+    [Fact]
+    public async Task DeleteConfigurationAsync_ReturnsBadRequest_WhenIdIsInvalidAsync()
+    {
+        // Act
+        IActionResult result = await _controller.DeleteConfigurationAsync(0);
+
+        // Assert
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal("ConfigurationId must be greater than 0", badRequest.Value);
+    }
+
+    [Fact]
+    public async Task DeleteConfigurationAsync_ReturnsOk_WhenMediatorReturnsSuccess()
+    {
+        // Arrange
+        var response = new BaseResponse
+        {
+            Success = true,
+            Message = "Deleted"
+        };
+        _mediatorMock
+            .Setup(x => x.Send(
+                It.IsAny<DeleteConfigurationCommand>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        // Act
+        IActionResult result = await _controller.DeleteConfigurationAsync(1);
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Same(response, ok.Value);
+    }
+
+    [Fact]
+    public async Task DeleteConfigurationAsync_ReturnsBadRequest_WhenMediatorReturnsFailureAsync()
+    {
+        // Arrange
+        var response = new BaseResponse
+        {
+            Success = false,
+            Message = "Delete failed"
+        };
+
+        _mediatorMock
+            .Setup(x => x.Send(
+                It.IsAny<DeleteConfigurationCommand>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        // Act
+        IActionResult result = await _controller.DeleteConfigurationAsync(1);
+
+        // Assert
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal(response.Message, badRequest.Value);
+    }
+}

--- a/test/Eras.Api.Tests/Controllers/ConfigurationsControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/ConfigurationsControllerTests.cs
@@ -49,7 +49,7 @@ public class ConfigurationsControllerTests
         var response = new List<Configurations>();
 
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<GetAllConfigurationsQuery>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<GetAllConfigurationsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
 
         // Act
@@ -61,13 +61,13 @@ public class ConfigurationsControllerTests
     }
 
     [Fact]
-    public async Task GetUserConfigurationsAsync_ReturnsOk()
+    public async Task GetUserConfigurationsAsync_ReturnsOkAsync()
     {
         // Arrange
         var response = new List<Configurations>();
 
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<GetUserConfigurationsQuery>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<GetUserConfigurationsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
 
         // Act
@@ -101,7 +101,7 @@ public class ConfigurationsControllerTests
         var response = new CreateCommandResponse<Configurations>(new Configurations(), "Success", true);
 
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<CreateConfigurationCommand>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<CreateConfigurationCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
 
         // Act
@@ -123,7 +123,7 @@ public class ConfigurationsControllerTests
         };
         var response = new CreateCommandResponse<Configurations>(new Configurations(), "Error", false);
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<CreateConfigurationCommand>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<CreateConfigurationCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
 
         // Act
@@ -146,7 +146,7 @@ public class ConfigurationsControllerTests
     }
 
     [Fact]
-    public async Task EditConfigurationAsync_ReturnsOk_WhenMediatorReturnsSuccess()
+    public async Task EditConfigurationAsync_ReturnsOk_WhenMediatorReturnsSuccessAsync()
     {
         // Arrange
         var dto = new ConfigurationsDTO
@@ -157,7 +157,7 @@ public class ConfigurationsControllerTests
         var response = new CreateCommandResponse<Configurations>(new Configurations(), "Success", true);
 
         _mediatorMock
-            .Setup(x => x.Send(
+            .Setup(X => X.Send(
                 It.IsAny<EditConfigurationCommand>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
@@ -182,7 +182,7 @@ public class ConfigurationsControllerTests
         var response = new CreateCommandResponse<Configurations>(new Configurations(), "Error", false);
 
         _mediatorMock
-            .Setup(x => x.Send(
+            .Setup(X => X.Send(
                 It.IsAny<EditConfigurationCommand>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
@@ -207,7 +207,7 @@ public class ConfigurationsControllerTests
     }
 
     [Fact]
-    public async Task DeleteConfigurationAsync_ReturnsOk_WhenMediatorReturnsSuccess()
+    public async Task DeleteConfigurationAsync_ReturnsOk_WhenMediatorReturnsSuccessAsync()
     {
         // Arrange
         var response = new BaseResponse
@@ -216,7 +216,7 @@ public class ConfigurationsControllerTests
             Message = "Deleted"
         };
         _mediatorMock
-            .Setup(x => x.Send(
+            .Setup(X => X.Send(
                 It.IsAny<DeleteConfigurationCommand>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
@@ -240,7 +240,7 @@ public class ConfigurationsControllerTests
         };
 
         _mediatorMock
-            .Setup(x => x.Send(
+            .Setup(X => X.Send(
                 It.IsAny<DeleteConfigurationCommand>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);

--- a/test/Eras.Api.Tests/Controllers/DashboardControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/DashboardControllerTests.cs
@@ -42,15 +42,15 @@ public class DashboardControllerTests
     }
 
     [Fact]
-    public async Task GetKpis_Should_Return_BadRequest_When_Query_Fails()
+    public async Task GetKpis_Should_Return_BadRequest_When_Query_FailsAsync()
     {
         // Arrange
         var response = new GetQueryResponse<DashboardKpiDto>(
-            null,
+            null!,
             "Error retrieving KPIs",
             false);
         _mediatorMock
-            .Setup(m => m.Send(It.IsAny<GetDashboardKpisQuery>(), It.IsAny<CancellationToken>()))
+            .Setup(M => M.Send(It.IsAny<GetDashboardKpisQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
         // Act
         var result = await _controller.GetKpis();

--- a/test/Eras.Api.Tests/Controllers/EvaluationControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/EvaluationControllerTests.cs
@@ -63,7 +63,7 @@ namespace Eras.Api.Tests.Controllers
                 "Updated",
                 true);
             _mockMediator
-                .Setup(x => x.Send(It.IsAny<UpdateEvaluationCommand>(), It.IsAny<CancellationToken>()))
+                .Setup(X => X.Send(It.IsAny<UpdateEvaluationCommand>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(response);
             var result = await _controller.UpdateEvaluationAsync(1, dto);
             var ok = Assert.IsType<OkObjectResult>(result);
@@ -83,7 +83,7 @@ namespace Eras.Api.Tests.Controllers
             var badRequest = Assert.IsType<BadRequestObjectResult>(result);
             Assert.Equal(400, badRequest.StatusCode);
             _mockMediator.Verify(
-                x => x.Send(It.IsAny<UpdateEvaluationCommand>(), It.IsAny<CancellationToken>()),
+                X => X.Send(It.IsAny<UpdateEvaluationCommand>(), It.IsAny<CancellationToken>()),
                 Times.Never);
         }
 
@@ -91,7 +91,7 @@ namespace Eras.Api.Tests.Controllers
         public async Task DeleteEvaluation_Should_Return_OkAsync()
         {
             _mockMediator
-                .Setup(x => x.Send(It.IsAny<DeleteEvaluationCommand>(), It.IsAny<CancellationToken>()))
+                .Setup(X => X.Send(It.IsAny<DeleteEvaluationCommand>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new BaseResponse("Deleted", true));
             var result = await _controller.DeleteEvaluationAsync(1);
             var ok = Assert.IsType<OkObjectResult>(result);
@@ -101,7 +101,7 @@ namespace Eras.Api.Tests.Controllers
         [Fact]
         public async Task GetEvaluationDetailsAsync_Should_ReturnOk_WhenFoundAsync()
         {
-            var response = new GetQueryResponse<Evaluation>(
+            var response = new GetQueryResponse<Evaluation?>(
                 new Evaluation(),
                 "Success",
                 true);
@@ -115,12 +115,12 @@ namespace Eras.Api.Tests.Controllers
         [Fact]
         public async Task GetEvaluationDetails_Should_Return_NotFound_WhenBodyIsNullAsync()
         {
-            var response = new GetQueryResponse<Evaluation>(
+            var response = new GetQueryResponse<Evaluation?>(
                 null,
                 "Not found",
                 false);
             _mockMediator
-                .Setup(x => x.Send(It.IsAny<GetEvaluationSummaryQuery>(), It.IsAny<CancellationToken>()))
+                .Setup(X => X.Send(It.IsAny<GetEvaluationSummaryQuery>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(response);
             var result = await _controller.GetEvaluationDetailsAsync(1);
             Assert.IsType<NotFoundObjectResult>(result);
@@ -131,7 +131,7 @@ namespace Eras.Api.Tests.Controllers
         {
             var page = new PagedResult<Evaluation>(0, new List<Evaluation>());
             _mockMediator
-                .Setup(x => x.Send(It.IsAny<GetAllEvaluationsQuery>(), It.IsAny<CancellationToken>()))
+                .Setup(X => X.Send(It.IsAny<GetAllEvaluationsQuery>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(page);
 
             var result = await _controller.GetAllEvaluationsAsync(new Pagination());
@@ -145,7 +145,7 @@ namespace Eras.Api.Tests.Controllers
         {
             var evaluations = new List<Evaluation>{new Evaluation()};
             _mockMediator
-                .Setup(x => x.Send(It.IsAny<GetEvaluationsByDateRangeQuery>(), It.IsAny<CancellationToken>()))
+                .Setup(X => X.Send(It.IsAny<GetEvaluationsByDateRangeQuery>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(evaluations);
             var result = await _controller.GetAllEvaluationsByDateRangeAsync(
                 DateTime.UtcNow,

--- a/test/Eras.Api.Tests/Controllers/EvaluationDetailsControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/EvaluationDetailsControllerTests.cs
@@ -79,7 +79,7 @@ public class EvaluationDetailsControllerTests
     {
         // Arrange
         _mockMediator
-            .Setup(x => x.Send(It.IsAny<StudentsByFiltersResponse>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<StudentsByFiltersResponse>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((PagedResult<StudentsByFiltersResponse>?)null);
         // Act
         var result = await _controller.StudentsByFilterAsync("", 1, [""], [1], [1], [1], new Pagination());
@@ -122,8 +122,8 @@ public class EvaluationDetailsControllerTests
     {
         // Arrange
         _mockMediator
-            .Setup(x => x.Send(It.IsAny<GetStudentsByEvaluationIdQuery>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((List<StudentsByFiltersResponse>?)null);
+            .Setup(X => X.Send(It.IsAny<GetStudentsByEvaluationIdQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(It.IsAny<List<StudentsByFiltersResponse>>());
         // Act
         var result = await _controller.StudentsByEvaluationIdAsync(
             1,

--- a/test/Eras.Api.Tests/Controllers/FeatureFlagControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/FeatureFlagControllerTests.cs
@@ -1,0 +1,231 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Eras.Api.Tests.Controllers;
+
+using Eras.Api.Controllers;
+using Eras.Application.DTOs;
+using Eras.Application.Features.FeatureFlags;
+using Eras.Error.Bussiness;
+
+using MediatR;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using Xunit;
+
+public class FeatureFlagControllerTests
+{
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly Mock<ILogger<FeatureFlagController>> _loggerMock;
+    private readonly FeatureFlagController _controller;
+
+    public FeatureFlagControllerTests()
+    {
+        _mediatorMock = new Mock<IMediator>();
+        _loggerMock = new Mock<ILogger<FeatureFlagController>>();
+
+        _controller = new FeatureFlagController(
+            _mediatorMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task GetFeatureFlagByNameAsync_ReturnsOk_WhenFeatureFlagExistsAsync()
+    {
+        // Arrange
+        var dto = new FeatureFlagDTO
+        {
+            Id = 1,
+            Name = "FeatureA",
+            Description = "Description",
+            IsEnabled = true,
+            Audit = null,
+        };
+
+        _mediatorMock
+            .Setup(x => x.Send(
+                It.IsAny<GetFeatureFlagByNameQuery>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(dto);
+
+        // Act
+        var result = await _controller.GetFeatureFlagByNameAsync("FeatureA");
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Same(dto, ok.Value);
+    }
+
+    [Fact]
+    public async Task GetFeatureFlagByNameAsync_ReturnsNotFound_WhenExceptionThrownAsync()
+    {
+        // Arrange
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<GetFeatureFlagByNameQuery>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new NotFoundException("error"));
+
+        // Act
+        var result = await _controller.GetFeatureFlagByNameAsync("FeatureA");
+
+        // Assert
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsOkAsync()
+    {
+        // Arrange
+        IReadOnlyCollection<FeatureFlagDTO> response =
+        [
+            new FeatureFlagDTO
+            {
+                Id = 1,
+                Name = "FeatureA",
+                Description = "Description",
+                IsEnabled = true,
+                Audit = null,
+            }
+        ];
+
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<GetAllFeatureFlagsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        // Act
+        var result = await _controller.GetAllAsync();
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Same(response, ok.Value);
+    }
+
+    [Fact]
+    public async Task CreateFeatureFlagAsync_ReturnsCreated_WhenSuccessfulAsync()
+    {
+        // Arrange
+        var dto = new FeatureFlagDTO
+        {
+            Id = 1,
+            Name = "FeatureA",
+            Description = "Description",
+            IsEnabled = true,
+            Audit = null,
+        };
+
+        var created = new FeatureFlagDTO
+        {
+            Id = 1,
+            Name = "FeatureA",
+            Description = "Description",
+            IsEnabled = true,
+            Audit = null,
+        };
+
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<CreateFeatureFlagCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(created);
+
+        // Act
+        var result = await _controller.CreateFeatureFlagAsync(dto);
+
+        // Assert
+        var createdResult = Assert.IsType<CreatedResult>(result.Result);
+        Assert.Same(created, createdResult.Value);
+    }
+
+    [Fact]
+    public async Task CreateFeatureFlagAsync_ReturnsConflict_WhenAlreadyExistsAsync()
+    {
+        // Arrange
+        var dto = new FeatureFlagDTO
+        {
+            Id = 1,
+            Name = "FeatureA",
+            Description = "Description",
+            IsEnabled = true,
+            Audit = null,
+        };
+
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<CreateFeatureFlagCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Already exists"));
+
+        // Act
+        var result = await _controller.CreateFeatureFlagAsync(dto);
+
+        // Assert
+        Assert.IsType<ConflictObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task UpdatedFeatureFlagAsync_ReturnsOk_AndUsesRouteIdAsync()
+    {
+        // Arrange
+        var dto = new FeatureFlagDTO
+        {
+            Id = 99,
+            Name = "FeatureA",
+            Description = "Description",
+            IsEnabled = true,
+            Audit = null,
+        };
+
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<UpdateFeatureFlagCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FeatureFlagDTO
+            {
+                Id = 5,
+                Name = "FeatureA",
+                Description = "Description",
+                IsEnabled = true,
+                Audit = null,
+            });
+
+        // Act
+        var result = await _controller.UpdatedFeatureFlagAsync(5, dto);
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+
+        var response = Assert.IsType<FeatureFlagDTO>(ok.Value);
+
+        Assert.Equal(5, response.Id);
+    }
+
+    [Fact]
+    public async Task DeleteFeatureFlagAsync_ReturnsNoContent_WhenSuccessfulAsync()
+    {
+        // Arrange
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<DeleteFeatureFlagCommand>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _controller.DeleteFeatureFlagAsync(10);
+
+        // Assert
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task DeleteFeatureFlagAsync_ReturnsNotFound_WhenKeyDoesNotExistAsync()
+    {
+        // Arrange
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<DeleteFeatureFlagCommand>(),It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new KeyNotFoundException());
+
+        // Act
+        var result = await _controller.DeleteFeatureFlagAsync(10);
+
+        // Assert
+        Assert.IsType<NotFoundResult>(result);
+    }
+}

--- a/test/Eras.Api.Tests/Controllers/FeatureFlagControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/FeatureFlagControllerTests.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Eras.Api.Tests.Controllers;
+﻿namespace Eras.Api.Tests.Controllers;
 
 using Eras.Api.Controllers;
 using Eras.Application.DTOs;
@@ -46,13 +40,11 @@ public class FeatureFlagControllerTests
             Name = "FeatureA",
             Description = "Description",
             IsEnabled = true,
-            Audit = null,
+            Audit = null!,
         };
 
         _mediatorMock
-            .Setup(x => x.Send(
-                It.IsAny<GetFeatureFlagByNameQuery>(),
-                It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<GetFeatureFlagByNameQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(dto);
 
         // Act
@@ -68,7 +60,7 @@ public class FeatureFlagControllerTests
     {
         // Arrange
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<GetFeatureFlagByNameQuery>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<GetFeatureFlagByNameQuery>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new NotFoundException("error"));
 
         // Act
@@ -90,12 +82,12 @@ public class FeatureFlagControllerTests
                 Name = "FeatureA",
                 Description = "Description",
                 IsEnabled = true,
-                Audit = null,
+                Audit = null!,
             }
         ];
 
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<GetAllFeatureFlagsQuery>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<GetAllFeatureFlagsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
 
         // Act
@@ -116,7 +108,7 @@ public class FeatureFlagControllerTests
             Name = "FeatureA",
             Description = "Description",
             IsEnabled = true,
-            Audit = null,
+            Audit = null!,
         };
 
         var created = new FeatureFlagDTO
@@ -125,11 +117,11 @@ public class FeatureFlagControllerTests
             Name = "FeatureA",
             Description = "Description",
             IsEnabled = true,
-            Audit = null,
+            Audit = null!,
         };
 
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<CreateFeatureFlagCommand>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<CreateFeatureFlagCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(created);
 
         // Act
@@ -150,11 +142,11 @@ public class FeatureFlagControllerTests
             Name = "FeatureA",
             Description = "Description",
             IsEnabled = true,
-            Audit = null,
+            Audit = null!,
         };
 
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<CreateFeatureFlagCommand>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<CreateFeatureFlagCommand>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("Already exists"));
 
         // Act
@@ -174,18 +166,18 @@ public class FeatureFlagControllerTests
             Name = "FeatureA",
             Description = "Description",
             IsEnabled = true,
-            Audit = null,
+            Audit = null!,
         };
 
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<UpdateFeatureFlagCommand>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<UpdateFeatureFlagCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new FeatureFlagDTO
             {
                 Id = 5,
                 Name = "FeatureA",
                 Description = "Description",
                 IsEnabled = true,
-                Audit = null,
+                Audit = null!,
             });
 
         // Act
@@ -204,7 +196,7 @@ public class FeatureFlagControllerTests
     {
         // Arrange
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<DeleteFeatureFlagCommand>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<DeleteFeatureFlagCommand>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         // Act
@@ -219,7 +211,7 @@ public class FeatureFlagControllerTests
     {
         // Arrange
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<DeleteFeatureFlagCommand>(),It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<DeleteFeatureFlagCommand>(),It.IsAny<CancellationToken>()))
             .ThrowsAsync(new KeyNotFoundException());
 
         // Act

--- a/test/Eras.Api.Tests/Controllers/HeatMapControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/HeatMapControllerTests.cs
@@ -76,7 +76,7 @@ public class HeatMapControllerTests
     {
         string pollUUID = "example-correct-uuid";
         var fakeResponse = new GetQueryResponse<HeatMapSummaryResponseVm>(
-            null, "Success", true
+            null!, "Success", true
         );
 
         _mediatorMock
@@ -95,7 +95,7 @@ public class HeatMapControllerTests
     {
         var pollUUID = "example-invalid-uuid";
         var fakeResponse = new GetQueryResponse<HeatMapSummaryResponseVm>(
-            null, "Invalid request", false
+            null!, "Invalid request", false
         );
 
         _mediatorMock
@@ -113,7 +113,7 @@ public class HeatMapControllerTests
     public async Task GetHeatMapSummaryByFilters_ReturnsOk_WhenSuccessAsync()
     {
         var fakeResponse = new GetQueryResponse<HeatMapSummaryResponseVm>(
-            null, "Success", true
+            null!, "Success", true
         );
 
         _mediatorMock
@@ -131,7 +131,7 @@ public class HeatMapControllerTests
     public async Task GetHeatMapSummaryByFilters_ReturnsBadRequest_WhenFailureAsync()
     {
         var fakeResponse = new GetQueryResponse<HeatMapSummaryResponseVm>(
-            null, "Invalid request", false
+            null!, "Invalid request", false
         );
 
         _mediatorMock

--- a/test/Eras.Api.Tests/Controllers/JUServiceControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/JUServiceControllerTests.cs
@@ -45,7 +45,7 @@ public class JUServiceControllerTests
             Count: 1
         );
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<GetJUServicesQuery>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<GetJUServicesQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
 
         // Act
@@ -75,7 +75,7 @@ public class JUServiceControllerTests
         var service = new JUService();
         var response = new CreateCommandResponse<JUService>(service, "Success", true);
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<CreateJUServiceCommand>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<CreateJUServiceCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
 
         // Act
@@ -91,9 +91,9 @@ public class JUServiceControllerTests
     {
         // Arrange
         var dto = new JUServiceDTO() { Name = "b" };
-        var response = new CreateCommandResponse<JUService>(null, "Error", false);
+        var response = new CreateCommandResponse<JUService>(null!, "Error", false);
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<CreateJUServiceCommand>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<CreateJUServiceCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
 
         // Act

--- a/test/Eras.Api.Tests/Controllers/JUServiceControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/JUServiceControllerTests.cs
@@ -64,7 +64,7 @@ public class JUServiceControllerTests
 
         // Assert
         var badRequest = Assert.IsType<BadRequestObjectResult>(result);
-        Assert.Equal("JUService cannot be null", badRequest.Value);
+        Assert.Equal("Service cannot be null", badRequest.Value);
     }
 
     [Fact]

--- a/test/Eras.Api.Tests/Controllers/JUServiceControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/JUServiceControllerTests.cs
@@ -1,0 +1,106 @@
+﻿using Eras.Api.Controllers;
+using Eras.Application.DTOs;
+using Eras.Application.Features.JUServices.Commands.CreateJUService;
+using Eras.Application.Features.JUServices.Queries.GetJUServices;
+using Eras.Application.Models.Response.Common;
+using Eras.Application.Utils;
+using Eras.Domain.Entities;
+
+using MediatR;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+namespace Eras.Api.Tests.Controllers;
+
+public class JUServiceControllerTests
+{
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly Mock<ILogger<JUServiceController>> _loggerMock;
+    private readonly JUServiceController _controller;
+
+    public JUServiceControllerTests()
+    {
+        _mediatorMock = new Mock<IMediator>();
+        _loggerMock = new Mock<ILogger<JUServiceController>>();
+
+        _controller = new JUServiceController(
+            _mediatorMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task GetJUServicesAsync_ReturnsOkAsync()
+    {
+        // Arrange
+        var pagination = new Pagination();
+        var response = new PagedResult<JUService>(Items:
+            [new JUService()
+            {
+                Id = 1,
+                Name = "Test",
+            }],
+            Count: 1
+        );
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<GetJUServicesQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        // Act
+        IActionResult result = await _controller.GetServicesAsync(pagination);
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Same(response, ok.Value);
+    }
+
+    [Fact]
+    public async Task CreateJUServiceAsync_ReturnsBadRequest_WhenJUServiceIsNullAsync()
+    {
+        // Act
+        IActionResult result = await _controller.CreateServiceAsync(null!);
+
+        // Assert
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal("JUService cannot be null", badRequest.Value);
+    }
+
+    [Fact]
+    public async Task CreateJUServiceAsync_ReturnsOk_WhenMediatorReturnsSuccessAsync()
+    {
+        // Arrange
+        var dto = new JUServiceDTO() { Name = "b" };
+        var service = new JUService();
+        var response = new CreateCommandResponse<JUService>(service, "Success", true);
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<CreateJUServiceCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        // Act
+        IActionResult result = await _controller.CreateServiceAsync(dto);
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Same(response, ok.Value);
+    }
+
+    [Fact]
+    public async Task CreateJUServiceAsync_ReturnsBadRequest_WhenMediatorReturnsFailureAsync()
+    {
+        // Arrange
+        var dto = new JUServiceDTO() { Name = "b" };
+        var response = new CreateCommandResponse<JUService>(null, "Error", false);
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<CreateJUServiceCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        // Act
+        IActionResult result = await _controller.CreateServiceAsync(dto);
+
+        // Assert
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal(response.Message, badRequest.Value);
+    }
+}

--- a/test/Eras.Api.Tests/Controllers/PollInstanceControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/PollInstanceControllerTests.cs
@@ -88,10 +88,10 @@ namespace Eras.Api.Tests.Controllers
         {
             // Arrange
             var pagination = new Pagination();
-            var expected = new GetQueryResponse<PagedResult<PollInstanceDTO>>(null, "Success", true);
+            var expected = new GetQueryResponse<PagedResult<PollInstanceDTO>>(null!, "Success", true);
 
             _mockMediator
-                .Setup(x => x.Send(It.IsAny<GetPollInstanceByCohortAndDaysQuery>(), It.IsAny<CancellationToken>()))
+                .Setup(X => X.Send(It.IsAny<GetPollInstanceByCohortAndDaysQuery>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(expected);
 
             // Act
@@ -131,7 +131,7 @@ namespace Eras.Api.Tests.Controllers
         };
 
             _mockMediator
-                .Setup(x => x.Send(
+                .Setup(X => X.Send(
                     It.IsAny<GetCohortComponentsByPollQuery>(),
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(response);
@@ -170,7 +170,7 @@ namespace Eras.Api.Tests.Controllers
         };
 
             _mockMediator
-                .Setup(x => x.Send(
+                .Setup(X => X.Send(
                     It.IsAny<GetCohortComponentsByPollQuery>(),
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(response);
@@ -191,8 +191,8 @@ namespace Eras.Api.Tests.Controllers
         {
             // Arrange
             _mockMediator
-                .Setup(x => x.Send(It.IsAny<GetComponentsAvgByStudentQuery>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((List<ComponentsAvg>?)null);
+                .Setup(X => X.Send(It.IsAny<GetComponentsAvgByStudentQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(It.IsAny<List<ComponentsAvg>>());
 
             // Act
             IActionResult result =
@@ -203,11 +203,11 @@ namespace Eras.Api.Tests.Controllers
         }
 
         [Fact]
-        public async Task GetComponentsRiskAvgByStudentAsync_ReturnsNotFound_WhenMediatorReturnsEmptyCollection()
+        public async Task GetComponentsRiskAvgByStudentAsync_ReturnsNotFound_WhenMediatorReturnsEmptyCollectionAsync()
         {
             // Arrange
             _mockMediator
-                .Setup(x => x.Send(It.IsAny<GetComponentsAvgByStudentQuery>(), It.IsAny<CancellationToken>()))
+                .Setup(X => X.Send(It.IsAny<GetComponentsAvgByStudentQuery>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new List<ComponentsAvg>());
 
             // Act
@@ -219,7 +219,7 @@ namespace Eras.Api.Tests.Controllers
         }
 
         [Fact]
-        public async Task GetComponentsRiskAvgByStudentAsync_ReturnsOk_WhenMediatorReturnsData()
+        public async Task GetComponentsRiskAvgByStudentAsync_ReturnsOk_WhenMediatorReturnsDataAsync()
         {
             // Arrange
             var response = new List<ComponentsAvg>
@@ -228,7 +228,7 @@ namespace Eras.Api.Tests.Controllers
         };
 
             _mockMediator
-                .Setup(x => x.Send(
+                .Setup(X => X.Send(
                     It.IsAny<GetComponentsAvgByStudentQuery>(),
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(response);

--- a/test/Eras.Api.Tests/Controllers/PollInstanceControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/PollInstanceControllerTests.cs
@@ -1,9 +1,13 @@
 ﻿
-using Eras.Application.Utils;
 using Eras.Api.Controllers;
 using Eras.Application.DTOs;
+using Eras.Application.Features.Cohorts.Queries.GetCohortComponentsByPoll;
+using Eras.Application.Features.Components.Queries;
 using Eras.Application.Features.PollInstances.Queries.GetPollInstancesByCohortAndDays;
+using Eras.Application.Models.Response.Calculations;
 using Eras.Application.Models.Response.Common;
+using Eras.Application.Utils;
+using Eras.Domain.Entities;
 
 using MediatR;
 
@@ -76,6 +80,166 @@ namespace Eras.Api.Tests.Controllers
 
             // Assert
             Assert.NotNull(result);
+        }
+
+
+        [Fact]
+        public async Task GetPollInstancesByCohortIdAndDaysAsync_ReturnsOkAsync()
+        {
+            // Arrange
+            var pagination = new Pagination();
+            var expected = new GetQueryResponse<PagedResult<PollInstanceDTO>>(null, "Success", true);
+
+            _mockMediator
+                .Setup(x => x.Send(It.IsAny<GetPollInstanceByCohortAndDaysQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expected);
+
+            // Act
+            IActionResult result = await _controller.GetPollInstancesByCohortIdAndDaysAsync(
+                new[] { 1, 2 },
+                30,
+                pagination,
+                true,
+                "poll-uuid",
+                null);
+
+            // Assert
+            var ok = Assert.IsType<OkObjectResult>(result);
+            Assert.Same(expected, ok.Value);
+        }
+
+        [Fact]
+        public async Task GetComponentsAvgGroupedByCohortAsync_ReturnsGroupedResponse_ForSingleCohortAsync()
+        {
+            // Arrange
+            var response = new List<GetCohortComponentsByPollResponse>
+        {
+            new()
+            {
+                CohortId = 1,
+                CohortName = "A",
+                ComponentName = "Academic",
+                AverageRiskByCohortComponent = 2
+            },
+            new()
+            {
+                CohortId = 1,
+                CohortName = "A",
+                ComponentName = "Attendance",
+                AverageRiskByCohortComponent = 3
+            }
+        };
+
+            _mockMediator
+                .Setup(x => x.Send(
+                    It.IsAny<GetCohortComponentsByPollQuery>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(response);
+
+            // Act
+            IActionResult result =
+                await _controller.GetComponentsAvgGroupedByCohortAsync("uuid", true);
+
+            // Assert
+            var ok = Assert.IsType<OkObjectResult>(result);
+
+            var value = Assert.IsAssignableFrom<IEnumerable<object>>(ok.Value);
+            Assert.Single(value);
+        }
+
+        [Fact]
+        public async Task GetComponentsAvgGroupedByCohortAsync_ReturnsGroupedResponse_ForMultipleCohortsAsync()
+        {
+            // Arrange
+            var response = new List<GetCohortComponentsByPollResponse>
+        {
+            new()
+            {
+                CohortId = 1,
+                CohortName = "A",
+                ComponentName = "Academic",
+                AverageRiskByCohortComponent = 1
+            },
+            new()
+            {
+                CohortId = 2,
+                CohortName = "B",
+                ComponentName = "Academic",
+                AverageRiskByCohortComponent = 2
+            }
+        };
+
+            _mockMediator
+                .Setup(x => x.Send(
+                    It.IsAny<GetCohortComponentsByPollQuery>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(response);
+
+            // Act
+            IActionResult result =
+                await _controller.GetComponentsAvgGroupedByCohortAsync("uuid", false);
+
+            // Assert
+            var ok = Assert.IsType<OkObjectResult>(result);
+
+            var value = Assert.IsAssignableFrom<IEnumerable<object>>(ok.Value);
+            Assert.Equal(2, value.Count());
+        }
+
+        [Fact]
+        public async Task GetComponentsRiskAvgByStudentAsync_ReturnsNotFound_WhenMediatorReturnsNullAsync()
+        {
+            // Arrange
+            _mockMediator
+                .Setup(x => x.Send(It.IsAny<GetComponentsAvgByStudentQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((List<ComponentsAvg>?)null);
+
+            // Act
+            IActionResult result =
+                await _controller.GetComponentsRiskAvgByStudentAsync(5, 10);
+
+            // Assert
+            Assert.IsType<NotFoundObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task GetComponentsRiskAvgByStudentAsync_ReturnsNotFound_WhenMediatorReturnsEmptyCollection()
+        {
+            // Arrange
+            _mockMediator
+                .Setup(x => x.Send(It.IsAny<GetComponentsAvgByStudentQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<ComponentsAvg>());
+
+            // Act
+            IActionResult result =
+                await _controller.GetComponentsRiskAvgByStudentAsync(5, 10);
+
+            // Assert
+            Assert.IsType<NotFoundObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task GetComponentsRiskAvgByStudentAsync_ReturnsOk_WhenMediatorReturnsData()
+        {
+            // Arrange
+            var response = new List<ComponentsAvg>
+        {
+            new()
+        };
+
+            _mockMediator
+                .Setup(x => x.Send(
+                    It.IsAny<GetComponentsAvgByStudentQuery>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(response);
+
+            // Act
+            IActionResult result =
+                await _controller.GetComponentsRiskAvgByStudentAsync(5, 10);
+
+            // Assert
+            var ok = Assert.IsType<OkObjectResult>(result);
+            Assert.Same(response, ok.Value);
         }
     }
 }

--- a/test/Eras.Api.Tests/Controllers/PollsControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/PollsControllerTests.cs
@@ -49,7 +49,7 @@ public class PollsControllerTests
         var badRequest = Assert.IsType<BadRequestObjectResult>(result);
         Assert.Equal("Only filter by StudentId or CohortId", badRequest.Value);
 
-        _mediatorMock.Verify(m => m.Send(It.IsAny<IRequest<object>>(), It.IsAny<CancellationToken>()),
+        _mediatorMock.Verify(M => M.Send(It.IsAny<IRequest<object>>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -60,7 +60,7 @@ public class PollsControllerTests
         var expected = new List<GetPollsQueryResponse>();
 
         _mediatorMock
-            .Setup(m => m.Send(It.IsAny<GetAllPollsQuery>(), It.IsAny<CancellationToken>()))
+            .Setup(M => M.Send(It.IsAny<GetAllPollsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(expected);
 
         // Act
@@ -69,8 +69,8 @@ public class PollsControllerTests
         // Assert
         var ok = Assert.IsType<OkObjectResult>(result);
         Assert.Same(expected, ok.Value);
-        _mediatorMock.Verify(m =>
-            m.Send(It.IsAny<GetAllPollsQuery>(),It.IsAny<CancellationToken>()),
+        _mediatorMock.Verify(M =>
+            M.Send(It.IsAny<GetAllPollsQuery>(),It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -81,7 +81,7 @@ public class PollsControllerTests
         var expected = new List<GetPollsQueryResponse>();
 
         _mediatorMock
-            .Setup(m => m.Send(It.Is<GetPollsByStudentQuery>(q => q.StudentId == 5),It.IsAny<CancellationToken>()))
+            .Setup(M => M.Send(It.Is<GetPollsByStudentQuery>(Q => Q.StudentId == 5), It.IsAny<CancellationToken>()))
             .ReturnsAsync(expected);
 
         // Act
@@ -90,8 +90,8 @@ public class PollsControllerTests
         // Assert
         var ok = Assert.IsType<OkObjectResult>(result);
         Assert.Same(expected, ok.Value);
-        _mediatorMock.Verify(m =>
-            m.Send(It.Is<GetPollsByStudentQuery>(q => q.StudentId == 5), It.IsAny<CancellationToken>()),
+        _mediatorMock.Verify(M =>
+            M.Send(It.Is<GetPollsByStudentQuery>(Q => Q.StudentId == 5), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -101,7 +101,7 @@ public class PollsControllerTests
         // Arrange
         var expected = new List<GetPollsQueryResponse>();
         _mediatorMock
-            .Setup(m => m.Send(It.Is<GetPollsByCohortListQuery>(q => q.CohortId == 10), It.IsAny<CancellationToken>()))
+            .Setup(M => M.Send(It.Is<GetPollsByCohortListQuery>(Q => Q.CohortId == 10), It.IsAny<CancellationToken>()))
             .ReturnsAsync(expected);
 
         // Act
@@ -111,8 +111,8 @@ public class PollsControllerTests
         var ok = Assert.IsType<OkObjectResult>(result);
         Assert.Same(expected, ok.Value);
 
-        _mediatorMock.Verify(m =>
-            m.Send(It.Is<GetPollsByCohortListQuery>(q => q.CohortId == 10),It.IsAny<CancellationToken>()),
+        _mediatorMock.Verify(M =>
+            M.Send(It.Is<GetPollsByCohortListQuery>(Q => Q.CohortId == 10), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -123,9 +123,7 @@ public class PollsControllerTests
         var expected = new List<PollVariableDto>();
 
         _mediatorMock
-            .Setup(m => m.Send(
-                It.Is<GetAllByPollAndCohortQuery>(q => q.cohortId == 7 && q.pollId == 3),
-                It.IsAny<CancellationToken>()))
+            .Setup(M => M.Send(It.Is<GetAllByPollAndCohortQuery>(Q => Q.cohortId == 7 && Q.pollId == 3), It.IsAny<CancellationToken>()))
             .ReturnsAsync(expected);
 
         // Act
@@ -149,11 +147,11 @@ public class PollsControllerTests
         };
 
         _mediatorMock
-            .Setup(m => m.Send(
-                It.Is<GetVariablesByPollUuidAndComponentQuery>(q =>
-                    q.pollUuid == "poll-uuid" &&
-                    q.LastVersion &&
-                    q.component.SequenceEqual(components)),
+            .Setup(M => M.Send(
+                It.Is<GetVariablesByPollUuidAndComponentQuery>(Q =>
+                    Q.pollUuid == "poll-uuid" &&
+                    Q.LastVersion &&
+                    Q.component.SequenceEqual(components)),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(expected);
 
@@ -163,8 +161,8 @@ public class PollsControllerTests
         // Assert
         var ok = Assert.IsType<OkObjectResult>(result);
         Assert.Same(expected, ok.Value);
-        _mediatorMock.Verify(m =>
-            m.Send(It.IsAny<GetVariablesByPollUuidAndComponentQuery>(), It.IsAny<CancellationToken>()),
+        _mediatorMock.Verify(M =>
+            M.Send(It.IsAny<GetVariablesByPollUuidAndComponentQuery>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 }

--- a/test/Eras.Api.Tests/Controllers/PollsControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/PollsControllerTests.cs
@@ -1,0 +1,170 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Eras.Api.Controllers;
+using Eras.Application.Dtos;
+using Eras.Application.DTOs.Poll;
+using Eras.Application.Features.Polls.Queries.GetAllByPollAndCohort;
+using Eras.Application.Features.Polls.Queries.GetAllPollsQuery;
+using Eras.Application.Features.Polls.Queries.GetPollsByCohort;
+using Eras.Application.Features.Polls.Queries.GetPollsByStudent;
+using Eras.Application.Features.Variables.Queries.GetVariablesByPollUuidAndComponent;
+using Eras.Application.Models.Response.Controllers.PollsController;
+using Eras.Domain.Entities;
+
+using MediatR;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using Xunit;
+
+namespace Eras.Api.Tests.Controllers;
+
+public class PollsControllerTests
+{
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly Mock<ILogger<PollsController>> _loggerMock;
+    private readonly PollsController _controller;
+
+    public PollsControllerTests()
+    {
+        _mediatorMock = new Mock<IMediator>();
+        _loggerMock = new Mock<ILogger<PollsController>>();
+        _controller = new PollsController(
+            _mediatorMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task GetPollsByCohortAsync_WhenBothStudentAndCohortProvided_ReturnsBadRequestAsync()
+    {
+        // Act
+        var result = await _controller.GetPollsByCohortAsync(CohortId: 1, StudentId: 2);
+
+        // Assert
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal("Only filter by StudentId or CohortId", badRequest.Value);
+
+        _mediatorMock.Verify(m => m.Send(It.IsAny<IRequest<object>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetPollsByCohortAsync_WhenNoFilters_ReturnsAllPollsAsync()
+    {
+        // Arrange
+        var expected = new List<GetPollsQueryResponse>();
+
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<GetAllPollsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        // Act
+        var result = await _controller.GetPollsByCohortAsync(0, 0);
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Same(expected, ok.Value);
+        _mediatorMock.Verify(m =>
+            m.Send(It.IsAny<GetAllPollsQuery>(),It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetPollsByCohortAsync_WhenStudentProvided_ReturnsStudentPollsAsync()
+    {
+        // Arrange
+        var expected = new List<GetPollsQueryResponse>();
+
+        _mediatorMock
+            .Setup(m => m.Send(It.Is<GetPollsByStudentQuery>(q => q.StudentId == 5),It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        // Act
+        var result = await _controller.GetPollsByCohortAsync(0, 5);
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Same(expected, ok.Value);
+        _mediatorMock.Verify(m =>
+            m.Send(It.Is<GetPollsByStudentQuery>(q => q.StudentId == 5), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetPollsByCohortAsync_WhenOnlyCohortProvided_ReturnsCohortPollsAsync()
+    {
+        // Arrange
+        var expected = new List<GetPollsQueryResponse>();
+        _mediatorMock
+            .Setup(m => m.Send(It.Is<GetPollsByCohortListQuery>(q => q.CohortId == 10), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        // Act
+        var result = await _controller.GetPollsByCohortAsync(10, 0);
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Same(expected, ok.Value);
+
+        _mediatorMock.Verify(m =>
+            m.Send(It.Is<GetPollsByCohortListQuery>(q => q.CohortId == 10),It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAllPollVariableByCohortAndPollAsync_ReturnsOkAsync()
+    {
+        // Arrange
+        var expected = new List<PollVariableDto>();
+
+        _mediatorMock
+            .Setup(m => m.Send(
+                It.Is<GetAllByPollAndCohortQuery>(q => q.cohortId == 7 && q.pollId == 3),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        // Act
+        var result = await _controller.GetAllPollVariableByCohortAndPollAsync(3, 7);
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Same(expected, ok.Value);
+    }
+
+    [Fact]
+    public async Task GetVariablesByComponentsAsync_ReturnsVariablesAsync()
+    {
+        // Arrange
+        var components = new List<string>{ "A", "B"};
+
+        var expected = new List<Variable>
+        {
+            new Variable(),
+            new Variable()
+        };
+
+        _mediatorMock
+            .Setup(m => m.Send(
+                It.Is<GetVariablesByPollUuidAndComponentQuery>(q =>
+                    q.pollUuid == "poll-uuid" &&
+                    q.LastVersion &&
+                    q.component.SequenceEqual(components)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        // Act
+        var result = await _controller.GetVariablesByComponentsAsync("poll-uuid", components, true);
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Same(expected, ok.Value);
+        _mediatorMock.Verify(m =>
+            m.Send(It.IsAny<GetVariablesByPollUuidAndComponentQuery>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/test/Eras.Api.Tests/Controllers/ProfessionalsControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/ProfessionalsControllerTests.cs
@@ -1,0 +1,109 @@
+﻿using Eras.Api.Controllers;
+using Eras.Application.DTOs;
+using Eras.Application.Features.Professionals.Commands.CreateProfessional;
+using Eras.Application.Features.Professionals.Queries.GetProfessionals;
+using Eras.Application.Models.Response;
+using Eras.Application.Models.Response.Common;
+using Eras.Application.Utils;
+using Eras.Domain.Entities;
+
+using MediatR;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using Xunit;
+namespace Eras.Api.Tests.Controllers;
+
+public class ProfessionalsControllerTests
+{
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly Mock<ILogger<ProfessionalsController>> _loggerMock;
+    private readonly ProfessionalsController _controller;
+
+    public ProfessionalsControllerTests()
+    {
+        _mediatorMock = new Mock<IMediator>();
+        _loggerMock = new Mock<ILogger<ProfessionalsController>>();
+
+        _controller = new ProfessionalsController(
+            _mediatorMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task GetProfessionalsAsync_ReturnsOkAsync()
+    {
+        // Arrange
+        var pagination = new Pagination();
+        var response = new PagedResult<JUProfessional>( Items:
+            [new JUProfessional()
+            {
+                Id = 1,
+                Name = "Test",
+                Uuid = "36",
+            }],
+            Count: 1
+        );
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<GetProfessionalsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        // Act
+        IActionResult result = await _controller.GetProfessionalsAsync(pagination);
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Same(response, ok.Value);
+    }
+
+    [Fact]
+    public async Task CreateProfessionalAsync_ReturnsBadRequest_WhenProfessionalIsNullAsync()
+    {
+        // Act
+        IActionResult result = await _controller.CreateProfessionalAsync(null!);
+
+        // Assert
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal("Professional cannot be null", badRequest.Value);
+    }
+
+    [Fact]
+    public async Task CreateProfessionalAsync_ReturnsOk_WhenMediatorReturnsSuccessAsync()
+    {
+        // Arrange
+        var dto = new JUProfessionalDTO() { Name = "b" };
+        var professional = new JUProfessional();
+        var response = new CreateCommandResponse<JUProfessional>(professional, "Success", true);
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<CreateProfessionalCommand>(),It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        // Act
+        IActionResult result = await _controller.CreateProfessionalAsync(dto);
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Same(response, ok.Value);
+    }
+
+    [Fact]
+    public async Task CreateProfessionalAsync_ReturnsBadRequest_WhenMediatorReturnsFailure()
+    {
+        // Arrange
+        var dto = new JUProfessionalDTO() { Name = "b" };
+        var response = new CreateCommandResponse<JUProfessional>(null, "Error", false);
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<CreateProfessionalCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        // Act
+        IActionResult result = await _controller.CreateProfessionalAsync(dto);
+
+        // Assert
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal(response.Message, badRequest.Value);
+    }
+}

--- a/test/Eras.Api.Tests/Controllers/ProfessionalsControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/ProfessionalsControllerTests.cs
@@ -48,7 +48,7 @@ public class ProfessionalsControllerTests
             Count: 1
         );
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<GetProfessionalsQuery>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<GetProfessionalsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
 
         // Act
@@ -78,7 +78,7 @@ public class ProfessionalsControllerTests
         var professional = new JUProfessional();
         var response = new CreateCommandResponse<JUProfessional>(professional, "Success", true);
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<CreateProfessionalCommand>(),It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<CreateProfessionalCommand>(),It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
 
         // Act
@@ -90,13 +90,13 @@ public class ProfessionalsControllerTests
     }
 
     [Fact]
-    public async Task CreateProfessionalAsync_ReturnsBadRequest_WhenMediatorReturnsFailure()
+    public async Task CreateProfessionalAsync_ReturnsBadRequest_WhenMediatorReturnsFailureAsync()
     {
         // Arrange
         var dto = new JUProfessionalDTO() { Name = "b" };
-        var response = new CreateCommandResponse<JUProfessional>(null, "Error", false);
+        var response = new CreateCommandResponse<JUProfessional>(null!, "Error", false);
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<CreateProfessionalCommand>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<CreateProfessionalCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
 
         // Act

--- a/test/Eras.Api.Tests/Controllers/ReportsControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/ReportsControllerTests.cs
@@ -1,0 +1,272 @@
+﻿using Eras.Api.Controllers;
+using Eras.Application.DTOs.CL;
+using Eras.Application.DTOs.Views;
+using Eras.Application.Features.Consolidator.Queries;
+using Eras.Application.Features.Consolidator.Queries.Polls;
+using Eras.Application.Features.Consolidator.Queries.Students;
+using Eras.Application.Models.Consolidator;
+using Eras.Application.Models.Response.Common;
+using Eras.Application.Utils;
+using Eras.Domain.Entities;
+
+using MediatR;
+
+using Microsoft.AspNetCore.Mvc;
+
+using Moq;
+
+using Xunit;
+
+using static System.Runtime.InteropServices.JavaScript.JSType;
+
+namespace Eras.Api.Tests.Controllers;
+
+public class ReportsControllerTests
+{
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly ReportsController _controller;
+
+    public ReportsControllerTests()
+    {
+        _controller = new ReportsController(_mediator.Object);
+    }
+
+    [Fact]
+    public async Task GetHigherRiskStudentsByCohortAsync_ReturnsOk_WhenQuerySucceedsAsync()
+    {
+        var student = new List<(Student, List<Answer>, decimal)>
+        {
+            (new Student
+            {
+                Uuid = "student-1",
+                Name = "John"
+            },
+            new List<Answer>
+            {
+                new()
+                {
+                    Id = 1,
+                    AnswerText = "Yes",
+                    RiskLevel = 2,
+                    PollVariableId = 3,
+                    PollInstanceId = 4
+                }
+            },
+            0.75m),
+        };
+
+        var response = new GetQueryResponse<List<(Student, List<Answer>, decimal)>>(student, "Success", true);
+        _mediator
+            .Setup(x => x.Send(It.IsAny<GetStudentTopQuery>(), default))
+            .ReturnsAsync(response);
+
+        var result = await _controller.GetHigherRiskStudentsByCohortAsync("C1", "Poll", 5);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetHigherRiskStudentsByCohortAsync_ReturnsBadRequest_WhenQueryFailsAsync()
+    {
+        var response = new GetQueryResponse<List<(Student, List<Answer>, decimal)>>(null, "Error", false);
+        _mediator
+            .Setup(x => x.Send(It.IsAny<GetStudentTopQuery>(), default))
+            .ReturnsAsync(response);
+
+        var result = await _controller.GetHigherRiskStudentsByCohortAsync("C1", "Poll", 5);
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetHigherRiskStudentsByCohortAsync_ReturnsNotFound_WhenExceptionOccursAsync()
+    {
+        _mediator
+            .Setup(x => x.Send(It.IsAny<GetStudentTopQuery>(), default))
+            .ThrowsAsync(new Exception("boom"));
+
+        var result = await _controller.GetHigherRiskStudentsByCohortAsync("C1", "Poll", 5);
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetHigherRiskStudentsByPollAsync_ReturnsOkAsync()
+    {
+        var response = new PagedResult<ErasCalculationsByPollDTO>(Items: null, Count: 0 );
+        _mediator
+            .Setup(x => x.Send(It.IsAny<GetPollTopQuery>(), default))
+            .ReturnsAsync(response);
+
+        var result = await _controller.GetHigherRiskStudentsByPollAsync(
+            Guid.NewGuid().ToString(),
+            new Pagination(),
+            "1,2,3");
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetHigherRiskStudentsByPollAsync_ReturnsNotFound_WhenExceptionOccursAsync()
+    {
+        _mediator
+            .Setup(x => x.Send(It.IsAny<GetPollTopQuery>(), default))
+            .ThrowsAsync(new Exception());
+
+        var result = await _controller.GetHigherRiskStudentsByPollAsync(
+            Guid.NewGuid().ToString(),
+            new Pagination(),
+            "1,2");
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetAvgRiskByPollAsync_ReturnsBadRequest_WhenNoCohortsAsync()
+    {
+        var result = await _controller.GetAvgRiskByPollAsync(
+            Guid.NewGuid().ToString(), "", false, 1);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetAvgRiskByPollAsync_ReturnsOk_WhenSuccessfulAsync()
+    {
+        var data = new AvgReportResponseVm();
+        var response = new GetQueryResponse<AvgReportResponseVm>(data, "Success", true);
+        _mediator
+            .Setup(x => x.Send(It.IsAny<PollAvgQuery>(), default))
+            .ReturnsAsync(response);
+
+        var result = await _controller.GetAvgRiskByPollAsync(Guid.NewGuid().ToString(), "1,2", false, 1);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetAvgRiskByPollAsync_ReturnsBadRequest_WhenQueryFailsAsync()
+    {
+        var response = new GetQueryResponse<AvgReportResponseVm>(null, "Error", false);
+        _mediator
+            .Setup(x => x.Send(It.IsAny<PollAvgQuery>(), default))
+            .ReturnsAsync(response);
+
+        var result = await _controller.GetAvgRiskByPollAsync(Guid.NewGuid().ToString(), "1", false, 1);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetAvgRiskByPollAsync_Returns500_WhenExceptionOccursAsync()
+    {
+        _mediator
+            .Setup(x => x.Send(It.IsAny<PollAvgQuery>(), default))
+            .ThrowsAsync(new Exception());
+
+        var result = await _controller.GetAvgRiskByPollAsync(Guid.NewGuid().ToString(),"1",false,1);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(500, objectResult.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetPollResultsCountAsync_ReturnsOk_WhenSuccessfulAsync()
+    {
+        var data = new CountReportResponseVm();
+        var response = new GetQueryResponse<CountReportResponseVm>(data, "Success", true);
+        _mediator
+            .Setup(x => x.Send(It.IsAny<PollCountQuery>(), default))
+            .ReturnsAsync(response);
+
+        var result = await _controller.GetPollResultsCountAsync(
+            Guid.NewGuid().ToString(), 1, "1,2", "3,4", false);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetPollResultsCountAsync_ReturnsBadRequest_WhenQueryFailsAsync()
+    {
+        var response = new GetQueryResponse<CountReportResponseVm>(null, "Error", false);
+        _mediator
+            .Setup(x => x.Send(It.IsAny<PollCountQuery>(), default))
+            .ReturnsAsync(response);
+
+        var result = await _controller.GetPollResultsCountAsync(
+            Guid.NewGuid().ToString(), 1, "1", "2", false);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetPollResultsCountAsync_Returns500_WhenExceptionOccursAsync()
+    {
+        _mediator
+            .Setup(x => x.Send(It.IsAny<PollCountQuery>(), default))
+            .ThrowsAsync(new Exception());
+
+        var result = await _controller.GetPollResultsCountAsync(
+            Guid.NewGuid().ToString(), 1, "1", "2", false);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(500, objectResult.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetComponentSummaryByPollAsync_ReturnsOk_WhenSuccessfulAsync()
+    {
+        var data = new RiskCountResponseVm()
+        {
+            AverageRisk = 2
+        };
+        var response = new GetQueryResponse<RiskCountResponseVm>(data, "Success", true);
+        _mediator
+            .Setup(x => x.Send(It.IsAny<GetRiskCountQuery>(), default))
+            .ReturnsAsync(response);
+
+        var result = await _controller.GetComponentSummaryByPollAsync(Guid.NewGuid().ToString());
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetComponentSummaryByPollAsync_ReturnsNotFound_WhenQueryFailsAsync()
+    {
+        var data = It.IsAny<RiskCountResponseVm>();
+        var response = new GetQueryResponse<RiskCountResponseVm>(data, "Error", false);
+        _mediator
+            .Setup(x => x.Send(It.IsAny<GetRiskCountQuery>(), default))
+            .ReturnsAsync(response);
+
+        var result = await _controller.GetComponentSummaryByPollAsync(Guid.NewGuid().ToString());
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetComponentSummaryByPollAsync_ReturnsBadRequest_WhenExceptionOccursAsync()
+    {
+        _mediator
+            .Setup(x => x.Send(It.IsAny<GetRiskCountQuery>(), default))
+            .ThrowsAsync(new Exception());
+
+        var result = await _controller.GetComponentSummaryByPollAsync(Guid.NewGuid().ToString());
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetCountSummaryAsync_ReturnsOkAsync()
+    {
+        var data = It.IsAny<Dictionary<string, int>>();
+        var response = new GetQueryResponse<Dictionary<string, int>>(data, "Success", true);
+        _mediator
+            .Setup(x => x.Send(It.IsAny<GetCountSummaryQuery>(), default))
+            .ReturnsAsync(response);
+
+        var result = await _controller.GetCountSummaryAsync();
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+}

--- a/test/Eras.Api.Tests/Controllers/ReportsControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/ReportsControllerTests.cs
@@ -17,8 +17,6 @@ using Moq;
 
 using Xunit;
 
-using static System.Runtime.InteropServices.JavaScript.JSType;
-
 namespace Eras.Api.Tests.Controllers;
 
 public class ReportsControllerTests
@@ -57,7 +55,7 @@ public class ReportsControllerTests
 
         var response = new GetQueryResponse<List<(Student, List<Answer>, decimal)>>(student, "Success", true);
         _mediator
-            .Setup(x => x.Send(It.IsAny<GetStudentTopQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<GetStudentTopQuery>(), default))
             .ReturnsAsync(response);
 
         var result = await _controller.GetHigherRiskStudentsByCohortAsync("C1", "Poll", 5);
@@ -68,9 +66,9 @@ public class ReportsControllerTests
     [Fact]
     public async Task GetHigherRiskStudentsByCohortAsync_ReturnsBadRequest_WhenQueryFailsAsync()
     {
-        var response = new GetQueryResponse<List<(Student, List<Answer>, decimal)>>(null, "Error", false);
+        var response = new GetQueryResponse<List<(Student, List<Answer>, decimal)>>(null!, "Error", false);
         _mediator
-            .Setup(x => x.Send(It.IsAny<GetStudentTopQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<GetStudentTopQuery>(), default))
             .ReturnsAsync(response);
 
         var result = await _controller.GetHigherRiskStudentsByCohortAsync("C1", "Poll", 5);
@@ -82,7 +80,7 @@ public class ReportsControllerTests
     public async Task GetHigherRiskStudentsByCohortAsync_ReturnsNotFound_WhenExceptionOccursAsync()
     {
         _mediator
-            .Setup(x => x.Send(It.IsAny<GetStudentTopQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<GetStudentTopQuery>(), default))
             .ThrowsAsync(new Exception("boom"));
 
         var result = await _controller.GetHigherRiskStudentsByCohortAsync("C1", "Poll", 5);
@@ -93,9 +91,9 @@ public class ReportsControllerTests
     [Fact]
     public async Task GetHigherRiskStudentsByPollAsync_ReturnsOkAsync()
     {
-        var response = new PagedResult<ErasCalculationsByPollDTO>(Items: null, Count: 0 );
+        var response = new PagedResult<ErasCalculationsByPollDTO>(Items: null!, Count: 0 );
         _mediator
-            .Setup(x => x.Send(It.IsAny<GetPollTopQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<GetPollTopQuery>(), default))
             .ReturnsAsync(response);
 
         var result = await _controller.GetHigherRiskStudentsByPollAsync(
@@ -110,7 +108,7 @@ public class ReportsControllerTests
     public async Task GetHigherRiskStudentsByPollAsync_ReturnsNotFound_WhenExceptionOccursAsync()
     {
         _mediator
-            .Setup(x => x.Send(It.IsAny<GetPollTopQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<GetPollTopQuery>(), default))
             .ThrowsAsync(new Exception());
 
         var result = await _controller.GetHigherRiskStudentsByPollAsync(
@@ -136,7 +134,7 @@ public class ReportsControllerTests
         var data = new AvgReportResponseVm();
         var response = new GetQueryResponse<AvgReportResponseVm>(data, "Success", true);
         _mediator
-            .Setup(x => x.Send(It.IsAny<PollAvgQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<PollAvgQuery>(), default))
             .ReturnsAsync(response);
 
         var result = await _controller.GetAvgRiskByPollAsync(Guid.NewGuid().ToString(), "1,2", false, 1);
@@ -147,9 +145,9 @@ public class ReportsControllerTests
     [Fact]
     public async Task GetAvgRiskByPollAsync_ReturnsBadRequest_WhenQueryFailsAsync()
     {
-        var response = new GetQueryResponse<AvgReportResponseVm>(null, "Error", false);
+        var response = new GetQueryResponse<AvgReportResponseVm>(null!, "Error", false);
         _mediator
-            .Setup(x => x.Send(It.IsAny<PollAvgQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<PollAvgQuery>(), default))
             .ReturnsAsync(response);
 
         var result = await _controller.GetAvgRiskByPollAsync(Guid.NewGuid().ToString(), "1", false, 1);
@@ -161,7 +159,7 @@ public class ReportsControllerTests
     public async Task GetAvgRiskByPollAsync_Returns500_WhenExceptionOccursAsync()
     {
         _mediator
-            .Setup(x => x.Send(It.IsAny<PollAvgQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<PollAvgQuery>(), default))
             .ThrowsAsync(new Exception());
 
         var result = await _controller.GetAvgRiskByPollAsync(Guid.NewGuid().ToString(),"1",false,1);
@@ -176,7 +174,7 @@ public class ReportsControllerTests
         var data = new CountReportResponseVm();
         var response = new GetQueryResponse<CountReportResponseVm>(data, "Success", true);
         _mediator
-            .Setup(x => x.Send(It.IsAny<PollCountQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<PollCountQuery>(), default))
             .ReturnsAsync(response);
 
         var result = await _controller.GetPollResultsCountAsync(
@@ -188,9 +186,9 @@ public class ReportsControllerTests
     [Fact]
     public async Task GetPollResultsCountAsync_ReturnsBadRequest_WhenQueryFailsAsync()
     {
-        var response = new GetQueryResponse<CountReportResponseVm>(null, "Error", false);
+        var response = new GetQueryResponse<CountReportResponseVm>(null!, "Error", false);
         _mediator
-            .Setup(x => x.Send(It.IsAny<PollCountQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<PollCountQuery>(), default))
             .ReturnsAsync(response);
 
         var result = await _controller.GetPollResultsCountAsync(
@@ -203,7 +201,7 @@ public class ReportsControllerTests
     public async Task GetPollResultsCountAsync_Returns500_WhenExceptionOccursAsync()
     {
         _mediator
-            .Setup(x => x.Send(It.IsAny<PollCountQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<PollCountQuery>(), default))
             .ThrowsAsync(new Exception());
 
         var result = await _controller.GetPollResultsCountAsync(
@@ -222,7 +220,7 @@ public class ReportsControllerTests
         };
         var response = new GetQueryResponse<RiskCountResponseVm>(data, "Success", true);
         _mediator
-            .Setup(x => x.Send(It.IsAny<GetRiskCountQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<GetRiskCountQuery>(), default))
             .ReturnsAsync(response);
 
         var result = await _controller.GetComponentSummaryByPollAsync(Guid.NewGuid().ToString());
@@ -236,7 +234,7 @@ public class ReportsControllerTests
         var data = It.IsAny<RiskCountResponseVm>();
         var response = new GetQueryResponse<RiskCountResponseVm>(data, "Error", false);
         _mediator
-            .Setup(x => x.Send(It.IsAny<GetRiskCountQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<GetRiskCountQuery>(), default))
             .ReturnsAsync(response);
 
         var result = await _controller.GetComponentSummaryByPollAsync(Guid.NewGuid().ToString());
@@ -248,7 +246,7 @@ public class ReportsControllerTests
     public async Task GetComponentSummaryByPollAsync_ReturnsBadRequest_WhenExceptionOccursAsync()
     {
         _mediator
-            .Setup(x => x.Send(It.IsAny<GetRiskCountQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<GetRiskCountQuery>(), default))
             .ThrowsAsync(new Exception());
 
         var result = await _controller.GetComponentSummaryByPollAsync(Guid.NewGuid().ToString());
@@ -262,7 +260,7 @@ public class ReportsControllerTests
         var data = It.IsAny<Dictionary<string, int>>();
         var response = new GetQueryResponse<Dictionary<string, int>>(data, "Success", true);
         _mediator
-            .Setup(x => x.Send(It.IsAny<GetCountSummaryQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<GetCountSummaryQuery>(), default))
             .ReturnsAsync(response);
 
         var result = await _controller.GetCountSummaryAsync();

--- a/test/Eras.Api.Tests/Controllers/ServiceProvidersControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/ServiceProvidersControllerTests.cs
@@ -42,7 +42,7 @@ public class ServiceProvidersControllerTests
             }
         ]);
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<GetAllServiceProvidersQuery>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<GetAllServiceProvidersQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
 
         // Act
@@ -76,7 +76,7 @@ public class ServiceProvidersControllerTests
         };
         var response = new CreateCommandResponse<ServiceProviders>(serviceProvider, "Success", true);
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<CreateServiceProviderCommand>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<CreateServiceProviderCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
 
         // Act
@@ -92,9 +92,9 @@ public class ServiceProvidersControllerTests
     {
         // Arrange
         var dto = new ServiceProvidersDTO() { ServiceProviderName = "", ServiceProviderLogo = "b" };
-        var response = new CreateCommandResponse<ServiceProviders>(null, "Error", false);
+        var response = new CreateCommandResponse<ServiceProviders>(null!, "Error", false);
         _mediatorMock
-            .Setup(x => x.Send(It.IsAny<CreateServiceProviderCommand>(), It.IsAny<CancellationToken>()))
+            .Setup(X => X.Send(It.IsAny<CreateServiceProviderCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(response);
 
         // Act

--- a/test/Eras.Api.Tests/Controllers/ServiceProvidersControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/ServiceProvidersControllerTests.cs
@@ -1,0 +1,107 @@
+﻿using Eras.Api.Controllers;
+using Eras.Application.DTOs;
+using Eras.Application.Features.ServiceProviders.Command;
+using Eras.Application.Features.ServiceProviders.Queries;
+using Eras.Application.Models.Response.Common;
+using Eras.Application.Utils;
+using Eras.Domain.Entities;
+
+using MediatR;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+namespace Eras.Api.Tests.Controllers;
+
+public class ServiceProvidersControllerTests
+{
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly Mock<ILogger<ServiceProvidersController>> _loggerMock;
+    private readonly ServiceProvidersController _controller;
+
+    public ServiceProvidersControllerTests()
+    {
+        _mediatorMock = new Mock<IMediator>();
+        _loggerMock = new Mock<ILogger<ServiceProvidersController>>();
+        _controller = new ServiceProvidersController(
+            _mediatorMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task GetServiceProvidersAsync_ReturnsOkAsync()
+    {
+        // Arrange
+        var response = new List<ServiceProviders>([
+            new ServiceProviders()
+            {
+                ServiceProviderName = "Name",
+                ServiceProviderLogo = "Test",
+            }
+        ]);
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<GetAllServiceProvidersQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        // Act
+        IActionResult result = await _controller.GetServiceProvidersAsync();
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Same(response, ok.Value);
+    }
+
+    [Fact]
+    public async Task CreateServiceProviderAsync_ReturnsBadRequest_WhenServiceProviderIsNullAsync()
+    {
+        // Act
+        IActionResult result = await _controller.CreateServiceProviderAsync(null!);
+
+        // Assert
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal("Service Provider cannot be null", badRequest.Value);
+    }
+
+    [Fact]
+    public async Task CreateServiceProviderAsync_ReturnsOk_WhenMediatorReturnsSuccessAsync()
+    {
+        // Arrange
+        var dto = new ServiceProvidersDTO() { ServiceProviderName = "", ServiceProviderLogo = "b" };
+        var serviceProvider = new ServiceProviders() 
+        {
+            ServiceProviderName = "A",
+            ServiceProviderLogo = "logo",
+        };
+        var response = new CreateCommandResponse<ServiceProviders>(serviceProvider, "Success", true);
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<CreateServiceProviderCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        // Act
+        IActionResult result = await _controller.CreateServiceProviderAsync(dto);
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Same(response, ok.Value);
+    }
+
+    [Fact]
+    public async Task CreateServiceProviderAsync_ReturnsBadRequest_WhenMediatorReturnsFailureAsync()
+    {
+        // Arrange
+        var dto = new ServiceProvidersDTO() { ServiceProviderName = "", ServiceProviderLogo = "b" };
+        var response = new CreateCommandResponse<ServiceProviders>(null, "Error", false);
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<CreateServiceProviderCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        // Act
+        IActionResult result = await _controller.CreateServiceProviderAsync(dto);
+
+        // Assert
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal(response.Message, badRequest.Value);
+    }
+}

--- a/test/Eras.Api.Tests/Controllers/StudentsControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/StudentsControllerTests.cs
@@ -45,7 +45,7 @@ public class StudentsControllerTests
     [Fact]
     public async Task ImportStudentsAsync_ReturnsBadRequest_WhenStudentsIsNullAsync()
     {
-        var result = await _controller.ImportStudentsAsync(null);
+        var result = await _controller.ImportStudentsAsync(null!);
 
         var badRequest = Assert.IsType<BadRequestObjectResult>(result);
         Assert.Equal("No Students body found", badRequest.Value);
@@ -60,10 +60,10 @@ public class StudentsControllerTests
             Email = "s@mail.com",
             SISId = "120,"
         };
-        var response = new CreateCommandResponse<Student[]>(null, "Success", true);
+        var response = new CreateCommandResponse<Student[]>(null!, "Success", true);
 
         _mediator
-            .Setup(x => x.Send(It.IsAny<CreateStudentsCommand>(), default))
+            .Setup(X => X.Send(It.IsAny<CreateStudentsCommand>(), default))
             .ReturnsAsync(response);
 
         var result = await _controller.ImportStudentsAsync([dto]);
@@ -80,10 +80,10 @@ public class StudentsControllerTests
             Email = "s@mail.com",
             SISId = "120,"
         };
-        var response = new CreateCommandResponse<Student[]>(null, "Error", false);
+        var response = new CreateCommandResponse<Student[]>(null!, "Error", false);
 
         _mediator
-            .Setup(x => x.Send(It.IsAny<CreateStudentsCommand>(), default))
+            .Setup(X => X.Send(It.IsAny<CreateStudentsCommand>(), default))
             .ReturnsAsync(response);
 
         var result = await _controller.ImportStudentsAsync([students]);
@@ -101,7 +101,7 @@ public class StudentsControllerTests
             Count: 1
         );
         _mediator
-            .Setup(x => x.Send(It.IsAny<GetAllStudentsQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<GetAllStudentsQuery>(), default))
             .ReturnsAsync(response);
 
         var result = await _controller.GetAllAsync(pagination);
@@ -118,7 +118,7 @@ public class StudentsControllerTests
         };
         var response = new CreateCommandResponse<Student>(student, "Success", true);
         _mediator
-            .Setup(x => x.Send(It.IsAny<GetStudentDetailsQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<GetStudentDetailsQuery>(), default))
             .ReturnsAsync(response);
 
         var result = await _controller.GetStudentDetailsByIdAsync(1);
@@ -129,9 +129,9 @@ public class StudentsControllerTests
     [Fact]
     public async Task GetStudentDetailsByIdAsync_ReturnsNotFound_WhenStudentDoesNotExistAsync()
     {
-        var response = new CreateCommandResponse<Student>(null, "Error", false);
+        var response = new CreateCommandResponse<Student>(null!, "Error", false);
         _mediator
-            .Setup(x => x.Send(It.IsAny<GetStudentDetailsQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<GetStudentDetailsQuery>(), default))
             .ReturnsAsync(response);
 
         var result = await _controller.GetStudentDetailsByIdAsync(1);
@@ -145,7 +145,7 @@ public class StudentsControllerTests
         var pagination = new Pagination();
         var response = new PagedResult<Student>(Items: [new Student()], Count: 1);
         _mediator
-            .Setup(x => x.Send(It.IsAny<GetAllStudentsByPollUuidAndDaysQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<GetAllStudentsByPollUuidAndDaysQuery>(), default))
             .ReturnsAsync(response);
 
         var result = await _controller.GetPreviewPollsAsync(pagination, Guid.NewGuid().ToString(), 30);
@@ -159,7 +159,7 @@ public class StudentsControllerTests
         var pagination = new Pagination();
         var response = new PagedResult<StudentAverageRiskDto>(Items: [new StudentAverageRiskDto()], Count: 1);
         _mediator
-            .Setup(x => x.Send(It.IsAny<GetAllAverageRiskByCohortAndPollQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<GetAllAverageRiskByCohortAndPollQuery>(), default))
             .ReturnsAsync(response);
 
         var result = await _controller.GetAllAvgRiskByCohortAndPollAsync(
@@ -176,7 +176,7 @@ public class StudentsControllerTests
     public async Task GetPollRiskSumStudentsAsync_ReturnsOkAsync()
     {
         _mediator
-            .Setup(x => x.Send(It.IsAny<GetCohortStudentsRiskByPollQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<GetCohortStudentsRiskByPollQuery>(), default))
             .ReturnsAsync(new List<GetCohortStudentsRiskByPollResponse>());
 
         var result = await _controller.GetPollRiskSumStudentsAsync(
@@ -190,10 +190,10 @@ public class StudentsControllerTests
     public async Task GetPollTopStudentsAsync_ReturnsOkAsync()
     {
         var response = new GetQueryResponse<PagedResult<GetCohortTopRiskStudentsByComponentResponse>>(
-            null, "Success", true);
+            null!, "Success", true);
 
         _mediator
-            .Setup(x => x.Send(It.IsAny<GetCohortTopRiskStudentsQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<GetCohortTopRiskStudentsQuery>(), default))
             .ReturnsAsync(response);
 
         var result = await _controller.GetPollTopStudentsAsync(
@@ -209,9 +209,9 @@ public class StudentsControllerTests
     public async Task GetComponentTopStudentsAsync_ReturnsOkAsync()
     {
         var response = new GetQueryResponse<PagedResult<GetCohortTopRiskStudentsByComponentResponse>>(
-            null, "Success", true);
+            null!, "Success", true);
         _mediator
-            .Setup(x => x.Send(It.IsAny<GetCohortTopRiskStudentsByComponentQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<GetCohortTopRiskStudentsByComponentQuery>(), default))
             .ReturnsAsync(response);
 
         var result = await _controller.GetComponentTopStudentsAsync(
@@ -227,9 +227,9 @@ public class StudentsControllerTests
     [Fact]
     public async Task GetStudentAnswersByPollAsync_ReturnsOkAsync()
     {
-        var response = new PagedResult<StudentAnswer>(Items: null, Count: 0);
+        var response = new PagedResult<StudentAnswer>(Items: null!, Count: 0);
         _mediator
-            .Setup(x => x.Send(It.IsAny<GetStudentAnswersByPollQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<GetStudentAnswersByPollQuery>(), default))
             .ReturnsAsync(response);
 
         var result = await _controller.GetStudentAnswersByPollAsync(1, 2, new Pagination());
@@ -241,7 +241,7 @@ public class StudentsControllerTests
     public async Task GetStudentAnswersByPollAsync_ReturnsNotFound_WhenExceptionOccursAsync()
     {
         _mediator
-            .Setup(x => x.Send(It.IsAny<GetStudentAnswersByPollQuery>(), default))
+            .Setup(X => X.Send(It.IsAny<GetStudentAnswersByPollQuery>(), default))
             .ThrowsAsync(new Exception("failure"));
 
         var result = await _controller.GetStudentAnswersByPollAsync(1, 2, new Pagination());

--- a/test/Eras.Api.Tests/Controllers/StudentsControllerTests.cs
+++ b/test/Eras.Api.Tests/Controllers/StudentsControllerTests.cs
@@ -1,0 +1,251 @@
+﻿using Eras.Api.Controllers;
+using Eras.Application.DTOs;
+using Eras.Application.DTOs.Student;
+using Eras.Application.Features.Answers.Queries;
+using Eras.Application.Features.Cohorts.Queries.GetCohortStudentsRiskByPoll;
+using Eras.Application.Features.Cohorts.Queries.GetCohortTopRiskStudents;
+using Eras.Application.Features.Cohorts.Queries.GetCohortTopRiskStudentsByComponent;
+using Eras.Application.Features.Students.Commands.CreateStudent;
+using Eras.Application.Features.Students.Queries.GetAll;
+using Eras.Application.Features.Students.Queries.GetAllAverageRiskByCohorAndPoll;
+using Eras.Application.Features.Students.Queries.GetAllByPollAndDate;
+using Eras.Application.Features.Students.Queries.GetStudentDetails;
+using Eras.Application.Models.Response.Calculations;
+using Eras.Application.Models.Response.Common;
+using Eras.Application.Models.Response.Controllers.StudentsController;
+using Eras.Application.Utils;
+using Eras.Domain.Entities;
+
+using MediatR;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using Xunit;
+
+namespace Eras.Api.Tests.Controllers;
+
+public class StudentsControllerTests
+{
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly Mock<ILogger<StudentsController>> _logger = new();
+    private readonly StudentsController _controller;
+
+    public StudentsControllerTests()
+    {
+        _mediator = new Mock<IMediator>();
+        _logger = new Mock<ILogger<StudentsController>>();
+        _controller = new StudentsController(
+            _mediator.Object,
+            _logger.Object);
+    }
+
+    [Fact]
+    public async Task ImportStudentsAsync_ReturnsBadRequest_WhenStudentsIsNullAsync()
+    {
+        var result = await _controller.ImportStudentsAsync(null);
+
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal("No Students body found", badRequest.Value);
+    }
+
+    [Fact]
+    public async Task ImportStudentsAsync_ReturnsOk_WhenImportSucceedsAsync()
+    {
+        var dto = new StudentImportDto()
+        {
+            Name = "S",
+            Email = "s@mail.com",
+            SISId = "120,"
+        };
+        var response = new CreateCommandResponse<Student[]>(null, "Success", true);
+
+        _mediator
+            .Setup(x => x.Send(It.IsAny<CreateStudentsCommand>(), default))
+            .ReturnsAsync(response);
+
+        var result = await _controller.ImportStudentsAsync([dto]);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task ImportStudentsAsync_Returns400_WhenImportFailsAsync()
+    {
+        var students = new StudentImportDto()
+        {
+            Name = "S",
+            Email = "s@mail.com",
+            SISId = "120,"
+        };
+        var response = new CreateCommandResponse<Student[]>(null, "Error", false);
+
+        _mediator
+            .Setup(x => x.Send(It.IsAny<CreateStudentsCommand>(), default))
+            .ReturnsAsync(response);
+
+        var result = await _controller.ImportStudentsAsync([students]);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(400, objectResult.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsOkAsync()
+    {
+        var pagination = new Pagination();
+        var response = new PagedResult<GetAllStudentsQueryResponse>(Items:
+            [new GetAllStudentsQueryResponse()],
+            Count: 1
+        );
+        _mediator
+            .Setup(x => x.Send(It.IsAny<GetAllStudentsQuery>(), default))
+            .ReturnsAsync(response);
+
+        var result = await _controller.GetAllAsync(pagination);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetStudentDetailsByIdAsync_ReturnsOk_WhenStudentExistsAsync()
+    {
+        var student = new Student()
+        {
+            Id = 1,
+        };
+        var response = new CreateCommandResponse<Student>(student, "Success", true);
+        _mediator
+            .Setup(x => x.Send(It.IsAny<GetStudentDetailsQuery>(), default))
+            .ReturnsAsync(response);
+
+        var result = await _controller.GetStudentDetailsByIdAsync(1);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetStudentDetailsByIdAsync_ReturnsNotFound_WhenStudentDoesNotExistAsync()
+    {
+        var response = new CreateCommandResponse<Student>(null, "Error", false);
+        _mediator
+            .Setup(x => x.Send(It.IsAny<GetStudentDetailsQuery>(), default))
+            .ReturnsAsync(response);
+
+        var result = await _controller.GetStudentDetailsByIdAsync(1);
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetPreviewPollsAsync_ReturnsOkAsync()
+    {
+        var pagination = new Pagination();
+        var response = new PagedResult<Student>(Items: [new Student()], Count: 1);
+        _mediator
+            .Setup(x => x.Send(It.IsAny<GetAllStudentsByPollUuidAndDaysQuery>(), default))
+            .ReturnsAsync(response);
+
+        var result = await _controller.GetPreviewPollsAsync(pagination, Guid.NewGuid().ToString(), 30);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetAllAvgRiskByCohortAndPollAsync_ReturnsOkAsync()
+    {
+        var pagination = new Pagination();
+        var response = new PagedResult<StudentAverageRiskDto>(Items: [new StudentAverageRiskDto()], Count: 1);
+        _mediator
+            .Setup(x => x.Send(It.IsAny<GetAllAverageRiskByCohortAndPollQuery>(), default))
+            .ReturnsAsync(response);
+
+        var result = await _controller.GetAllAvgRiskByCohortAndPollAsync(
+            "1,2",
+            Guid.NewGuid().ToString(),
+            pagination,
+            true,
+            1);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetPollRiskSumStudentsAsync_ReturnsOkAsync()
+    {
+        _mediator
+            .Setup(x => x.Send(It.IsAny<GetCohortStudentsRiskByPollQuery>(), default))
+            .ReturnsAsync(new List<GetCohortStudentsRiskByPollResponse>());
+
+        var result = await _controller.GetPollRiskSumStudentsAsync(
+            Guid.NewGuid().ToString(),
+            1);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetPollTopStudentsAsync_ReturnsOkAsync()
+    {
+        var response = new GetQueryResponse<PagedResult<GetCohortTopRiskStudentsByComponentResponse>>(
+            null, "Success", true);
+
+        _mediator
+            .Setup(x => x.Send(It.IsAny<GetCohortTopRiskStudentsQuery>(), default))
+            .ReturnsAsync(response);
+
+        var result = await _controller.GetPollTopStudentsAsync(
+            Guid.NewGuid().ToString(),
+            1,
+            true,
+            new Pagination());
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetComponentTopStudentsAsync_ReturnsOkAsync()
+    {
+        var response = new GetQueryResponse<PagedResult<GetCohortTopRiskStudentsByComponentResponse>>(
+            null, "Success", true);
+        _mediator
+            .Setup(x => x.Send(It.IsAny<GetCohortTopRiskStudentsByComponentQuery>(), default))
+            .ReturnsAsync(response);
+
+        var result = await _controller.GetComponentTopStudentsAsync(
+            Guid.NewGuid().ToString(),
+            "Mental Health",
+            1,
+            true,
+            new Pagination());
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetStudentAnswersByPollAsync_ReturnsOkAsync()
+    {
+        var response = new PagedResult<StudentAnswer>(Items: null, Count: 0);
+        _mediator
+            .Setup(x => x.Send(It.IsAny<GetStudentAnswersByPollQuery>(), default))
+            .ReturnsAsync(response);
+
+        var result = await _controller.GetStudentAnswersByPollAsync(1, 2, new Pagination());
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetStudentAnswersByPollAsync_ReturnsNotFound_WhenExceptionOccursAsync()
+    {
+        _mediator
+            .Setup(x => x.Send(It.IsAny<GetStudentAnswersByPollQuery>(), default))
+            .ThrowsAsync(new Exception("failure"));
+
+        var result = await _controller.GetStudentAnswersByPollAsync(1, 2, new Pagination());
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+}


### PR DESCRIPTION
## Description

I added unit tests to increase the code coverage for:

- AssessmentsController
- AuthController
- ConfigurationsController
- FeatureFlagController
- ProfessionalsController
- JUServiceController
- PollInstancesController
- PollsController
- ReportsController
- ServiceProvidersController
- StudentsController

NOTE:
As you may have noticed, I did not aggregate the unit tests for the JUInterventions and JURemissions controllers because they are not used. Should I remove them from this branch??

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [x] Others: unit tests - code coverage

## Checklist

- [x] Have the requirements been met?
- [x] Is the code easy to read?
- [x] Do unit tests pass?
- [x] Is the code formatted correctly?

## C# Checklist

- [x] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [x] Does the code handle exceptions correctly
- [x] Is the code subject to concurrency issues? Are shared objects properly protected?
- [x] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [x] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues

#472 