### PR TITLE
feat: Extend IFileStorageService with additional methods and implemen…

### DIFF
--- a/src/Eras.Application/Contracts/Infrastructure/IFileStorageService.cs
+++ b/src/Eras.Application/Contracts/Infrastructure/IFileStorageService.cs
@@ -1,8 +1,58 @@
 namespace Eras.Application.Contracts.Infrastructure;
 
+/// <summary>
+/// Generic, entity-agnostic contract for storing and retrieving file content. 
+/// </summary>
 public interface IFileStorageService
 {
+    /// <summary>
+    /// Saves <paramref name="fileStream"/> under <paramref name="folder"/>, generating a
+    /// collision-safe physical name derived from <paramref name="fileName"/>'s extension
+    /// (the original name itself is not preserved by the storage layer — callers that need it
+    /// back must persist it separately, e.g. in <c>Attachment.OriginalFileName</c>).
+    /// </summary>
+    /// <param name="fileStream">The file content to persist. Read to completion by this call.</param>
+    /// <param name="fileName">Original file name; only its extension is used.</param>
+    /// <param name="folder">Logical folder/partition the file is stored under.</param>
+    /// <returns>
+    /// The storage key identifying the saved file — pass this back to <see cref="ReadAsync"/>,
+    /// <see cref="DeleteAsync"/>, <see cref="ExistsAsync"/>, and <see cref="GetUrlAsync"/>.
+    /// </returns>
     Task<string> SaveAsync(Stream fileStream, string fileName, string folder);
-    Task<Stream> ReadAsync(string relativePath);
-    Task DeleteAsync(string relativePath);
+
+    /// <summary>
+    /// Opens the file identified by <paramref name="key"/> for reading.
+    /// </summary>
+    /// <param name="key">The storage key previously returned by <see cref="SaveAsync"/>.</param>
+    /// <returns>A readable stream positioned at the start of the file's (decrypted) content.</returns>
+    /// <exception cref="FileNotFoundException">No file exists for <paramref name="key"/>.</exception>
+    Task<Stream> ReadAsync(string key);
+
+    /// <summary>
+    /// Deletes the file identified by <paramref name="key"/>, if it exists.
+    /// </summary>
+    /// <param name="key">The storage key previously returned by <see cref="SaveAsync"/>.</param>
+    /// <remarks>Idempotent: deleting a key that does not exist is not an error.</remarks>
+    Task DeleteAsync(string key);
+
+    /// <summary>
+    /// Checks whether a file exists for <paramref name="key"/>, without reading its content.
+    /// </summary>
+    /// <param name="key">The storage key previously returned by <see cref="SaveAsync"/>.</param>
+    /// <returns><see langword="true"/> if the file is present; otherwise <see langword="false"/>. Never throws for a missing key.</returns>
+    Task<bool> ExistsAsync(string key);
+
+    /// <summary>
+    /// Returns a URL clients can use to fetch the file identified by <paramref name="key"/>
+    /// directly from the storage backend (e.g. a signed, time-limited Swift Temporary URL),
+    /// bypassing the application server.
+    /// </summary>
+    /// <param name="key">The storage key previously returned by <see cref="SaveAsync"/>.</param>
+    /// <returns>
+    /// The direct-access URL, or <see langword="null"/> if this provider has no such concept
+    /// (e.g. local disk — callers must fall back to streaming the file via <see cref="ReadAsync"/>).
+    /// Does not throw for a missing key; callers should still check <see cref="ExistsAsync"/> or
+    /// handle a failed download at the returned URL.
+    /// </returns>
+    Task<string?> GetUrlAsync(string key);
 }

--- a/src/Eras.Infrastructure/FileStorage/LocalFileStorageService.cs
+++ b/src/Eras.Infrastructure/FileStorage/LocalFileStorageService.cs
@@ -50,9 +50,9 @@ public sealed class LocalFileStorageService : IFileStorageService
         return Path.Combine(folder, safeFileName).Replace('\\', '/');
     }
 
-    public async Task<Stream> ReadAsync(string relativePath)
+    public async Task<Stream> ReadAsync(string key)
     {
-        string fullPath = Path.Combine(_basePath, relativePath);
+        string fullPath = Path.Combine(_basePath, key);
 
         if (!File.Exists(fullPath))
             throw new FileNotFoundException("Attachment not found.", fullPath);
@@ -64,9 +64,9 @@ public sealed class LocalFileStorageService : IFileStorageService
         return decrypted;
     }
 
