### PR TITLE
Fix/be 473/import polls not extracting all data

### DIFF
--- a/src/Eras.Api/Controllers/CosmicLatteController.cs
+++ b/src/Eras.Api/Controllers/CosmicLatteController.cs
@@ -113,7 +113,7 @@ public class CosmicLatteController(
             // Extract respondents from Cosmic Latte in the background; the client polls
             // GET imports/{id} + /items and confirms the selection later (no payload round-trip).
             int importJobId = await _importJobService.StartExtractionAsync(
-                Request.EvaluationSetName, Request.ConfigurationId, Request.StartDate, Request.EndDate, Request.EvaluationId);
+                Request.EvaluationSetName, Request.ConfigurationId, Request.StartDate, Request.EndDate, Request.EvaluationId, Request.PollId);
             return Accepted(new { importJobId, status = "Extracting" });
         }
         catch (ArgumentException ex)

--- a/src/Eras.Application/DTOs/StartExtractionRequest.cs
+++ b/src/Eras.Application/DTOs/StartExtractionRequest.cs
@@ -7,6 +7,7 @@ namespace Eras.Application.DTOs
         public string? StartDate { get; set; }
         public string? EndDate { get; set; }
         public int EvaluationId { get; set; }
+        public string? PollId { get; set; }
     }
 
     public class ConfirmImportRequest

--- a/src/Eras.Application/Services/ICosmicLatteAPIService.cs
+++ b/src/Eras.Application/Services/ICosmicLatteAPIService.cs
@@ -15,7 +15,7 @@ namespace Eras.Application.Services
         /// invoking <paramref name="OnExtracted"/> per respondent with its PollDTO and whether the
         /// student was already imported. Enables progress reporting during the extraction phase.
         /// </summary>
-        Task ExtractRespondentsAsync(string EvaluationSetName, string StartDate, string EndDate, string ApiKey, string ApiUrl, Func<PollDTO, bool, Task> OnExtracted);
+        Task ExtractRespondentsAsync(string EvaluationSetName, string StartDate, string EndDate, string PollId, string ApiKey, string ApiUrl, Func<PollDTO, bool, Task> OnExtracted);
         Task<CreatedPollDTO> SavePreviewPolls(List<PollDTO> PollsDtos, int EvaluationId);
         Task<List<PollDataItem>> GetPollsNameList(string BaseUrl, string ApiKey);
     }

--- a/src/Eras.Application/Services/IImportJobService.cs
+++ b/src/Eras.Application/Services/IImportJobService.cs
@@ -5,7 +5,7 @@ namespace Eras.Application.Services
 {
     public interface IImportJobService
     {
-        Task<int> StartExtractionAsync(string EvaluationSetName, int ConfigurationId, string? StartDate, string? EndDate, int EvaluationId);
+        Task<int> StartExtractionAsync(string EvaluationSetName, int ConfigurationId, string? StartDate, string? EndDate, int EvaluationId, string? PollId);
         Task<bool> ConfirmImportAsync(int ImportJobId, List<int> ItemIds);
         Task<int> QueueImportAsync(List<PollDTO> Polls, int EvaluationId);
         Task<ImportJobStatusDTO?> GetStatusAsync(int ImportJobId);

--- a/src/Eras.Application/Services/ImportJobService.cs
+++ b/src/Eras.Application/Services/ImportJobService.cs
@@ -34,7 +34,7 @@ namespace Eras.Application.Services
             _evaluationRepository = EvaluationRepository;
         }
 
-        public async Task<int> StartExtractionAsync(string EvaluationSetName, int ConfigurationId, string? StartDate, string? EndDate, int EvaluationId)
+        public async Task<int> StartExtractionAsync(string EvaluationSetName, int ConfigurationId, string? StartDate, string? EndDate, int EvaluationId, string? PollId)
         {
             if (EvaluationSetName.Length > MaxPollNameLength)
             {
@@ -61,6 +61,7 @@ namespace Eras.Application.Services
                 PollsPayload = "[]",
                 CreatedAtUtc = now,
                 UpdatedAtUtc = now,
+                PollId = PollId
             };
             ImportJob created = await _importJobRepository.AddAsync(job);
             await _queue.EnqueueAsync(created.Id);

--- a/src/Eras.Domain/Entities/ImportJob.cs
+++ b/src/Eras.Domain/Entities/ImportJob.cs
@@ -44,5 +44,6 @@ namespace Eras.Domain.Entities
 
         public DateTime CreatedAtUtc { get; set; }
         public DateTime UpdatedAtUtc { get; set; }
+        public string? PollId { get; set; }
     }
 }

--- a/src/Eras.Infrastructure/BackgroundProcessing/ImportQueueBackgroundService.cs
+++ b/src/Eras.Infrastructure/BackgroundProcessing/ImportQueueBackgroundService.cs
@@ -105,6 +105,7 @@ namespace Eras.Infrastructure.BackgroundProcessing
                 job.EvaluationSetName ?? string.Empty,
                 job.StartDate ?? string.Empty,
                 job.EndDate ?? string.Empty,
+                job.PollId ?? string.Empty,
                 configuration.EncryptedKey,
                 configuration.BaseURL,
                 async (poll, alreadyImported) =>

--- a/src/Eras.Infrastructure/External/CosmicLatteClient/CosmicLatteAPIService.cs
+++ b/src/Eras.Infrastructure/External/CosmicLatteClient/CosmicLatteAPIService.cs
@@ -194,12 +194,13 @@ namespace Eras.Infrastructure.External.CosmicLatteClient
             string EvaluationSetName,
             string StartDate,
             string EndDate,
+            string PollId,
             string ApiKey,
             string ApiUrl,
             Func<PollDTO, bool, Task> OnExtracted)
         {
             var decryptedApiKey = _encryptor.Decrypt(ApiKey);
-            string path = $"{ApiUrl}{PathEvaluation}?$top=1000&$filter=name eq '{EvaluationSetName}'";
+            string path = $"{ApiUrl}{PathEvaluation}?$top=1000&$filter=name eq '{EvaluationSetName}' or parent eq 'evaluationSets:{PollId}'";
 
             var request = new HttpRequestMessage(HttpMethod.Get, path);
             request.Headers.Add(HeaderApiKey, decryptedApiKey);

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Configurations/ImportJobConfiguration.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Configurations/ImportJobConfiguration.cs
@@ -51,6 +51,8 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Configurations
             Builder.Property(Job => Job.UpdatedAtUtc)
                 .HasColumnName("updated_at_utc")
                 .IsRequired();
+            Builder.Property(Job => Job.PollId)
+                .HasColumnName("poll_id");
 
             Builder.HasIndex(Job => Job.EvaluationId)
                 .HasDatabaseName("ix_import_jobs_evaluation_id");

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Entities/ImportJobEntity.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Entities/ImportJobEntity.cs
@@ -19,5 +19,6 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Entities
         public string PollsPayload { get; set; } = string.Empty;
         public DateTime CreatedAtUtc { get; set; }
         public DateTime UpdatedAtUtc { get; set; }
+        public string? PollId { get; set; }
     }
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Mappers/ImportJobMapper.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Mappers/ImportJobMapper.cs
@@ -24,6 +24,7 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Mappers
                 PollsPayload = Entity.PollsPayload,
                 CreatedAtUtc = Entity.CreatedAtUtc,
                 UpdatedAtUtc = Entity.UpdatedAtUtc,
+                PollId = Entity.PollId
             };
         }
 
@@ -46,6 +47,7 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Mappers
                 PollsPayload = Model.PollsPayload,
                 CreatedAtUtc = Model.CreatedAtUtc,
                 UpdatedAtUtc = Model.UpdatedAtUtc,
+                PollId = Model.PollId
             };
         }
     }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260812032311_AddPollIdToImportJob.Designer.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260812032311_AddPollIdToImportJob.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Eras.Infrastructure.Persistence.PostgreSQL;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260812032311_AddPollIdToImportJob")]
