### PR TITLE
feat: Generalize local storage partitioning for intervention attachments

### DIFF
--- a/src/Eras.Application/Features/RemissionManagement/Handlers/DeleteInterventionAttachmentCommandHandler.cs
+++ b/src/Eras.Application/Features/RemissionManagement/Handlers/DeleteInterventionAttachmentCommandHandler.cs
@@ -1,5 +1,6 @@
 using Eras.Application.Contracts.Infrastructure;
 using Eras.Application.Contracts.Persistence.AssessmentManagement;
+using Eras.Application.Utils;
 using Eras.Domain.Entities.AssessmentManagement;
 
 using MediatR;
@@ -39,8 +40,7 @@ public sealed class DeleteInterventionAttachmentCommandHandler : IRequestHandler
             throw new KeyNotFoundException($"Attachment '{request.FileName}' not found in intervention '{request.InterventionId}'.");
 
         string relativePath = Path.Combine(
-            "interventions",
-            request.InterventionId.ToString(),
+            AttachmentKeyScheme.BuildFolder(InterventionConstants.AttachmentEntityType, request.InterventionId),
             request.FileName).Replace('\\', '/');
 
         await _fileStorage.DeleteAsync(relativePath);

--- a/src/Eras.Application/Features/RemissionManagement/Handlers/UploadInterventionAttachmentsCommandHandler.cs
+++ b/src/Eras.Application/Features/RemissionManagement/Handlers/UploadInterventionAttachmentsCommandHandler.cs
@@ -1,6 +1,7 @@
 using Eras.Application.Contracts.Infrastructure;
 using Eras.Application.Contracts.Persistence.AssessmentManagement;
 using Eras.Application.Models;
+using Eras.Application.Utils;
 using Eras.Domain.Entities.AssessmentManagement;
 
 using MediatR;
@@ -41,7 +42,7 @@ public sealed class UploadInterventionAttachmentsCommandHandler
                 throw new InvalidOperationException($"Extension '{ext}' is not allowed.");
         }
 
-        string folder = $"interventions/{request.InterventionId}";
+        string folder = AttachmentKeyScheme.BuildFolder(InterventionConstants.AttachmentEntityType, request.InterventionId);
 
         IReadOnlyCollection<string> existingHashes =
             await _repository.GetAttachmentHashesAsync(request.InterventionId, cancellationToken);

--- a/src/Eras.Application/Utils/AttachmentKeyScheme.cs
+++ b/src/Eras.Application/Utils/AttachmentKeyScheme.cs
@@ -1,0 +1,15 @@
+namespace Eras.Application.Utils
+{
+    /// <summary>
+    /// Single source of truth for the entity-agnostic storage folder prefix
+    /// (`{entityType}/{entityId}`) that callers of <c>IFileStorageService.SaveAsync</c>'s
+    /// `folder` argument build from. Combined with the physical file name the provider itself
+    /// generates (`{uuid}.{ext}`), this produces the full `{entityType}/{entityId}/{uuid}.{ext}`
+    /// key scheme — without every caller hand-rolling the string (previously duplicated,
+    /// independently, in the upload and delete Intervention attachment handlers).
+    /// </summary>
+    public static class AttachmentKeyScheme
+    {
+        public static string BuildFolder(string entityType, int entityId) => $"{entityType}/{entityId}";
+    }
+}

--- a/src/Eras.Domain/Entities/AssessmentManagement/InterventionConstants.cs
+++ b/src/Eras.Domain/Entities/AssessmentManagement/InterventionConstants.cs
@@ -3,4 +3,13 @@ namespace Eras.Domain.Entities.AssessmentManagement;
 public static class InterventionConstants
 {
     public const int MaxAttachments = 5;
+
+    /// <summary>
+    /// The `entityType` value Interventions use in the generic attachment storage key scheme
+    /// (`{entityType}/{entityId}/{uuid}.{ext}`, see <c>AttachmentKeyScheme</c>). Kept as the
+    /// pre-existing literal ("interventions", lowercase/plural) rather than renamed to match
+    /// <c>Attachment.EntityType</c>'s convention elsewhere, so already-uploaded files on disk
+    /// stay resolvable at their existing paths.
+    /// </summary>
+    public const string AttachmentEntityType = "interventions";
 }

--- a/test/Eras.Application.Tests/Utilities/AttachmentKeySchemeTest.cs
+++ b/test/Eras.Application.Tests/Utilities/AttachmentKeySchemeTest.cs
@@ -1,0 +1,24 @@
+using Eras.Application.Utils;
+
+namespace Eras.Application.Tests.Utilities;
+
+public class AttachmentKeySchemeTest
+{
+    [Fact]
+    public void BuildFolder_Should_CombineEntityTypeAndEntityId_WithSlashSeparator()
+    {
+        string folder = AttachmentKeyScheme.BuildFolder("interventions", 1);
+
+        Assert.Equal("interventions/1", folder);
+    }
+
+    [Theory]
+    [InlineData("Assessment", 42, "Assessment/42")]
+    [InlineData("Student", 7, "Student/7")]
+    public void BuildFolder_Should_BeEntityAgnostic(string entityType, int entityId, string expected)
+    {
+        string folder = AttachmentKeyScheme.BuildFolder(entityType, entityId);
+
+        Assert.Equal(expected, folder);
+    }
+}


### PR DESCRIPTION
## Description
Generalize local storage partitioning for intervention attachments avoiding Magic Strings

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation Improvements
- [ ] Others:

## Checklist

- [x] Have the requirements been met?
- [x] Is the code easy to read?
- [x] Do unit tests pass?
- [x] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues
[#540](https://github.com/JU-DEV-Bootcamps/ERAS/issues/540)

