### PR TITLE
535 bug summary charts calculates incorrect percentages for some questions

### DIFF
--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollInstanceRepository.cs
@@ -16,6 +16,13 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
 
 public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollInstance, PollInstanceEntity>(Context, PollInstanceMapper.ToDomain, PollInstanceMapper.ToPersistence), IPollInstanceRepository
 {
+    private static bool IsValidAnswer(string? answerText) =>
+        !string.IsNullOrEmpty(answerText) &&
+        answerText != "-" &&
+        !answerText.Equals("None", StringComparison.OrdinalIgnoreCase) &&
+        !answerText.Equals("Ninguno", StringComparison.OrdinalIgnoreCase) &&
+        !answerText.Equals("Ninguna", StringComparison.OrdinalIgnoreCase);
+
     public async Task<PollInstance?> GetByUuidAsync(string Uuid)
     {
         PollInstanceEntity? pollInstance = await _context.PollInstances
@@ -139,8 +146,8 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
     }
 
     public async Task<AvgReportResponseVm> GetReportByPollCohortAsync(
-    string PollUuid, List<int> CohortIds, bool LastVersion,
-    DateTime startDate, DateTime endDate)
+        string PollUuid, List<int> CohortIds, bool LastVersion,
+        DateTime startDate, DateTime endDate)
     {
         List<string> emailsInCohort = await _context.StudentCohorts
             .Where(SC => CohortIds.Contains(SC.CohortId))
@@ -149,7 +156,13 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
                 S => S.Id,
                 (SC, S) => new { SC, S })
             .Select(SC => SC.S.Email)
+            .Distinct()
             .ToListAsync();
+
+        int pollVersion = _context.Polls
+            .Where(A => A.Uuid == PollUuid)
+            .Select(A => A.LastVersion)
+            .FirstOrDefault();
 
         IQueryable<ErasCalculationsByPollDTO> reportQuery;
 
@@ -161,6 +174,7 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
             where A.PollUuid == PollUuid
             where PI.FinishedAt >= startDate && PI.FinishedAt <= endDate
             where emailsInCohort.Contains(A.StudentEmail)
+            where A.PollVersion == pollVersion
             select new ErasCalculationsByPollDTO
             {
                 ComponentName = A.ComponentName,
@@ -178,10 +192,11 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
         {
             reportQuery =
             from A in _context.ErasCalculationsByPoll
-            join PI in _context.PollInstances on A.PollInstanceId equals PI.Id 
+            join PI in _context.PollInstances on A.PollInstanceId equals PI.Id
             where A.PollUuid == PollUuid
-            where PI.FinishedAt >= startDate && PI.FinishedAt <= endDate 
+            where PI.FinishedAt >= startDate && PI.FinishedAt <= endDate
             where emailsInCohort.Contains(A.StudentEmail)
+            where A.PollVersion != pollVersion
             select new ErasCalculationsByPollDTO
             {
                 ComponentName = A.ComponentName,
@@ -196,26 +211,16 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
             };
         }
 
-        List<ErasCalculationsByPollDTO> results = await reportQuery.ToListAsync();
+        List<ErasCalculationsByPollDTO> rawResults = await reportQuery.ToListAsync();
 
-        var filteredResultsForMath = results.Where(A => 
-            A.AnswerText != "-" && 
-            A.AnswerText != "" && 
-            !string.IsNullOrEmpty(A.AnswerText) &&
-            !A.AnswerText.Equals("None", StringComparison.OrdinalIgnoreCase) &&
-            !A.AnswerText.Equals("Ninguno", StringComparison.OrdinalIgnoreCase) &&
-            !A.AnswerText.Equals("Ninguna", StringComparison.OrdinalIgnoreCase)
-        ).ToList();
+        List<ErasCalculationsByPollDTO> results = [.. rawResults
+            .GroupBy(A => new { A.ComponentName, A.Question, A.Position, A.AnswerText, A.StudentEmail })
+            .Select(g => g.First())];
+
+        var filteredResultsForMath = results.Where(A => IsValidAnswer(A.AnswerText)).ToList();
 
         var avgByComponent = filteredResultsForMath
             .GroupBy(A => A.ComponentName)
-            .ToDictionary(
-                g => g.Key,
-                g => (decimal)Math.Round(g.Average(x => (double)x.AnswerRisk), 2)
-            );
-
-        var avgByQuestion = filteredResultsForMath
-            .GroupBy(A => new { A.ComponentName, A.Position, A.Question })
             .ToDictionary(
                 g => g.Key,
                 g => (decimal)Math.Round(g.Average(x => (double)x.AnswerRisk), 2)
@@ -230,32 +235,35 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
                 Questions = [.. AnsPerComp
                     .OrderBy(A => A.VariableAverageRisk)
                     .GroupBy(A => new { A.Question, A.Position })
-                    .Select(AnsPerVar => new AvgReportQuestions
+                    .Select(AnsPerVar =>
                     {
-                        Question = AnsPerVar.Key.Question,
-                        Position = AnsPerVar.Key.Position,
-                        AverageAnswer = AnsPerVar
-                            .Where(A => A.AnswerText != "-" && 
-                                A.AnswerText != "" && 
-                                !string.IsNullOrEmpty(A.AnswerText) &&
-                                A.AnswerText != "None" && A.AnswerText != "none" &&
-                                A.AnswerText != "Ninguno" && A.AnswerText != "ninguno" &&
-                                A.AnswerText != "Ninguna" && A.AnswerText != "ninguna")
-                            .GroupBy(A => A.AnswerText)
-                            .OrderByDescending(A => A.Count())
-                            .FirstOrDefault()?.Key ?? "-",
-                        AverageRisk = AnsPerVar.First().VariableAverageRisk,
-                        AnswersDetails = [.. AnsPerVar
-                            .GroupBy(A => A.AnswerText)
-                            .Select(AnsGroup => new AnswerDetails
-                            {
-                                AnswerText = AnsGroup.Key,
-                                AnswerPercentage = AnsGroup.First().AnswerPercentage,
-                                StudentsEmails = [.. AnsGroup.Select(A => A.StudentEmail)],
-                                RiskLevel = (int)AnsGroup.First().AnswerRisk
-                            })]
+                        var validAnswers = AnsPerVar.Where(A => IsValidAnswer(A.AnswerText)).ToList();
+                        var totalValid = validAnswers.Count;
+
+                        return new AvgReportQuestions
+                        {
+                            Question = AnsPerVar.Key.Question,
+                            Position = AnsPerVar.Key.Position,
+                            AverageAnswer = validAnswers
+                                .GroupBy(A => A.AnswerText)
+                                .OrderByDescending(A => A.Count())
+                                .FirstOrDefault()?.Key ?? "-",
+                            AverageRisk = AnsPerVar.First().VariableAverageRisk,
+                            AnswersDetails = [.. AnsPerVar
+                                .GroupBy(A => A.AnswerText)
+                                .Select(AnsGroup => new AnswerDetails
+                                {
+                                    AnswerText = AnsGroup.Key,
+                                    AnswerPercentage = IsValidAnswer(AnsGroup.Key) && totalValid > 0
+                                        ? Math.Round(AnsGroup.Count() * 100m / totalValid, 2)
+                                        : 0,
+                                    StudentsEmails = [.. AnsGroup.Select(A => A.StudentEmail)],
+                                    RiskLevel = (int)AnsGroup.First().AnswerRisk
+                                })]
+                        };
                     })]
             })];