+    partial class AddPollIdToImportJob
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260812032311_AddPollIdToImportJob.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Migrations/20260812032311_AddPollIdToImportJob.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Eras.Infrastructure.Persistence.PostgreSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPollIdToImportJob : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "poll_id",
+                table: "import_jobs",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "poll_id",
+                table: "import_jobs");
+        }
+    }
+}

--- a/test/Eras.Api.Tests/Controllers/CosmicLatteControllerTest.cs
+++ b/test/Eras.Api.Tests/Controllers/CosmicLatteControllerTest.cs
@@ -205,7 +205,7 @@ namespace Eras.Api.Tests.Controllers
         public async Task StartExtraction_Should_Return_OkResultAsync()
         {
             mockImportJobService
-                .Setup(x => x.StartExtractionAsync("", 1, "", "", 5))
+                .Setup(x => x.StartExtractionAsync("", 1, "", "", 5, ""))
                 .ReturnsAsync(1);
             var result = await controller.StartExtractionAsync(new StartExtractionRequest
             {
@@ -227,7 +227,8 @@ namespace Eras.Api.Tests.Controllers
                 ConfigurationId = 1,
                 StartDate = "2024-01-01",
                 EndDate = "2024-12-31",
-                EvaluationId = 5
+                EvaluationId = 5,
+                PollId = "parentPollId"
             };
             mockImportJobService
                 .Setup(x => x.StartExtractionAsync(
@@ -235,7 +236,8 @@ namespace Eras.Api.Tests.Controllers
                     It.IsAny<int>(),
                     It.IsAny<string>(),
                     It.IsAny<string>(),
-                    It.IsAny<int>()))
+                    It.IsAny<int>(),
+                    It.IsAny<string>()))
                 .ThrowsAsync(new ArgumentException("Error"));
             var result = await controller.StartExtractionAsync(request);
             var badRequest = Assert.IsType<BadRequestObjectResult>(result);

--- a/test/Eras.Application.Tests/Mappers/ImportJobMapperTest.cs
+++ b/test/Eras.Application.Tests/Mappers/ImportJobMapperTest.cs
@@ -1,0 +1,83 @@
+using Eras.Domain.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL.Mappers;
+
+namespace Eras.Application.Tests.Mappers;
+public class ImportJobMapperTest
+{
+    [Fact]
+    public void ToDomain_Should_Convert_ImportJobEntity_To_ImportJob()
+    {
+        var entity = new ImportJobEntity
+        {
+            EvaluationId = 1,
+            Status = Domain.Entities.ImportJobStatus.Queued,
+            TotalCount = 3,
+            ProcessedCount = 2,
+            ExtractedCount = 1,
+            RetryCount = 1,
+            ConfigurationId = 1,
+            StartDate = DateTime.Now.ToString(),
+            EndDate = DateTime.Now.ToString(),
+            PollsPayload = "{}",
+            CreatedAtUtc = DateTime.Now,
+            UpdatedAtUtc = DateTime.Now,
+            PollId = "p0lL1D"
+        };
+
+        ImportJob result = ImportJobMapper.ToDomain(entity);
+
+        Assert.NotNull(result);
+        Assert.Equal(entity.EvaluationId, result.EvaluationId);
+        Assert.Equal(entity.Status, result.Status);
+        Assert.Equal(entity.TotalCount, result.TotalCount);
+        Assert.Equal(entity.ProcessedCount, result.ProcessedCount);
+        Assert.Equal(entity.ExtractedCount, result.ExtractedCount);
+        Assert.Equal(entity.RetryCount, result.RetryCount);
+        Assert.Equal(entity.ConfigurationId, result.ConfigurationId);
+        Assert.Equal(entity.StartDate, result.StartDate);
+        Assert.Equal(entity.EndDate, result.EndDate);
+        Assert.Equal(entity.PollsPayload, result.PollsPayload);
+        Assert.Equal(entity.CreatedAtUtc, result.CreatedAtUtc);
+        Assert.Equal(entity.UpdatedAtUtc, result.UpdatedAtUtc);
+        Assert.Equal(entity.PollId, result.PollId);
+    }
+
+    [Fact]
+    public void ToPersistence_Should_Convert_ImportJob_To_ImportJobEntity()
+    {
+        var job = new ImportJob
+        {
+            EvaluationId = 1,
+            Status = Domain.Entities.ImportJobStatus.Queued,
+            TotalCount = 3,
+            ProcessedCount = 2,
+            ExtractedCount = 1,
+            RetryCount = 1,
+            ConfigurationId = 1,
+            StartDate = DateTime.Now.ToString(),
+            EndDate = DateTime.Now.ToString(),
+            PollsPayload = "{}",
+            CreatedAtUtc = DateTime.Now,
+            UpdatedAtUtc = DateTime.Now,
+            PollId = "p0lL1D"
+        };
+
+        ImportJobEntity result = ImportJobMapper.ToPersistence(job);
+
+        Assert.NotNull(result);
+        Assert.Equal(job.EvaluationId, result.EvaluationId);
+        Assert.Equal(job.Status, result.Status);
+        Assert.Equal(job.TotalCount, result.TotalCount);
+        Assert.Equal(job.ProcessedCount, result.ProcessedCount);
+        Assert.Equal(job.ExtractedCount, result.ExtractedCount);
+        Assert.Equal(job.RetryCount, result.RetryCount);
+        Assert.Equal(job.ConfigurationId, result.ConfigurationId);
+        Assert.Equal(job.StartDate, result.StartDate);
+        Assert.Equal(job.EndDate, result.EndDate);
+        Assert.Equal(job.PollsPayload, result.PollsPayload);
+        Assert.Equal(job.CreatedAtUtc, result.CreatedAtUtc);
+        Assert.Equal(job.UpdatedAtUtc, result.UpdatedAtUtc);
+        Assert.Equal(job.PollId, result.PollId);
+    }
+}

--- a/test/Eras.Application.Tests/Services/ImportJobServiceTests.cs
+++ b/test/Eras.Application.Tests/Services/ImportJobServiceTests.cs
@@ -37,7 +37,7 @@ public class ImportJobServiceTests
 
         // Act
         var exception = await Assert.ThrowsAsync<ArgumentException>(
-            () => _service.StartExtractionAsync(longName, 1, "2026-01-01", "2026-12-31", 1));
+            () => _service.StartExtractionAsync(longName, 1, "2026-01-01", "2026-12-31", 1, "p0Ll1D"));
 
         // Assert
         Assert.Equal("There was an error during the import: Poll Name exceeds the maximum length of 100 characters.",
@@ -54,7 +54,7 @@ public class ImportJobServiceTests
 
         // Act
         var exception = await Assert.ThrowsAsync<ArgumentException>(
-            () => _service.StartExtractionAsync("Poll", 1, "not-a-date", "2024-12-31", 1));
+            () => _service.StartExtractionAsync("Poll", 1, "not-a-date", "2024-12-31", 1, "p0Ll1D"));
 
         // Assert
         Assert.Equal("There was an error during the import: Invalid start or end date.", exception.Message);
@@ -81,6 +81,7 @@ public class ImportJobServiceTests
         var evaluationId = 1;
         var configurationId = 5;
         var pollName = "My Poll";
+        var pollId = "p0Ll1D";
 
         _mockEvaluationRepository.Setup(Repo => Repo.GetByIdAsync(evaluationId)).ReturnsAsync(evaluation);
 
@@ -95,7 +96,7 @@ public class ImportJobServiceTests
             });
 
         // Act
-        var result = await _service.StartExtractionAsync(pollName, configurationId, startDate, endDate, evaluationId);
+        var result = await _service.StartExtractionAsync(pollName, configurationId, startDate, endDate, evaluationId, pollId);
 
         // Assert
         Assert.Equal(42, result);


### PR DESCRIPTION
## Description

- Added PollId reference to extract polls process so we can filter by evaluation name and parent ID in Cosmic-Latte API call
- Updated ImportJob Entity
- Added migrations for ImportJob
- Fixed tests
- Added tests for ImportJobMapper

Must be tested along with FE PR #999 https://github.com/JU-DEV-Bootcamps/ERAS-FE/pull/999

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues

Must be tested along with FE PR #999 https://github.com/JU-DEV-Bootcamps/ERAS-FE/pull/999