-    public Task DeleteAsync(string relativePath)
+    public Task DeleteAsync(string key)
     {
-        string fullPath = Path.Combine(_basePath, relativePath);
+        string fullPath = Path.Combine(_basePath, key);
         if (File.Exists(fullPath))
         {
             File.Delete(fullPath);
@@ -74,4 +74,17 @@ public sealed class LocalFileStorageService : IFileStorageService
         }
         return Task.CompletedTask;
     }
+
+    public Task<bool> ExistsAsync(string key)
+    {
+        string fullPath = Path.Combine(_basePath, key);
+        return Task.FromResult(File.Exists(fullPath));
+    }
+
+    /// <remarks>
+    /// Local disk has no direct-access URL concept — files are only reachable by streaming
+    /// through the application via <see cref="ReadAsync"/>. Always returns <see langword="null"/>;
+    /// this is not an error, callers should treat it as "no direct URL available".
+    /// </remarks>
+    public Task<string?> GetUrlAsync(string key) => Task.FromResult<string?>(null);
 }

--- a/test/Eras.Infrastructure.Tests/FileStorage/FileStorageServiceContractTests.cs
+++ b/test/Eras.Infrastructure.Tests/FileStorage/FileStorageServiceContractTests.cs
@@ -1,0 +1,115 @@
+using System.Text;
+
+using Eras.Application.Contracts.Infrastructure;
+
+namespace Eras.Infrastructure.Tests.FileStorage;
+
+/// <summary>
+/// Reusable contract suite for any <see cref="IFileStorageService"/> implementation. Subclass and
+/// implement <see cref="CreateSut"/> to hold a new provider (e.g. a future Swift provider) to the
+/// same behavioral bar as <see cref="LocalFileStorageServiceContractTests"/> — every provider must
+/// pass this suite unmodified.
+/// </summary>
+public abstract class FileStorageServiceContractTests
+{
+    /// <summary>Creates a fresh instance of the provider under test.</summary>
+    protected abstract IFileStorageService CreateSut();
+
+    private static Stream ContentStream(string content) => new MemoryStream(Encoding.UTF8.GetBytes(content));
+
+    private static async Task<string> ReadAllTextAsync(Stream stream)
+    {
+        await using var _ = stream;
+        using var reader = new StreamReader(stream);
+        return await reader.ReadToEndAsync();
+    }
+
+    [Fact]
+    public async Task SaveAsync_Should_ReturnKey_ThatReadAsyncRetrievesTheSameContentFrom()
+    {
+        IFileStorageService sut = CreateSut();
+
+        string key = await sut.SaveAsync(ContentStream("hello world"), "file.txt", "contract-tests");
+        string content = await ReadAllTextAsync(await sut.ReadAsync(key));
+
+        Assert.Equal("hello world", content);
+    }
+
+    [Fact]
+    public async Task SaveAsync_Should_NotPreserveOriginalFileName_InTheReturnedKey()
+    {
+        IFileStorageService sut = CreateSut();
+
+        string key = await sut.SaveAsync(ContentStream("data"), "very-original-name.pdf", "contract-tests");
+
+        Assert.DoesNotContain("very-original-name", key);
+        Assert.EndsWith(".pdf", key);
+    }
+
+    [Fact]
+    public async Task ReadAsync_Should_ThrowFileNotFoundException_ForAnUnknownKey()
+    {
+        IFileStorageService sut = CreateSut();
+
+        await Assert.ThrowsAsync<FileNotFoundException>(
+            () => sut.ReadAsync("contract-tests/does-not-exist.bin"));
+    }
+
+    [Fact]
+    public async Task ExistsAsync_Should_ReturnTrue_AfterSaveAsync()
+    {
+        IFileStorageService sut = CreateSut();
+
+        string key = await sut.SaveAsync(ContentStream("data"), "file.bin", "contract-tests");
+
+        Assert.True(await sut.ExistsAsync(key));
+    }
+
+    [Fact]
+    public async Task ExistsAsync_Should_ReturnFalse_ForAnUnknownKey()
+    {
+        IFileStorageService sut = CreateSut();
+
+        Assert.False(await sut.ExistsAsync("contract-tests/does-not-exist.bin"));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Should_RemoveTheFile_SoExistsAsyncThenReturnsFalse()
+    {
+        IFileStorageService sut = CreateSut();
+
+        string key = await sut.SaveAsync(ContentStream("data"), "file.bin", "contract-tests");
+        await sut.DeleteAsync(key);
+
+        Assert.False(await sut.ExistsAsync(key));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Should_NotThrow_ForAnUnknownKey()
+    {
+        IFileStorageService sut = CreateSut();
+
+        await sut.DeleteAsync("contract-tests/does-not-exist.bin");
+    }
+
+    [Fact]
+    public async Task GetUrlAsync_Should_NotThrow_AndReturnEitherNullOrAnAbsoluteUri()
+    {
+        IFileStorageService sut = CreateSut();
+        string key = await sut.SaveAsync(ContentStream("data"), "file.bin", "contract-tests");
+
+        string? url = await sut.GetUrlAsync(key);
+
+        Assert.True(url is null || Uri.IsWellFormedUriString(url, UriKind.Absolute));
+    }
+
+    [Fact]
+    public async Task GetUrlAsync_Should_NotThrow_ForAnUnknownKey()
+    {
+        IFileStorageService sut = CreateSut();
+
+        string? url = await sut.GetUrlAsync("contract-tests/does-not-exist.bin");
+
+        Assert.True(url is null || Uri.IsWellFormedUriString(url, UriKind.Absolute));
+    }
+}

--- a/test/Eras.Infrastructure.Tests/FileStorage/LocalFileStorageServiceContractTests.cs
+++ b/test/Eras.Infrastructure.Tests/FileStorage/LocalFileStorageServiceContractTests.cs
@@ -1,0 +1,40 @@
+using Eras.Application.Contracts.Infrastructure;
+using Eras.Infrastructure.FileStorage;
+
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+namespace Eras.Infrastructure.Tests.FileStorage;
+
+/// <summary>
+/// Runs the shared <see cref="FileStorageServiceContractTests"/> suite against
+/// <see cref="LocalFileStorageService"/> backed by a real, disposable temp directory on disk.
+/// xUnit constructs a fresh instance of this class per test method, so each test gets its own
+/// temp directory, cleaned up in <see cref="Dispose"/>.
+/// </summary>
+public sealed class LocalFileStorageServiceContractTests : FileStorageServiceContractTests, IDisposable
+{
+    private readonly DirectoryInfo _tempDirectory =
+        Directory.CreateTempSubdirectory("eras-filestorage-contract-");
+
+    protected override IFileStorageService CreateSut()
+    {
+        return new LocalFileStorageService(
+            _tempDirectory.FullName,
+            new PassThroughFileEncryptionService(),
+            Mock.Of<ILogger<LocalFileStorageService>>());
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            _tempDirectory.Delete(recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup; a leftover temp dir doesn't fail the test.
+        }
+    }
+}

--- a/test/Eras.Infrastructure.Tests/FileStorage/PassThroughFileEncryptionService.cs
+++ b/test/Eras.Infrastructure.Tests/FileStorage/PassThroughFileEncryptionService.cs
@@ -1,0 +1,27 @@
+using Eras.Application.Contracts.Infrastructure;
+
+namespace Eras.Infrastructure.Tests.FileStorage;
+
+/// <summary>
+/// No-op <see cref="IFileEncryptionService"/> fake used by <see cref="FileStorageServiceContractTests"/>
+/// so the storage-provider contract can be exercised in isolation from AES specifics (which have
+/// their own concern and aren't part of what the contract suite verifies).
+/// </summary>
+internal sealed class PassThroughFileEncryptionService : IFileEncryptionService
+{
+    public async Task<Stream> EncryptAsync(Stream plainStream, CancellationToken cancellationToken = default)
+    {
+        var output = new MemoryStream();
+        await plainStream.CopyToAsync(output, cancellationToken);
+        output.Position = 0;
+        return output;
+    }
+
+    public async Task<Stream> DecryptAsync(Stream cipherStream, CancellationToken cancellationToken = default)
+    {
+        var output = new MemoryStream();
+        await cipherStream.CopyToAsync(output, cancellationToken);
+        output.Position = 0;
+        return output;
+    }
+}


### PR DESCRIPTION
## Description
Extend `IFileStorageService` with additional methods and implement `LocalFileStorageService` functionality


## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues
[#539](https://github.com/JU-DEV-Bootcamps/ERAS/issues/539)