+
         return new AvgReportResponseVm { Components = report, PollCount = results.DistinctBy(R => R.StudentEmail).Count() };
     }
 
@@ -287,7 +295,6 @@ public class PollInstanceRepository(AppDbContext Context) : BaseRepository<PollI
             where A.PollUuid == PollUuid
             where CohortIds.Contains(A.CohortId)
             where VariableIds.Contains(A.PollVariableId)
-            //where PI.FinishedAt >= startDate && PI.FinishedAt <= endDate -- OLD conditional
             where PI.Audit.CreatedAt >= startDate && PI.FinishedAt <= endDate
             where PI.EvaluationId == EvaluationId
             select new ErasCalculationsByPollDTO

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/PollInstanceRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/PollInstanceRepositoryTest.cs
@@ -534,14 +534,16 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
                     PollUuid = "poll-Uuid", ComponentName = "Academic", Question = "How are your grades?",
                     AnswerText = "Good", StudentEmail = "student1@test.com", AnswerRisk = 10,
                     VariableAverageRisk = 10, AnswerPercentage = 50, PollInstanceId = 1,
-                    StudentName = "Student One", CohortName = "Cohort A"
+                    StudentName = "Student One", CohortName = "Cohort A",
+                    PollVersion = 1
                 },
                 new ErasCalculationsByPollEntity
                 {
                     PollUuid = "poll-Uuid", ComponentName = "Academic", Question = "How are your grades?",
                     AnswerText = "Bad", StudentEmail = "student1@test.com", AnswerRisk = 30,
                     VariableAverageRisk = 20, AnswerPercentage = 50, PollInstanceId = 1,
-                    StudentName = "Student One", CohortName = "Cohort A"
+                    StudentName = "Student One", CohortName = "Cohort A",
+                    PollVersion = 1
                 }
             }.AsQueryable().BuildMockDbSet();
 
@@ -591,14 +593,16 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
                     PollUuid = "poll-Uuid", ComponentName = "Academic", Question = "Q1",
                     AnswerText = "Ninguno", StudentEmail = "student1@test.com", AnswerRisk = 0,
                     VariableAverageRisk = 0, AnswerPercentage = 100, PollInstanceId = 1,
-                    StudentName = "Student One", CohortName = "Cohort A"
+                    StudentName = "Student One", CohortName = "Cohort A",
+                    PollVersion = 1
                 },
                 new ErasCalculationsByPollEntity
                 {
                     PollUuid = "poll-Uuid", ComponentName = "Academic", Question = "Q1",
                     AnswerText = "Good", StudentEmail = "student1@test.com", AnswerRisk = 20,
                     VariableAverageRisk = 20, AnswerPercentage = 100, PollInstanceId = 1,
-                    StudentName = "Student One", CohortName = "Cohort A"
+                    StudentName = "Student One", CohortName = "Cohort A",
+                    PollVersion = 1
                 }
             }.AsQueryable().BuildMockDbSet();
 


### PR DESCRIPTION
## Description

Summary chart percentages are now displaying correctly, and the number of imported students matches the number of students shown in the charts, particularly in the Summary Charts.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues


