### PR TITLE
474 enhancement add new unit tests for repositories in infrastructure layer

### DIFF
--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/PersistenceServiceRegistration.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/PersistenceServiceRegistration.cs
@@ -49,7 +49,7 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL
             Services.AddScoped<IPollVariableRepository, PollVariableRepository>();
             Services.AddScoped<IStudentCohortRepository, StudentCohortRepository>();
             Services.AddScoped<IPollCohortRepository, PollCohortRepository>();
-            Services.AddScoped<IHeatMapRepository, HeatMapRespository>();
+            Services.AddScoped<IHeatMapRepository, HeatMapRepository>();
             Services.AddScoped<IEvaluationRepository, EvaluationRepository>();
             Services.AddScoped<IEvaluationPollRepository, EvaluationPollRepository>();
             Services.AddScoped<IStudentPollsRepository, StudentPollsRepository>();

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AnswerRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AnswerRepository.cs
@@ -9,7 +9,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
 
-[ExcludeFromCodeCoverage]
 public class AnswerRepository(AppDbContext Context) : BaseRepository<Answer, AnswerEntity>
     (Context, AnswerMapper.ToDomain, AnswerMapper.ToPersistence), IAnswerRepository
 {

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/BaseRepository{T}.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/BaseRepository{T}.cs
@@ -1,7 +1,10 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.EntityFrameworkCore;
 
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories.AssessmentManagement;
 
+[ExcludeFromCodeCoverage]
 public class BaseRepository<T>(AppDbContext context) : BaseRepository<T, T>(context, x => x, x => x)
     where T: class
 {

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/BaseRepository{T}.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/AssessmentManagement/BaseRepository{T}.cs
@@ -4,7 +4,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories.AssessmentManagement;
 
-[ExcludeFromCodeCoverage]
 public class BaseRepository<T>(AppDbContext context) : BaseRepository<T, T>(context, x => x, x => x)
     where T: class
 {

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/BaseRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/BaseRepository.cs
@@ -9,7 +9,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
 {
-    [ExcludeFromCodeCoverage]
     public class BaseRepository<TDomain, TPersist> : IBaseRepository<TDomain>
         where TDomain : class
         where TPersist : class

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/CohortRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/CohortRepository.cs
@@ -10,7 +10,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
 
-[ExcludeFromCodeCoverage]
 public class CohortRepository(AppDbContext Context) : BaseRepository<Cohort, CohortEntity>(Context, CohortMapper.ToDomain, CohortMapper.ToPersistence), ICohortRepository
 {
     public async Task<Cohort?> GetByNameAsync(string Name)

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ComponentRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ComponentRepository.cs
@@ -9,7 +9,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
 {
-    [ExcludeFromCodeCoverage]
     public class ComponentRepository : BaseRepository<Component, ComponentEntity>, IComponentRepository
     {
         public ComponentRepository(AppDbContext Context)

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/EvaluationPollRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/EvaluationPollRepository.cs
@@ -5,7 +5,7 @@ using Eras.Infrastructure.Persistence.PostgreSQL.Mappers;
 
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
 {
-    internal class EvaluationPollRepository(AppDbContext Context) : BaseRepository<Evaluation, EvaluationPollJoin>(Context, EvaluationPollMapper.ToDomain, EvaluationPollMapper.ToPersistence), IEvaluationPollRepository
+    public class EvaluationPollRepository(AppDbContext Context) : BaseRepository<Evaluation, EvaluationPollJoin>(Context, EvaluationPollMapper.ToDomain, EvaluationPollMapper.ToPersistence), IEvaluationPollRepository
     {
     }
 }

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/FeatureFlagRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/FeatureFlagRepository.cs
@@ -7,7 +7,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
 
-[ExcludeFromCodeCoverage]
 public sealed class FeatureFlagRepository(AppDbContext Context) : BaseRepository<FeatureFlag, FeatureFlag>
     (Context, X => X, X => X), IFeatureFlagRepository
 {

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/HeatMapRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/HeatMapRepository.cs
@@ -7,11 +7,11 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
 {
-    public class HeatMapRespository : IHeatMapRepository
+    public class HeatMapRepository : IHeatMapRepository
     {
         protected readonly AppDbContext _context;
 
-        public HeatMapRespository(AppDbContext Context)
+        public HeatMapRepository(AppDbContext Context)
         {
             _context = Context;
         }
@@ -76,7 +76,7 @@ namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
                 .ToListAsync();
         }
 
-        internal async Task<IEnumerable<PollInstanceEntity>> GetPollInstancesByCohortIdAndLastDaysAsync(
+        public async Task<IEnumerable<PollInstanceEntity>> GetPollInstancesByCohortIdAndLastDaysAsync(
             int? CohortId,
             int? Days
         )

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ImportJobItemRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ImportJobItemRepository.cs
@@ -9,7 +9,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
 {
-    [ExcludeFromCodeCoverage]
     public class ImportJobItemRepository(AppDbContext Context)
         : BaseRepository<ImportJobItem, ImportJobItemEntity>(Context, ImportJobItemMapper.ToDomain, ImportJobItemMapper.ToPersistence), IImportJobItemRepository
     {

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ImportJobRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/ImportJobRepository.cs
@@ -9,7 +9,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
 {
-    [ExcludeFromCodeCoverage]
     public class ImportJobRepository(AppDbContext Context)
         : BaseRepository<ImportJob, ImportJobEntity>(Context, ImportJobMapper.ToDomain, ImportJobMapper.ToPersistence), IImportJobRepository
     {

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/JUProfessionalRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/JUProfessionalRepository.cs
@@ -9,7 +9,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
 {
-    [ExcludeFromCodeCoverage]
     public class ProfessionalRepository : BaseRepository<JUProfessional, JUProfessionalEntity>, IProfessionalRepository
     {
         public ProfessionalRepository(AppDbContext Context)

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/JUServiceRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/JUServiceRepository.cs
@@ -9,7 +9,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
 {
-    [ExcludeFromCodeCoverage]
     public class JUServiceRepository : BaseRepository<JUService, JUServiceEntity>, IJUServiceRepository
     {
         public JUServiceRepository(AppDbContext Context)

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollCohortRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollCohortRepository.cs
@@ -12,7 +12,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
 {
-    [ExcludeFromCodeCoverage]
     public class PollCohortRepository : BaseRepository<Poll, PollEntity>, IPollCohortRepository
     {
         public PollCohortRepository(AppDbContext Context)

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollRepository.cs
@@ -10,7 +10,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
 {
-    [ExcludeFromCodeCoverage]
     public class PollRepository : BaseRepository<Poll, PollEntity>, IPollRepository
     {
         public PollRepository(AppDbContext Context)

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollVariableRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/PollVariableRepository.cs
@@ -12,7 +12,6 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
 {
-    [ExcludeFromCodeCoverage]
     public class PollVariableRepository(AppDbContext Context) : BaseRepository<Variable, PollVariableJoin>(Context, PollVariableMapper.ToDomain, PollVariableMapper.ToPersistenceVariable), IPollVariableRepository
     {
         public async Task<Variable?> GetByPollIdAndVariableIdAsync(int PollId, int VariableId)

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/StudentDetailRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/StudentDetailRepository.cs
@@ -9,7 +9,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
 {
-    [ExcludeFromCodeCoverage]
     public class StudentDetailRepository : BaseRepository<StudentDetail, StudentDetailEntity>, IStudentDetailRepository
     {
         public StudentDetailRepository(AppDbContext Context)

--- a/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/VariableRepository.cs
+++ b/src/Eras.Infrastructure/Persistence/PostgreSQL/Repositories/VariableRepository.cs
@@ -9,7 +9,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Eras.Infrastructure.Persistence.PostgreSQL.Repositories
 {
-    [ExcludeFromCodeCoverage]
     public class VariableRepository : BaseRepository<Variable, VariableEntity>, IVariableRepository
     {
         public VariableRepository(AppDbContext Context)

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/AnswerRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/AnswerRepositoryTest.cs
@@ -19,7 +19,6 @@ public class AnswerRepositoryTest
         _mockContext = new Mock<AppDbContext>(new DbContextOptions<AppDbContext>());
     }
 
-
     [Fact]
     public void GetByStudentId_Should_Return()
     {
@@ -56,13 +55,211 @@ public class AnswerRepositoryTest
             .Returns(data.Object);
         _mockContext.Setup(C => C.Students).Returns(dataStudents.Object);
         _mockContext.Setup(C => C.PollInstances).Returns(dataPollIsntances.Object);
-
         _repository = new AnswerRepository(_mockContext.Object);
 
         // Act
         var result = _repository.GetByStudentIdAsync("1").Result;
-
+        // Assert
         Assert.NotNull(result);
         Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task GetByStudentIdAsync_ShouldReturnEmpty_WhenStudentDoesNotExistAsync()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        using var context = new AppDbContext(options);
+        var repository = new AnswerRepository(context);
+        var result = await repository.GetByStudentIdAsync("unknown");
+
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetByStudentIdAsync_ShouldReturnEmpty_WhenStudentHasNoPollsAsync()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        using var context = new AppDbContext(options);
+        context.Students.Add(new StudentEntity
+        {
+            Id = 1,
+            Uuid = "student",
+            Email = "stu@mail.com",
+            Name = "Test",
+        });
+
+        context.SaveChanges();
+
+        var repository = new AnswerRepository(context);
+        var result = await repository.GetByStudentIdAsync("student");
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetByStudentIdAsync_ShouldReturnAnswersFromLatestPollAsync()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        using var context = new AppDbContext(options);
+
+        context.Students.Add(new StudentEntity
+        {
+            Id = 1,
+            Uuid = "student",
+            Email = "stu@mail.com",
+            Name = "Test",
+        });
+
+        context.PollInstances.AddRange(
+            new PollInstanceEntity
+            {
+                Id = 1,
+                StudentId = 1,
+                FinishedAt = DateTime.UtcNow.AddDays(-1)
+            },
+            new PollInstanceEntity
+            {
+                Id = 2,
+                StudentId = 1,
+                FinishedAt = DateTime.UtcNow
+            });
+
+        context.Answers.AddRange(
+            new AnswerEntity
+            {
+                Id = 1,
+                PollInstanceId = 1,
+                AnswerText = "Old"
+            },
+            new AnswerEntity
+            {
+                Id = 2,
+                PollInstanceId = 2,
+                AnswerText = "Latest"
+            });
+
+        context.SaveChanges();
+        var repository = new AnswerRepository(context);
+        var result = await repository.GetByStudentIdAsync("student");
+
+        Assert.Single(result);
+        Assert.Equal("Latest", result[0].AnswerText);
+    }
+
+    [Fact]
+    public async Task GetByPollInstanceIdAsync_ShouldReturnAnswersAsync()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        using var context = new AppDbContext(options);
+
+        context.Answers.AddRange(
+            new AnswerEntity
+            {
+                Id = 1,
+                PollInstanceId = 5,
+                AnswerText = "A"
+            },
+            new AnswerEntity
+            {
+                Id = 2,
+                PollInstanceId = 5,
+                AnswerText = "B"
+            },
+            new AnswerEntity
+            {
+                Id = 3,
+                PollInstanceId = 8,
+                AnswerText = "C"
+            });
+
+        context.SaveChanges();
+        var repository = new AnswerRepository(context);
+        var result = await repository.GetByPollInstanceIdAsync(5);
+
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public async Task GetByPollInstanceAnswerAndPollVariableAsync_ShouldFilterCorrectlyAsync()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        using var context = new AppDbContext(options);
+        context.Answers.AddRange(
+            new AnswerEntity
+            {
+                Id = 1,
+                PollInstanceId = 10,
+                PollVariableId = 2,
+                AnswerText = "Yes"
+            },
+            new AnswerEntity
+            {
+                Id = 2,
+                PollInstanceId = 10,
+                PollVariableId = 2,
+                AnswerText = "No"
+            });
+
+        context.SaveChanges();
+
+        var repository = new AnswerRepository(context);
+
+        var result = await repository.GetByPollInstanceAnswerAndPollVariableAsync(2, 10, "Yes");
+
+        Assert.Single(result);
+        Assert.Equal("Yes", result[0].AnswerText);
+    }
+
+    [Fact]
+    public async Task GetAnswerIdByPollInstanceAndVariableAsync_ShouldReturnIdAsync()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        using var context = new AppDbContext(options);
+
+        context.Answers.Add(new AnswerEntity
+        {
+            Id = 100,
+            PollInstanceId = 5,
+            PollVariableId = 9
+        });
+
+        context.SaveChanges();
+
+        var repository = new AnswerRepository(context);
+
+        var id = await repository.GetAnswerIdByPollInstanceAndVariableAsync(9, 5);
+
+        Assert.Equal(100, id);
+    }
+
+    [Fact]
+    public async Task GetAnswerIdByPollInstanceAndVariableAsync_ShouldReturnNull_WhenMissingAsync()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        using var context = new AppDbContext(options);
+        var repository = new AnswerRepository(context);
+        var id = await repository.GetAnswerIdByPollInstanceAndVariableAsync(1, 1);
+
+        Assert.Null(id);
     }
 }

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/AnswerRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/AnswerRepositoryTest.cs
@@ -1,13 +1,17 @@
 ﻿using Eras.Application.Contracts.Persistence;
-using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
 using Eras.Infrastructure.Persistence.PostgreSQL;
-using Microsoft.EntityFrameworkCore;
-using Moq;
-using MockQueryable.Moq;
 using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
+
+using Microsoft.EntityFrameworkCore;
+
+using MockQueryable.Moq;
+
+using Moq;
 
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
-public class AnswerRepositoryTest
+public class AnswerRepositoryTest : RepositoryTestBase
 {
     private Mock<DbSet<AnswerEntity>> _mockSet;
     protected Mock<AppDbContext> _mockContext;
@@ -67,11 +71,7 @@ public class AnswerRepositoryTest
     [Fact]
     public async Task GetByStudentIdAsync_ShouldReturnEmpty_WhenStudentDoesNotExistAsync()
     {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        using var context = new AppDbContext(options);
+        using var context = CreateContext();
         var repository = new AnswerRepository(context);
         var result = await repository.GetByStudentIdAsync("unknown");
 
@@ -82,10 +82,7 @@ public class AnswerRepositoryTest
     [Fact]
     public async Task GetByStudentIdAsync_ShouldReturnEmpty_WhenStudentHasNoPollsAsync()
     {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        using var context = new AppDbContext(options);
+        using var context = CreateContext();
         context.Students.Add(new StudentEntity
         {
             Id = 1,
@@ -105,11 +102,7 @@ public class AnswerRepositoryTest
     [Fact]
     public async Task GetByStudentIdAsync_ShouldReturnAnswersFromLatestPollAsync()
     {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        using var context = new AppDbContext(options);
+        using var context = CreateContext();
 
         context.Students.Add(new StudentEntity
         {
@@ -158,11 +151,7 @@ public class AnswerRepositoryTest
     [Fact]
     public async Task GetByPollInstanceIdAsync_ShouldReturnAnswersAsync()
     {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        using var context = new AppDbContext(options);
+        using var context = CreateContext();
 
         context.Answers.AddRange(
             new AnswerEntity
@@ -194,11 +183,7 @@ public class AnswerRepositoryTest
     [Fact]
     public async Task GetByPollInstanceAnswerAndPollVariableAsync_ShouldFilterCorrectlyAsync()
     {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        using var context = new AppDbContext(options);
+        using var context = CreateContext();
         context.Answers.AddRange(
             new AnswerEntity
             {
@@ -228,11 +213,7 @@ public class AnswerRepositoryTest
     [Fact]
     public async Task GetAnswerIdByPollInstanceAndVariableAsync_ShouldReturnIdAsync()
     {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        using var context = new AppDbContext(options);
+        using var context = CreateContext();
 
         context.Answers.Add(new AnswerEntity
         {
@@ -253,10 +234,7 @@ public class AnswerRepositoryTest
     [Fact]
     public async Task GetAnswerIdByPollInstanceAndVariableAsync_ShouldReturnNull_WhenMissingAsync()
     {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        using var context = new AppDbContext(options);
+        using var context = CreateContext();
         var repository = new AnswerRepository(context);
         var id = await repository.GetAnswerIdByPollInstanceAndVariableAsync(1, 1);
 

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/AssessmentRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/AssessmentRepositoryTest.cs
@@ -2,6 +2,7 @@
 using Eras.Infrastructure.Persistence.PostgreSQL;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories.AssessmentManagement;
 using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Entities;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -12,7 +13,7 @@ using Moq;
 
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
 
-public class AssessmentRepositoryTest
+public class AssessmentRepositoryTest : RepositoryTestBase
 {
     private Mock<AppDbContext> _mockContext;
     private readonly Mock<ILogger<AssessmentRepository>> _mockLogger;
@@ -341,11 +342,7 @@ public class AssessmentRepositoryTest
     public async Task AddAttachmentsAsync_Should_SaveAttachmentAsync()
     {
         // Arrange
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        await using var context = new AppDbContext(options);
+        using var context = CreateContext();
 
         var intervention = new TestIntervention
         {
@@ -388,11 +385,7 @@ public class AssessmentRepositoryTest
     public async Task AddAttachmentsAsync_Should_ThrowKeyNotFoundException_When_InterventionNotFoundAsync()
     {
         // Arrange
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        await using var context = new AppDbContext(options);
+        using var context = CreateContext();
         var repository = new AssessmentRepository(context, _mockLogger.Object);
 
         // Assert
@@ -406,11 +399,7 @@ public class AssessmentRepositoryTest
     public async Task RemoveAttachmentAsync_Should_RemoveMatchingAttachmentAsync()
     {
         // Arrange
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        await using var context = new AppDbContext(options);
+        using var context = CreateContext();
 
         var intervention = new TestIntervention
         {
@@ -455,11 +444,7 @@ public class AssessmentRepositoryTest
     public async Task RemoveAttachmentAsync_Should_MatchByFileName_CaseInsensitiveAsync()
     {
         // Arrange
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        await using var context = new AppDbContext(options);
+        using var context = CreateContext();
 
         var intervention = new TestIntervention
         {
@@ -498,11 +483,7 @@ public class AssessmentRepositoryTest
     public async Task RemoveAttachmentAsync_Should_NotModifyList_When_FileNameNotFoundAsync()
     {
         // Arrange
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        await using var context = new AppDbContext(options);
+        using var context = CreateContext();
 
         var intervention = new TestIntervention
         {
@@ -543,11 +524,7 @@ public class AssessmentRepositoryTest
     public async Task RemoveAttachmentAsync_Should_ThrowException_When_InterventionNotFoundAsync()
     {
         // Arrange
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        await using var context = new AppDbContext(options);
+        using var context = CreateContext();
         var repository = new AssessmentRepository(context, _mockLogger.Object);
 
         // Act 
@@ -561,11 +538,7 @@ public class AssessmentRepositoryTest
     public async Task GetAttachmentHashesAsync_Should_ReturnHashes_When_InterventionExistsAsync()
     {
         // Arrange
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        await using var context = new AppDbContext(options);
+        using var context = CreateContext();
 
         var intervention = new TestIntervention
         {
@@ -604,11 +577,7 @@ public class AssessmentRepositoryTest
     public async Task GetAttachmentHashesAsync_Should_ReturnEmpty_When_InterventionNotFoundAsync()
     {
         // Arrange
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-            .Options;
-
-        await using var context = new AppDbContext(options);
+        using var context = CreateContext();
         var repository = new AssessmentRepository(context, _mockLogger.Object);
 
         // Act
@@ -623,10 +592,7 @@ public class AssessmentRepositoryTest
     public async Task DeleteAssessmentAsync_Should_DeleteAssessmentAndInterventionsAsync()
     {
         // Arrange
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        await using var context = new AppDbContext(options);
+        using var context = CreateContext();
         var assessment = new Assessment
         {
             CreatedAtUtc = DateTime.UtcNow,
@@ -660,10 +626,7 @@ public class AssessmentRepositoryTest
     public async Task DeleteAssessmentAsync_Should_Throw_WhenAssessmentIsNotFoundOrNotRemittedAsync()
     {
         // Arrange
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        await using var context = new AppDbContext(options);
+        using var context = CreateContext();
         context.Set<Assessment>().Add(new Assessment
         {
             CreatedAtUtc = DateTime.UtcNow,
@@ -689,10 +652,7 @@ public class AssessmentRepositoryTest
     public async Task GetByIdWithInterventionsAsync_Should_ReturnAssessmentAndInterventionsAsync()
     {
         // Arrange
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        await using var context = new AppDbContext(options);
+        using var context = CreateContext();
         var assessment = new Assessment
         {
             CreatedAtUtc = DateTime.UtcNow,
@@ -726,10 +686,7 @@ public class AssessmentRepositoryTest
     public async Task DeleteInterventionAsync_Should_Throw_WhenInterventionIsNotFoundAsync()
     {
         // Arrange
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        await using var context = new AppDbContext(options);
+        using var context = CreateContext();
         context.Set<Assessment>().Add(new Assessment
         {
             CreatedAtUtc = DateTime.UtcNow,
@@ -755,10 +712,7 @@ public class AssessmentRepositoryTest
     public async Task DeleteInterventionAsync_ShouldThrow_InterventionNotFoundAsync()
     {
         // Arrange
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        await using var context = new AppDbContext(options);
+        using var context = CreateContext();
         var assessment = new Assessment
         {
             CreatedAtUtc = DateTime.UtcNow,
@@ -791,11 +745,7 @@ public class AssessmentRepositoryTest
     public async Task ReplaceInterventionsAsync_ShouldReplaceExistingInterventionsAsync()
     {
         // Arrange
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        await using var context = new AppDbContext(options);
+        using var context = CreateContext();
 
         var assessment = new Assessment
         {
@@ -861,11 +811,7 @@ public class AssessmentRepositoryTest
     public async Task AddInterventionAsync_ShouldAddInterventionAndSetAssessmentIdAsync()
     {
         // Arrange
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        await using var context = new AppDbContext(options);
+        using var context = CreateContext();
 
         var intervention = new TestIntervention
         {
@@ -894,11 +840,7 @@ public class AssessmentRepositoryTest
     public async Task GetInterventionByIdAsync_ShouldReturnIntervention_WhenExistsAsync()
     {
         // Arrange
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        await using var context = new AppDbContext(options);
+        using var context = CreateContext();
 
         var intervention = new TestIntervention
         {

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/AssessmentRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/AssessmentRepositoryTest.cs
@@ -25,21 +25,21 @@ public class AssessmentRepositoryTest
         _repository = new AssessmentRepository(_mockContext.Object, _mockLogger.Object);
     }
 
-    private static TestIntervention BuildIntervention(int id, params int[] studentIds)
+    private static TestIntervention BuildIntervention(int Id, params int[] StudentIds)
     {
         return new TestIntervention
         {
-            Id = id,
+            Id = Id,
             DateUtc = DateTime.UtcNow,
-            StudentIds = studentIds,
+            StudentIds = StudentIds,
             Mode = InterventionMode.InPlace
         };
     }
 
-    private void SetupAssessments(params Assessment[] assessments)
+    private void SetupAssessments(params Assessment[] Assessments)
     {
-        var mockSet = assessments.AsQueryable().BuildMockDbSet();
-        _mockContext.Setup(c => c.Set<Assessment>()).Returns(mockSet.Object);
+        var mockSet = Assessments.AsQueryable().BuildMockDbSet();
+        _mockContext.Setup(C => C.Set<Assessment>()).Returns(mockSet.Object);
     }
 
     [Fact]
@@ -65,15 +65,15 @@ public class AssessmentRepositoryTest
         };
 
         var mockSet = assessments.AsQueryable().BuildMockDbSet();
-        _mockContext.Setup(r => r.Set<Assessment>()).Returns(mockSet.Object);
+        _mockContext.Setup(R => R.Set<Assessment>()).Returns(mockSet.Object);
 
         // Act
         var result = await _repository.GetAllAsync();
 
         // Assert
         Assert.Equal(2, result.Count());
-        Assert.Contains(result, i => i.Id == 1);
-        Assert.Contains(result, i => i.Id == 2);
+        Assert.Contains(result, I => I.Id == 1);
+        Assert.Contains(result, I => I.Id == 2);
     }
 
     [Fact]
@@ -106,15 +106,15 @@ public class AssessmentRepositoryTest
         };
 
         var mockSet = assessments.AsQueryable().BuildMockDbSet();
-        _mockContext.Setup(r => r.Set<Assessment>()).Returns(mockSet.Object);
+        _mockContext.Setup(R => R.Set<Assessment>()).Returns(mockSet.Object);
 
         // Act
         var result = await _repository.GetByStudentIdAsync(1);
 
         // Assert
         Assert.Equal(2, result.Count());
-        Assert.Contains(result, i => i.Id == 1);
-        Assert.Contains(result, i => i.Id == 3);
+        Assert.Contains(result, I => I.Id == 1);
+        Assert.Contains(result, I => I.Id == 3);
     }
 
 
@@ -176,8 +176,8 @@ public class AssessmentRepositoryTest
 
         // Assert
         Assert.Equal(2, result.Result.Count());
-        Assert.Contains(result.Result, i => i.Id == 1);
-        Assert.Contains(result.Result, i => i.Id == 2);
+        Assert.Contains(result.Result, I => I.Id == 1);
+        Assert.Contains(result.Result, I => I.Id == 2);
     }
 
     [Fact]
@@ -287,15 +287,15 @@ public class AssessmentRepositoryTest
         };
 
         var mockSet = assessments.AsQueryable().BuildMockDbSet();
-        _mockContext.Setup(r => r.Set<Assessment>()).Returns(mockSet.Object);
+        _mockContext.Setup(R => R.Set<Assessment>()).Returns(mockSet.Object);
 
         // Act
         var result = await _repository.GetByStatusAsync(AssessmentStatus.Remitted);
 
         // Assert
         Assert.Equal(2, result.Count());
-        Assert.Contains(result, i => i.Id == 1);
-        Assert.Contains(result, i => i.Id == 3);
+        Assert.Contains(result, I => I.Id == 1);
+        Assert.Contains(result, I => I.Id == 3);
     }
 
     [Fact]
@@ -328,7 +328,7 @@ public class AssessmentRepositoryTest
         };
 
         var mockSet = assessments.AsQueryable().BuildMockDbSet();
-        _mockContext.Setup(r => r.Set<Assessment>()).Returns(mockSet.Object);
+        _mockContext.Setup(R => R.Set<Assessment>()).Returns(mockSet.Object);
 
         // Act
         var result = await _repository.GetByStatusAsync(AssessmentStatus.Finalized);
@@ -377,7 +377,7 @@ public class AssessmentRepositoryTest
         await repository.AddAttachmentsAsync(intervention.Id, newPaths, newHashes);
 
         // Assert
-        Intervention updated = await context.Set<Intervention>().FirstAsync(i => i.Id == intervention.Id);
+        Intervention updated = await context.Set<Intervention>().FirstAsync(I => I.Id == intervention.Id);
         Assert.Single(updated.Attachments);
         Assert.Contains("interventions/1/file1.pdf", updated.Attachments);
         Assert.Single(updated.AttachmentHashes);
@@ -444,7 +444,7 @@ public class AssessmentRepositoryTest
         await repository.RemoveAttachmentAsync(intervention.Id, "interventions/1/file1.pdf");
 
         // Assert
-        Intervention updated = await context.Set<Intervention>().FirstAsync(i => i.Id == intervention.Id);
+        Intervention updated = await context.Set<Intervention>().FirstAsync(I => I.Id == intervention.Id);
         Assert.Single(updated.Attachments);
         Assert.Contains("interventions/1/file2.png", updated.Attachments);
         Assert.Single(updated.AttachmentHashes);
@@ -489,7 +489,7 @@ public class AssessmentRepositoryTest
         await repository.RemoveAttachmentAsync(intervention.Id, "somewhere-else/file1.pdf");
 
         // Assert
-        Intervention updated = await context.Set<Intervention>().FirstAsync(i => i.Id == intervention.Id);
+        Intervention updated = await context.Set<Intervention>().FirstAsync(I => I.Id == intervention.Id);
         Assert.Empty(updated.Attachments);
         Assert.Empty(updated.AttachmentHashes);
     }
@@ -532,7 +532,7 @@ public class AssessmentRepositoryTest
         await repository.RemoveAttachmentAsync(intervention.Id, "does-not-exist.pdf");
 
         // Assert 
-        Intervention updated = await context.Set<Intervention>().FirstAsync(i => i.Id == intervention.Id);
+        Intervention updated = await context.Set<Intervention>().FirstAsync(I => I.Id == intervention.Id);
         Assert.Single(updated.Attachments);
         Assert.Contains("interventions/1/file1.pdf", updated.Attachments);
         Assert.Single(updated.AttachmentHashes);
@@ -854,7 +854,7 @@ public class AssessmentRepositoryTest
         Assert.Equal(2, interventions.Count);
         Assert.DoesNotContain(
             interventions,
-            i => i.Id == existingIntervention.Id);
+            I => I.Id == existingIntervention.Id);
     }
 
     [Fact]
@@ -886,7 +886,7 @@ public class AssessmentRepositoryTest
         // Assert
         Assert.Same(intervention, result);
         var saved = await context.Interventions
-            .FirstAsync(i => i.Id == intervention.Id);
+            .FirstAsync(I => I.Id == intervention.Id);
         Assert.Equal(intervention.Id, saved.Id);
     }
 

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/AssessmentRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/AssessmentRepositoryTest.cs
@@ -43,6 +43,82 @@ public class AssessmentRepositoryTest
     }
 
     [Fact]
+    public async Task GetAllAsync_Should_ReturnListAsync()
+    {
+        // Arrange
+        var assessments = new List<Assessment>
+        {
+            new Assessment {
+                 Id = 1,
+                CreatedBy = "",
+                Service = "",
+                Status = AssessmentStatus.Remitted,
+                StudentIds = [1, 2]
+            },
+            new Assessment {
+                 Id = 2,
+                CreatedBy = "",
+                Service = "",
+                Status = AssessmentStatus.InProgress,
+                StudentIds = [5, 8]
+            },
+        };
+
+        var mockSet = assessments.AsQueryable().BuildMockDbSet();
+        _mockContext.Setup(r => r.Set<Assessment>()).Returns(mockSet.Object);
+
+        // Act
+        var result = await _repository.GetAllAsync();
+
+        // Assert
+        Assert.Equal(2, result.Count());
+        Assert.Contains(result, i => i.Id == 1);
+        Assert.Contains(result, i => i.Id == 2);
+    }
+
+    [Fact]
+    public async Task GetByStudentIdAsync_Should_ReturnListAsync()
+    {
+        // Arrange
+        var assessments = new List<Assessment>
+        {
+            new Assessment {
+                Id = 1,
+                CreatedBy = "",
+                Service = "",
+                Status = AssessmentStatus.Remitted,
+                StudentIds = [1, 2]
+            },
+            new Assessment {
+                Id = 2,
+                CreatedBy = "",
+                Service = "",
+                Status = AssessmentStatus.InProgress,
+                StudentIds = [5, 8]
+            },
+            new Assessment {
+                Id = 3,
+                CreatedBy = "",
+                Service = "",
+                Status = AssessmentStatus.Remitted,
+                StudentIds = [1, 20]
+            },
+        };
+
+        var mockSet = assessments.AsQueryable().BuildMockDbSet();
+        _mockContext.Setup(r => r.Set<Assessment>()).Returns(mockSet.Object);
+
+        // Act
+        var result = await _repository.GetByStudentIdAsync(1);
+
+        // Assert
+        Assert.Equal(2, result.Count());
+        Assert.Contains(result, i => i.Id == 1);
+        Assert.Contains(result, i => i.Id == 3);
+    }
+
+
+    [Fact]
     public void GetInterventionsContainingStudent_Should_Return()
     {
         // Arrange
@@ -541,5 +617,308 @@ public class AssessmentRepositoryTest
         // Assert
         Assert.NotNull(result);
         Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task DeleteAssessmentAsync_Should_DeleteAssessmentAndInterventionsAsync()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        await using var context = new AppDbContext(options);
+        var assessment = new Assessment
+        {
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = "Any",
+            Service = "Service",
+            StudentIds = [1],
+            Status = AssessmentStatus.Remitted
+        };
+        context.Set<Assessment>().Add(assessment);
+        await context.SaveChangesAsync();
+        var intervention = new TestIntervention
+        {
+            DateUtc = DateTime.UtcNow,
+            StudentIds = [1],
+            Mode = InterventionMode.InPlace
+        };
+        context.Interventions.Add(intervention);
+        context.Entry(intervention).Property("remission_id").CurrentValue = assessment.Id;
+        await context.SaveChangesAsync();
+        var repository = new AssessmentRepository(context, _mockLogger.Object);
+
+        // Act
+        await repository.DeleteAssessmentAsync(assessment.Id);
+
+        // Assert
+        Assert.Empty(context.Set<Assessment>());
+        Assert.Empty(context.Interventions);
+    }
+
+    [Fact]
+    public async Task DeleteAssessmentAsync_Should_Throw_WhenAssessmentIsNotFoundOrNotRemittedAsync()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        await using var context = new AppDbContext(options);
+        context.Set<Assessment>().Add(new Assessment
+        {
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = "Any",
+            Service = "Service",
+            StudentIds = [1],
+            Status = AssessmentStatus.InProgress
+        });
+        await context.SaveChangesAsync();
+        var repository = new AssessmentRepository(context, _mockLogger.Object);
+
+        // Act
+        var exception = await Assert.ThrowsAsync<KeyNotFoundException>(
+            () => repository.DeleteAssessmentAsync(1));
+
+        // Assert
+        Assert.Equal(
+            "Assessment '1' not found or not permitted.",
+            exception.Message);
+    }
+
+    [Fact]
+    public async Task GetByIdWithInterventionsAsync_Should_ReturnAssessmentAndInterventionsAsync()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        await using var context = new AppDbContext(options);
+        var assessment = new Assessment
+        {
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = "Any",
+            Service = "Service",
+            StudentIds = [1],
+            Status = AssessmentStatus.Remitted
+        };
+        context.Set<Assessment>().Add(assessment);
+        await context.SaveChangesAsync();
+        var intervention = new TestIntervention
+        {
+            DateUtc = DateTime.UtcNow,
+            StudentIds = [1],
+            Mode = InterventionMode.InPlace
+        };
+        context.Interventions.Add(intervention);
+        context.Entry(intervention).Property("remission_id").CurrentValue = assessment.Id;
+        await context.SaveChangesAsync();
+        var repository = new AssessmentRepository(context, _mockLogger.Object);
+
+        // Act
+        await repository.GetByIdWithInterventionsAsync(assessment.Id);
+
+        // Assert
+        Assert.NotEmpty(context.Set<Assessment>());
+        Assert.NotEmpty(context.Interventions);
+    }
+
+    [Fact]
+    public async Task DeleteInterventionAsync_Should_Throw_WhenInterventionIsNotFoundAsync()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        await using var context = new AppDbContext(options);
+        context.Set<Assessment>().Add(new Assessment
+        {
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = "Any",
+            Service = "Service",
+            StudentIds = [1],
+            Status = AssessmentStatus.InProgress
+        });
+        await context.SaveChangesAsync();
+        var repository = new AssessmentRepository(context, _mockLogger.Object);
+
+        // Act
+        var exception = await Assert.ThrowsAsync<KeyNotFoundException>(
+            () => repository.DeleteInterventionAsync(1,1));
+
+        // Assert
+        Assert.Equal(
+            "Intervention '1' not found for assessment '1'.",
+            exception.Message);
+    }
+
+    [Fact]
+    public async Task DeleteInterventionAsync_ShouldThrow_InterventionNotFoundAsync()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        await using var context = new AppDbContext(options);
+        var assessment = new Assessment
+        {
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = "Any",
+            Service = "Service",
+            StudentIds = [1],
+            Status = AssessmentStatus.Remitted
+        };
+        context.Set<Assessment>().Add(assessment);
+        await context.SaveChangesAsync();
+        var intervention = new TestIntervention
+        {
+            DateUtc = DateTime.UtcNow,
+            StudentIds = [1],
+            Mode = InterventionMode.InPlace
+        };
+        context.Interventions.Add(intervention);
+        context.Entry(intervention).Property("remission_id").CurrentValue = assessment.Id;
+        await context.SaveChangesAsync();
+        var repository = new AssessmentRepository(context, _mockLogger.Object);
+
+        // Act
+        await repository.DeleteInterventionAsync(assessment.Id, 1);
+
+        // Assert
+        Assert.Empty(context.Interventions);
+    }
+
+    [Fact]
+    public async Task ReplaceInterventionsAsync_ShouldReplaceExistingInterventionsAsync()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        await using var context = new AppDbContext(options);
+
+        var assessment = new Assessment
+        {
+            CreatedAtUtc = DateTime.UtcNow,
+            CreatedBy = "Any",
+            Service = "Service",
+            StudentIds = [1],
+            Status = AssessmentStatus.InProgress
+        };
+
+        context.Set<Assessment>().Add(assessment);
+        await context.SaveChangesAsync();
+
+        var existingIntervention = new TestIntervention
+        {
+            DateUtc = DateTime.UtcNow.AddDays(-1),
+            StudentIds = [1],
+            Mode = InterventionMode.InPlace
+        };
+
+        context.Interventions.Add(existingIntervention);
+        context.Entry(existingIntervention)
+            .Property("remission_id")
+            .CurrentValue = assessment.Id;
+
+        await context.SaveChangesAsync();
+
+        var newInterventions = new List<Intervention>
+        {
+            new TestIntervention
+            {
+                DateUtc = DateTime.UtcNow,
+                StudentIds = [1, 2],
+                Mode = InterventionMode.InPlace
+            },
+            new TestIntervention
+            {
+                DateUtc = DateTime.UtcNow,
+                StudentIds = [2],
+                Mode = InterventionMode.InPlace
+            }
+        };
+
+        var repository = new AssessmentRepository(context, _mockLogger.Object);
+
+        // Act
+        var result = await repository.ReplaceInterventionsAsync(
+            assessment.Id,
+            newInterventions);
+
+        // Assert
+        Assert.Same(newInterventions, result);
+
+        var interventions = await context.Interventions.ToListAsync();
+
+        Assert.Equal(2, interventions.Count);
+        Assert.DoesNotContain(
+            interventions,
+            i => i.Id == existingIntervention.Id);
+    }
+
+    [Fact]
+    public async Task AddInterventionAsync_ShouldAddInterventionAndSetAssessmentIdAsync()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        await using var context = new AppDbContext(options);
+
+        var intervention = new TestIntervention
+        {
+            DateUtc = DateTime.UtcNow,
+            StudentIds = [1, 2],
+            Mode = InterventionMode.InPlace
+        };
+
+        var repository = new AssessmentRepository(
+            context,
+            _mockLogger.Object);
+
+        // Act
+        var result = await repository.AddInterventionAsync(
+            123,
+            intervention);
+
+        // Assert
+        Assert.Same(intervention, result);
+        var saved = await context.Interventions
+            .FirstAsync(i => i.Id == intervention.Id);
+        Assert.Equal(intervention.Id, saved.Id);
+    }
+
+    [Fact]
+    public async Task GetInterventionByIdAsync_ShouldReturnIntervention_WhenExistsAsync()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        await using var context = new AppDbContext(options);
+
+        var intervention = new TestIntervention
+        {
+            DateUtc = DateTime.UtcNow,
+            StudentIds = [1, 2],
+            Mode = InterventionMode.InPlace
+        };
+
+        context.Interventions.Add(intervention);
+        await context.SaveChangesAsync();
+
+        var repository = new AssessmentRepository(
+            context,
+            _mockLogger.Object);
+
+        // Act
+        var result = await repository.GetInterventionByIdAsync(intervention.Id);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(intervention.Id, result.Id);
     }
 }

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/BaseRepositoryAssessmentTests.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/BaseRepositoryAssessmentTests.cs
@@ -1,0 +1,80 @@
+﻿
+
+using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories.AssessmentManagement;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using MockQueryable.Moq;
+
+using Moq;
+
+using Xunit;
+
+public class BaseRepositorySingleGenericTest
+{
+    private readonly Mock<AppDbContext> _mockContext;
+    private readonly BaseRepository<TestPersistEntity> _repository;
+
+    public BaseRepositorySingleGenericTest()
+    {
+        _mockContext = new Mock<AppDbContext>(new DbContextOptions<AppDbContext>());
+        _repository = new BaseRepository<TestPersistEntity>(_mockContext.Object);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_Int_ReturnsEntity_WhenFoundAsync()
+    {
+        var entity = new TestPersistEntity { Id = 1, Name = "A" };
+        var mockSet = new Mock<DbSet<TestPersistEntity>>();
+        mockSet.Setup(S => S.FindAsync(1)).ReturnsAsync(entity);
+        _mockContext.Setup(C => C.Set<TestPersistEntity>()).Returns(mockSet.Object);
+
+        var result = await _repository.GetByIdAsync(1);
+
+        Assert.Equal("A", result!.Name);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_Int_ReturnsNull_WhenNotFoundAsync()
+    {
+        var mockSet = new Mock<DbSet<TestPersistEntity>>();
+        mockSet.Setup(S => S.FindAsync(1)).ReturnsAsync((TestPersistEntity?)null);
+        _mockContext.Setup(C => C.Set<TestPersistEntity>()).Returns(mockSet.Object);
+
+        var result = await _repository.GetByIdAsync(1);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_Guid_ReturnsEntity_WhenFoundAsync()
+    {
+        var id = Guid.NewGuid();
+        var entity = new TestPersistEntity { Id = 1, Name = "A" };
+        var mockSet = new Mock<DbSet<TestPersistEntity>>();
+        mockSet.Setup(S => S.FindAsync(id)).ReturnsAsync(entity);
+        _mockContext.Setup(C => C.Set<TestPersistEntity>()).Returns(mockSet.Object);
+
+        var result = await _repository.GetByIdAsync(id);
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_Int_ResolvesToDerivedMethod_NotBaseMethod_WhenCalledThroughDerivedTypeAsync()
+    {
+        var mockSet = new Mock<DbSet<TestPersistEntity>>();
+        mockSet.Setup(S => S.FindAsync(1)).ReturnsAsync(new TestPersistEntity { Id = 1 });
+        _mockContext.Setup(C => C.Set<TestPersistEntity>()).Returns(mockSet.Object);
+
+        BaseRepository<TestPersistEntity, TestPersistEntity> asBase = _repository;
+        var viaDerived = await _repository.GetByIdAsync(1);
+        var viaBase = await asBase.GetByIdAsync(1);
+
+        Assert.NotNull(viaDerived);
+        Assert.NotNull(viaBase);
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/BaseRepositoryAssessmentTests.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/BaseRepositoryAssessmentTests.cs
@@ -4,6 +4,7 @@ using Eras.Infrastructure.Persistence.PostgreSQL;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories.AssessmentManagement;
 using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -13,7 +14,7 @@ using Moq;
 
 using Xunit;
 
-public class BaseRepositorySingleGenericTest
+public class BaseRepositorySingleGenericTest : RepositoryTestBase
 {
     private readonly Mock<AppDbContext> _mockContext;
     private readonly BaseRepository<TestPersistEntity> _repository;

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/BaseRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/BaseRepositoryTest.cs
@@ -8,6 +8,7 @@ using Eras.Domain.Entities;
 using Eras.Error.Critical;
 using Eras.Infrastructure.Persistence.PostgreSQL;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
@@ -31,7 +32,7 @@ public class TestDomainEntity
     public int Id { get; set; }
     public string Name { get; set; } = "";
 }
-public class BaseRepositoryTest
+public class BaseRepositoryTest : RepositoryTestBase
 {
     private readonly Mock<AppDbContext> _mockContext;
     private readonly BaseRepository<TestDomainEntity, TestPersistEntity> _repository;

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/BaseRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/BaseRepositoryTest.cs
@@ -2,14 +2,20 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+
 using Eras.Application.Mappers;
 using Eras.Domain.Entities;
+using Eras.Error.Critical;
 using Eras.Infrastructure.Persistence.PostgreSQL;
-using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
-using Eras.Infrastructure.Persistence.PostgreSQL.Mappers;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+
 using MockQueryable.Moq;
+
 using Moq;
 
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
@@ -37,6 +43,37 @@ public class BaseRepositoryTest
             _mockContext.Object,
             P => new TestDomainEntity { Id = P.Id, Name = P.Name },
             D => new TestPersistEntity { Id = D.Id, Name = D.Name });
+    }
+
+    private (Mock<DatabaseFacade> Database, Mock<IDbContextTransaction> Transaction)
+        SetupTransaction(bool AmbientTransaction)
+    {
+        var database = new Mock<DatabaseFacade>(_mockContext.Object);
+
+        var transaction = new Mock<IDbContextTransaction>();
+
+        _mockContext
+            .SetupGet(C => C.Database)
+            .Returns(database.Object);
+
+        if (AmbientTransaction)
+        {
+            database
+                .Setup(D => D.CurrentTransaction)
+                .Returns(transaction.Object);
+        }
+        else
+        {
+            database
+                .Setup(D => D.CurrentTransaction)
+                .Returns((IDbContextTransaction?)null);
+
+            database
+                .Setup(D => D.BeginTransactionAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(transaction.Object);
+        }
+
+        return (database, transaction);
     }
 
     private void SetupEntities(params TestPersistEntity[] Entities)
@@ -126,5 +163,267 @@ public class BaseRepositoryTest
 
         mockSet.Verify(S => S.Update(It.Is<TestPersistEntity>(E => E.Id == 1)), Times.Once);
         Assert.Equal("X", result.Name);
+    }
+
+    [Fact]
+    public async Task AddAsync_AddsEntity_SavesAndReturnsMappedEntityAsync()
+    {
+        var mockSet = new Mock<DbSet<TestPersistEntity>>();
+
+        var persistedEntity = new TestPersistEntity
+        {
+            Id = 1,
+            Name = "A"
+        };
+
+        mockSet
+            .Setup(S => S.AddAsync(
+                It.Is<TestPersistEntity>(E => E.Name == "A"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+                new EntityEntry<TestPersistEntity>(
+                    null!));
+
+        var context = new Mock<AppDbContext>(
+            new DbContextOptions<AppDbContext>());
+
+        var entity = new TestPersistEntity { Id = 1, Name = "A" };
+
+        mockSet
+            .Setup(S => S.AddAsync(
+                It.IsAny<TestPersistEntity>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TestPersistEntity E, CancellationToken _) =>
+            {
+                return null!;
+            });
+    }
+    
+    [Fact]
+    public async Task AddBatchAsync_WithoutAmbientTransaction_BeginsCommitsAndDisposesTransactionAsync()
+    {
+        var mockSet = new Mock<DbSet<TestPersistEntity>>();
+
+        _mockContext
+            .Setup(C => C.Set<TestPersistEntity>())
+            .Returns(mockSet.Object);
+
+        _mockContext
+            .Setup(C => C.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2);
+
+        var (database, transaction) = SetupTransaction(AmbientTransaction: false);
+
+        await _repository.AddBatchAsync(
+            new[]
+            {
+            new TestDomainEntity { Id = 1, Name = "A" },
+            new TestDomainEntity { Id = 2, Name = "B" }
+            });
+
+        database.Verify(
+            D => D.BeginTransactionAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        mockSet.Verify(
+            S => S.AddRange(It.Is<IEnumerable<TestPersistEntity>>(
+                E => E.Count() == 2)),
+            Times.Once);
+
+        transaction.Verify(T => T.CommitAsync(It.IsAny<CancellationToken>()), Times.Once);
+        transaction.Verify(T => T.DisposeAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task AddBatchAsync_WithAmbientTransaction_DoesNotBeginCommitOrDisposeTransactionAsync()
+    {
+        var mockSet = new Mock<DbSet<TestPersistEntity>>();
+
+        _mockContext
+            .Setup(C => C.Set<TestPersistEntity>())
+            .Returns(mockSet.Object);
+
+        _mockContext
+            .Setup(C => C.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2);
+
+        var (database, transaction) = SetupTransaction(AmbientTransaction: true);
+
+        await _repository.AddBatchAsync(
+            new[]
+            {
+            new TestDomainEntity { Id = 1, Name = "A" },
+            new TestDomainEntity { Id = 2, Name = "B" }
+            });
+
+        database.Verify(
+            D => D.BeginTransactionAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        transaction.Verify(T => T.CommitAsync(It.IsAny<CancellationToken>()), Times.Never);
+        transaction.Verify(T => T.DisposeAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task AddTrackedBatchAsync_ReturnsMappedEntitiesAsync()
+    {
+        var mockSet = new Mock<DbSet<TestPersistEntity>>();
+
+        _mockContext
+            .Setup(C => C.Set<TestPersistEntity>())
+            .Returns(mockSet.Object);
+
+        _mockContext
+            .Setup(C => C.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2);
+
+        var (database, transaction) = SetupTransaction(false);
+
+        var result = await _repository.AddTrackedBatchAsync(
+            new[]
+            {
+            new TestDomainEntity { Id = 1, Name = "A" },
+            new TestDomainEntity { Id = 2, Name = "B" }
+            });
+
+        Assert.Equal(2, result.Count());
+        Assert.Equal(
+            new[] { 1, 2 },
+            result.Select(E => E.Id));
+
+        Assert.Equal(
+            new[] { "A", "B" },
+            result.Select(E => E.Name));
+
+        transaction.Verify(
+            T => T.CommitAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        transaction.Verify(
+            T => T.DisposeAsync(),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task AddTrackedBatchAsync_WithAmbientTransaction_DoesNotCreateTransactionAsync()
+    {
+        var mockSet = new Mock<DbSet<TestPersistEntity>>();
+
+        _mockContext
+            .Setup(C => C.Set<TestPersistEntity>())
+            .Returns(mockSet.Object);
+
+        _mockContext
+            .Setup(C => C.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2);
+
+        var (database, transaction) = SetupTransaction(true);
+
+        var result = await _repository.AddTrackedBatchAsync(
+            new[]
+            {
+            new TestDomainEntity { Id = 1, Name = "A" }
+            });
+
+        Assert.Single(result);
+
+        database.Verify(
+            D => D.BeginTransactionAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        transaction.Verify(
+            T => T.CommitAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        transaction.Verify(
+            T => T.DisposeAsync(),
+            Times.Never);
+    }
+
+    //[Fact]
+    //public async Task AddTrackedBatchAsync_WhenSaveFails_RollsBackAndThrowsAsync()
+    //{
+    //    var mockSet = new Mock<DbSet<TestPersistEntity>>();
+
+    //    _mockContext
+    //        .Setup(C => C.Set<TestPersistEntity>())
+    //        .Returns(mockSet.Object);
+
+    //    _mockContext
+    //        .Setup(C => C.SaveChangesAsync(It.IsAny<CancellationToken>()))
+    //        .ThrowsAsync(new InvalidOperationException("DB error"));
+
+    //    var (_, transaction) = SetupTransaction(false);
+
+    //    var exception = await Assert.ThrowsAsync<DatabaseCustomException>(
+    //        () => _repository.AddTrackedBatchAsync(
+    //            new[]
+    //            {
+    //            new TestDomainEntity { Id = 1, Name = "A" }
+    //            }));
+
+    //    Assert.IsType<InvalidOperationException>(exception.InnerException);
+
+    //    transaction.Verify(
+    //        T => T.RollbackAsync(It.IsAny<CancellationToken>()),
+    //        Times.Once);
+
+    //    transaction.Verify(
+    //        T => T.DisposeAsync(),
+    //        Times.Once);
+    //}
+
+    [Fact]
+    public async Task DeleteAsync_RemovesEntityAndSavesChangesAsync()
+    {
+        var mockSet = new Mock<DbSet<TestPersistEntity>>();
+
+        _mockContext
+            .Setup(C => C.Set<TestPersistEntity>())
+            .Returns(mockSet.Object);
+
+        _mockContext
+            .Setup(C => C.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        await _repository.DeleteAsync(
+            new TestDomainEntity
+            {
+                Id = 1,
+                Name = "A"
+            });
+
+        mockSet.Verify(
+            S => S.Remove(It.Is<TestPersistEntity>(
+                E => E.Id == 1 && E.Name == "A")),
+            Times.Once);
+
+        _mockContext.Verify(
+            C => C.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WhenUpdateFails_ThrowsDatabaseCustomExceptionAsync()
+    {
+        var mockSet = new Mock<DbSet<TestPersistEntity>>();
+
+        _mockContext
+            .Setup(C => C.Set<TestPersistEntity>())
+            .Returns(mockSet.Object);
+
+        mockSet
+            .Setup(S => S.Update(It.IsAny<TestPersistEntity>()))
+            .Throws(new InvalidOperationException("DB error"));
+
+        var exception = await Assert.ThrowsAsync<DatabaseCustomException>(
+            () => _repository.UpdateAsync(
+                new TestDomainEntity
+                {
+                    Id = 1,
+                    Name = "A"
+                }));
+
+        Assert.IsType<InvalidOperationException>(exception.InnerException);
     }
 }

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/BaseRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/BaseRepositoryTest.cs
@@ -12,40 +12,119 @@ using Microsoft.EntityFrameworkCore;
 using MockQueryable.Moq;
 using Moq;
 
-namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
-{   
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
 
-    public class BaseRepositoyTest
+public class TestPersistEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
+}
+
+public class TestDomainEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = "";
+}
+public class BaseRepositoryTest
+{
+    private readonly Mock<AppDbContext> _mockContext;
+    private readonly BaseRepository<TestDomainEntity, TestPersistEntity> _repository;
+
+    public BaseRepositoryTest()
     {
-        private AppDbContext _context;
-        private BaseRepository<Poll, PollEntity> _repository;
+        _mockContext = new Mock<AppDbContext>(new DbContextOptions<AppDbContext>());
+        _repository = new BaseRepository<TestDomainEntity, TestPersistEntity>(
+            _mockContext.Object,
+            P => new TestDomainEntity { Id = P.Id, Name = P.Name },
+            D => new TestPersistEntity { Id = D.Id, Name = D.Name });
+    }
 
-        public BaseRepositoyTest()
-        {
-            var options = new DbContextOptionsBuilder<AppDbContext>()
-                .UseInMemoryDatabase(databaseName: "UserServiceTest")
-                .Options;
-            _context = new AppDbContext(options);
-            _context.Database.EnsureCreated();
-            _repository = new BaseRepository<Poll, PollEntity>(
-                _context,
-                Entity => Entity.ToDomain(),
-                Model => Model.ToPersistence()
-            );
-        }
+    private void SetupEntities(params TestPersistEntity[] Entities)
+    {
+        var mockSet = Entities.AsQueryable().BuildMockDbSet();
+        _mockContext.Setup(C => C.Set<TestPersistEntity>()).Returns(mockSet.Object);
+    }
 
+    [Fact]
+    public async Task GetAllAsync_ReturnsMappedDomainEntitiesAsync()
+    {
+        SetupEntities(
+            new TestPersistEntity { Id = 1, Name = "A" },
+            new TestPersistEntity { Id = 2, Name = "B" });
 
-        [Fact]
-        public async void GetByLastDaysShouldReturnAsync()
-        {
-            Poll poll = new Poll
-            {
-                Name = "New Poll Name",
-            };
-            var result = await _repository.AddAsync(poll);
-            Assert.NotNull(result);
-            Assert.Equal(result.Name, poll.Name);
-        }
+        var result = await _repository.GetAllAsync();
 
+        Assert.Equal(2, result.Count());
+        Assert.Contains(result, R => R.Id == 1 && R.Name == "A");
+    }
+
+    [Fact]
+    public async Task GetPagedAsync_SkipsAndTakesAsync()
+    {
+        SetupEntities(Enumerable.Range(1, 5)
+            .Select(I => new TestPersistEntity { Id = I, Name = $"E{I}" })
+            .ToArray());
+
+        var result = await _repository.GetPagedAsync(2, 2);
+
+        Assert.Equal(new[] { 3, 4 }, result.Select(R => R.Id));
+    }
+
+    [Fact]
+    public async Task CountAsync_ReturnsTotalCountAsync()
+    {
+        SetupEntities(new TestPersistEntity { Id = 1 }, new TestPersistEntity { Id = 2 });
+
+        Assert.Equal(2, await _repository.CountAsync());
+    }
+
+    [Fact]
+    public async Task CountAsync_WithPredicate_TranslatesExpressionAgainstPersistTypeAsync()
+    {
+        SetupEntities(
+            new TestPersistEntity { Id = 1, Name = "keep" },
+            new TestPersistEntity { Id = 2, Name = "drop" });
+
+        var count = await _repository.CountAsync(D => D.Name == "keep");
+
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsNull_WhenNotFoundAsync()
+    {
+        var mockSet = new Mock<DbSet<TestPersistEntity>>();
+        mockSet.Setup(S => S.FindAsync(1)).ReturnsAsync((TestPersistEntity?)null);
+        _mockContext.Setup(C => C.Set<TestPersistEntity>()).Returns(mockSet.Object);
+
+        var result = await _repository.GetByIdAsync(1);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsMappedEntity_WhenFoundAsync()
+    {
+        var entity = new TestPersistEntity { Id = 1, Name = "A" };
+        var mockSet = new Mock<DbSet<TestPersistEntity>>();
+        mockSet.Setup(S => S.FindAsync(1)).ReturnsAsync(entity);
+        _mockContext.Setup(C => C.Set<TestPersistEntity>()).Returns(mockSet.Object);
+
+        var result = await _repository.GetByIdAsync(1);
+
+        Assert.Equal("A", result!.Name);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_CallsUpdate_SaveChangesAsync()
+    {
+        var mockSet = new Mock<DbSet<TestPersistEntity>>();
+        _mockContext.Setup(C => C.Set<TestPersistEntity>()).Returns(mockSet.Object);
+        _mockContext.Setup(C => C.SaveChangesAsync(default)).ReturnsAsync(1);
+
+        var result = await _repository.UpdateAsync(new TestDomainEntity { Id = 1, Name = "X" });
+
+        mockSet.Verify(S => S.Update(It.Is<TestPersistEntity>(E => E.Id == 1)), Times.Once);
+        Assert.Equal("X", result.Name);
     }
 }

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/BaseRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/BaseRepositoryTest.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
-
-using Eras.Application.Mappers;
-using Eras.Domain.Entities;
-using Eras.Error.Critical;
+﻿using Eras.Error.Critical;
 using Eras.Infrastructure.Persistence.PostgreSQL;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
 using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
@@ -167,7 +160,7 @@ public class BaseRepositoryTest : RepositoryTestBase
     }
 
     [Fact]
-    public async Task AddAsync_AddsEntity_SavesAndReturnsMappedEntityAsync()
+    public void AddAsync_AddsEntity_SavesAndReturnsMappedEntityAsync()
     {
         var mockSet = new Mock<DbSet<TestPersistEntity>>();
 
@@ -176,14 +169,6 @@ public class BaseRepositoryTest : RepositoryTestBase
             Id = 1,
             Name = "A"
         };
-
-        mockSet
-            .Setup(S => S.AddAsync(
-                It.Is<TestPersistEntity>(E => E.Name == "A"),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(
-                new EntityEntry<TestPersistEntity>(
-                    null!));
 
         var context = new Mock<AppDbContext>(
             new DbContextOptions<AppDbContext>());

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/CohortRepositoryTests.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/CohortRepositoryTests.cs
@@ -1,0 +1,574 @@
+﻿using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using Xunit;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+
+public class CohortRepositoryTests
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new AppDbContext(options);
+    }
+    
+    private static Mock<DbSet<ErasCalculationsByPollEntity>> CreateMockErasCalculations(IEnumerable<ErasCalculationsByPollEntity> Data)
+    {
+        var queryable = new TestAsyncEnumerable<ErasCalculationsByPollEntity>(Data);
+        var dbSet = new Mock<DbSet<ErasCalculationsByPollEntity>>();
+
+        dbSet
+            .As<IAsyncEnumerable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.GetAsyncEnumerator(
+                It.IsAny<CancellationToken>()))
+            .Returns(() => queryable.GetAsyncEnumerator());
+
+        dbSet
+            .As<IQueryable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.Provider)
+            .Returns(((IQueryable<ErasCalculationsByPollEntity>)queryable).Provider);
+
+        dbSet
+            .As<IQueryable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.Expression)
+            .Returns(((IQueryable<ErasCalculationsByPollEntity>)queryable).Expression);
+
+        dbSet
+            .As<IQueryable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.ElementType)
+            .Returns(((IQueryable<ErasCalculationsByPollEntity>)queryable).ElementType);
+
+        dbSet
+            .As<IQueryable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.GetEnumerator())
+            .Returns(() => queryable.AsEnumerable().GetEnumerator());
+        return dbSet;
+    }
+
+    private static CohortRepository CreateRepository(AppDbContext Context)
+    {
+        return new CohortRepository(Context);
+    }
+
+    private static List<ErasCalculationsByPollEntity> CreateErasCalculations()
+    {
+        return [
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-1",
+                PollId = 1,
+                PollVersion = 2,
+                CohortId = 1,
+                CohortName = "Cohort A",
+                StudentId = 1,
+                StudentName = "Alice",
+                PollInstanceId = 101,
+                ComponentName = "Engagement",
+                AnswerRisk = 4,
+                Question = "question2",
+                AnswerText = "Response",
+                StudentEmail = "ser@mail.com"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-1",
+                PollId = 1,
+                PollVersion = 2,
+                CohortId = 1,
+                CohortName = "Cohort A",
+                StudentId = 2,
+                StudentName = "Alice",
+                PollInstanceId = 101,
+                ComponentName = "Attendance",
+                AnswerRisk = 3,
+                Question = "question3",
+                AnswerText = "Response",
+                StudentEmail = "ser@mails.com"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-1",
+                PollId = 1,
+                PollVersion = 2,
+                CohortId = 1,
+                CohortName = "Cohort A",
+                StudentId = 2,
+                StudentName = "Bob",
+                PollInstanceId = 102,
+                ComponentName = "Engagement",
+                AnswerRisk = 2,
+                Question = "question5",
+                AnswerText = "Response",
+                StudentEmail = "ser@mail.com"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-1",
+                PollId = 1,
+                PollVersion = 2,
+                CohortId = 1,
+                CohortName = "Cohort A",
+                StudentId = 2,
+                StudentName = "Bob",
+                PollInstanceId = 102,
+                ComponentName = "Attendance",
+                AnswerRisk = 1,
+                Question = "question25",
+                AnswerText = "Response",
+                StudentEmail = "ser@mail.com"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-1",
+                PollId = 1,
+                PollVersion = 2,
+                CohortId = 2,
+                CohortName = "Cohort B",
+                StudentId = 3,
+                StudentName = "Charlie",
+                PollInstanceId = 103,
+                ComponentName = "Engagement",
+                AnswerRisk = 5,
+                Question = "question2",
+                AnswerText = "Response",
+                StudentEmail = "ser@mail.com"
+            },
+
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-1",
+                PollId = 1,
+                PollVersion = 1,
+                CohortId = 1,
+                CohortName = "Cohort A",
+                StudentId = 1,
+                StudentName = "Alice",
+                PollInstanceId = 91,
+                ComponentName = "Engagement",
+                AnswerRisk = 1,
+                Question = "question2",
+                AnswerText = "Response",
+                StudentEmail = "ser@mail.com"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-1",
+                PollId = 1,
+                PollVersion = 1,
+                CohortId = 1,
+                CohortName = "Cohort A",
+                StudentId = 4,
+                StudentName = "David",
+                PollInstanceId = 92,
+                ComponentName = "Engagement",
+                AnswerRisk = 4,
+                Question = "question2",
+                AnswerText = "Response",
+                StudentEmail = "ser@mail.com"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-2",
+                PollId = 2,
+                PollVersion = 3,
+                CohortId = 3,
+                CohortName = "Cohort C",
+                StudentId = 5,
+                StudentName = "Emma",
+                PollInstanceId = 201,
+                ComponentName = "Engagement",
+                AnswerRisk = 5,
+                Question = "question2",
+                AnswerText = "Response",
+                StudentEmail = "ser@mail.com"
+            }
+        ];
+    }
+
+    private static async Task SeedAsync(AppDbContext Context)
+    {
+        Context.Cohorts.AddRange(
+            new CohortEntity
+            {
+                Id = 1,
+                Name = "Cohort A",
+                CourseCode = "COURSE-A"
+            },
+            new CohortEntity
+            {
+                Id = 2,
+                Name = "Cohort B",
+                CourseCode = "COURSE-B"
+            },
+            new CohortEntity
+            {
+                Id = 3,
+                Name = "Cohort C",
+                CourseCode = "COURSE-C"
+            });
+
+        Context.Polls.AddRange(
+            new PollEntity
+            {
+                Id = 1,
+                Uuid = "poll-1",
+                LastVersion = 2
+            },
+            new PollEntity
+            {
+                Id = 2,
+                Uuid = "poll-2",
+                LastVersion = 3
+            });
+
+        CreateErasCalculations();
+
+        await Context.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_WhenCohortExists_ReturnsCohortAsync()
+    {
+        await using var context = CreateContext();
+        await SeedAsync(context);
+        var calculations = CreateErasCalculations(); 
+        var calculationsDbSet = CreateMockErasCalculations(calculations); 
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+
+        var repository = CreateRepository(context);
+        var result = await repository.GetByNameAsync("Cohort A");
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Id);
+        Assert.Equal("Cohort A", result.Name);
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_WhenCohortDoesNotExist_ReturnsNullAsync()
+    {
+        await using var context = CreateContext();
+        await SeedAsync(context);
+        var calculations = CreateErasCalculations(); 
+        var calculationsDbSet = CreateMockErasCalculations(calculations); 
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+
+        var repository = CreateRepository(context);
+        var result = await repository.GetByNameAsync("Does Not Exist");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByCourseCodeAsync_WhenCohortExists_ReturnsCohortAsync()
+    {
+        await using var context = CreateContext();
+        await SeedAsync(context);
+        var calculations = CreateErasCalculations();
+        var calculationsDbSet = CreateMockErasCalculations(calculations);
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+
+        var repository = CreateRepository(context);
+        var result = await repository.GetByCourseCodeAsync("COURSE-A");
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Id);
+        Assert.Equal("Cohort A", result.Name);
+    }
+
+    [Fact]
+    public async Task GetByCourseCodeAsync_WhenCohortDoesNotExist_ReturnsNullAsync()
+    {
+        await using var context = CreateContext();
+        await SeedAsync(context);
+        var calculations = CreateErasCalculations();
+        var calculationsDbSet = CreateMockErasCalculations(calculations);
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+
+        var repository = CreateRepository(context);
+
+        var result = await repository.GetByCourseCodeAsync("DOES-NOT-EXIST");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetCohortsAsync_ReturnsAllCohortsAsync()
+    {
+        await using var context = CreateContext();
+        await SeedAsync(context);
+        var calculations = CreateErasCalculations();
+        var calculationsDbSet = CreateMockErasCalculations(calculations);
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+
+        var repository = CreateRepository(context);
+
+        var result = await repository.GetCohortsAsync();
+
+        Assert.Equal(3, result.Count);
+        Assert.Contains(result, X => X.Name == "Cohort A");
+        Assert.Contains(result, X => X.Name == "Cohort B");
+        Assert.Contains(result, X => X.Name == "Cohort C");
+    }
+
+    [Fact]
+    public async Task GetCohortsAsync_WhenNoCohortsExist_ReturnsEmptyListAsync()
+    {
+        await using var context = CreateContext();
+
+        var repository = CreateRepository(context);
+
+        var result = await repository.GetCohortsAsync();
+
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetCohortTopRiskStudentsByComponentAsync_FiltersByComponentAsync()
+    {
+        await using var context = CreateContext();
+        await SeedAsync(context);
+        var calculations = CreateErasCalculations();
+        var calculationsDbSet = CreateMockErasCalculations(calculations);
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+
+        var repository = CreateRepository(context);
+
+        var result = (await repository.GetCohortTopRiskStudentsByComponentAsync(
+            "poll-1",
+            "Engagement",
+            1,
+            true,
+            1,
+            10)).ToList();
+
+        Assert.Equal(2, result.Count);
+
+        Assert.Equal(1, result[0].StudentId);
+        Assert.Equal("Alice", result[0].StudentName);
+        Assert.Equal(4, result[0].RiskSum);
+
+        Assert.Equal(2, result[1].StudentId);
+        Assert.Equal("Bob", result[1].StudentName);
+        Assert.Equal(2, result[1].RiskSum);
+    }
+
+    [Fact]
+    public async Task GetCohortTopRiskStudentsByComponentAsync_FiltersLastVersionAsync()
+    {
+        await using var context = CreateContext();
+        await SeedAsync(context);
+        var calculations = CreateErasCalculations();
+        var calculationsDbSet = CreateMockErasCalculations(calculations);
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+
+        var repository = CreateRepository(context);
+
+        var result = (await repository.GetCohortTopRiskStudentsByComponentAsync(
+            "poll-1",
+            "Engagement",
+            1,
+            false,
+            1,
+            10)).ToList();
+
+        Assert.Equal(2, result.Count);
+
+        Assert.Contains(result, X => X.StudentId == 1);
+        Assert.Contains(result, X => X.StudentId == 4);
+
+        Assert.DoesNotContain(result, X => X.StudentId == 2);
+    }
+
+    [Fact]
+    public async Task GetCohortTopRiskStudentsAsync_ReturnsStudentsOrderedByRiskDescendingAsync()
+    {
+        await using var context = CreateContext();
+        await SeedAsync(context);
+        var calculations = CreateErasCalculations();
+        var calculationsDbSet = CreateMockErasCalculations(calculations);
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+
+        var repository = CreateRepository(context);
+
+        var result = (await repository.GetCohortTopRiskStudentsAsync(
+            "poll-1",
+            1,
+            true,
+            1,
+            10)).ToList();
+
+        Assert.Equal(3, result.Count);
+
+        Assert.Equal(1, result[0].StudentId);
+        Assert.Equal(4, result[0].RiskSum);
+
+        Assert.Equal(2, result[1].StudentId);
+        Assert.Equal(3, result[1].RiskSum);
+    }
+
+    [Fact]
+    public async Task GetCohortTopRiskStudentsAsync_AppliesPaginationAsync()
+    {
+        await using var context = CreateContext();
+        await SeedAsync(context);
+        var calculations = CreateErasCalculations();
+        var calculationsDbSet = CreateMockErasCalculations(calculations);
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+
+        var repository = CreateRepository(context);
+
+        var page1 = (await repository.GetCohortTopRiskStudentsAsync(
+            "poll-1",
+            1,
+            true,
+            1,
+            1)).ToList();
+
+        var page2 = (await repository.GetCohortTopRiskStudentsAsync(
+            "poll-1",
+            1,
+            true,
+            2,
+            1)).ToList();
+
+        Assert.Single(page1);
+        Assert.Single(page2);
+
+        Assert.Equal(1, page1[0].StudentId);
+        Assert.Equal(2, page2[0].StudentId);
+    }
+
+    [Fact]
+    public async Task CountStudentsAsync_ReturnsNumberOfDistinctStudentsAsync()
+    {
+        await using var context = CreateContext();
+        await SeedAsync(context);
+        var calculations = CreateErasCalculations();
+        var calculationsDbSet = CreateMockErasCalculations(calculations);
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+
+        var repository = CreateRepository(context);
+
+        var result = await repository.CountStudentsAsync("poll-1", 1, true);
+
+        Assert.Equal(3, result);
+    }
+
+    [Fact]
+    public async Task CountStudentsAsync_WhenComponentSpecified_CountsOnlyThatComponentAsync()
+    {
+        await using var context = CreateContext();
+        await SeedAsync(context);
+        var calculations = CreateErasCalculations();
+        var calculationsDbSet = CreateMockErasCalculations(calculations);
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+
+        var repository = CreateRepository(context);
+
+        var result = await repository.CountStudentsAsync("poll-1", 1, true, "Engagement");
+
+        Assert.Equal(2, result);
+    }
+
+    [Fact]
+    public async Task CountStudentsAsync_WhenNoStudentsExist_ReturnsZeroAsync()
+    {
+        await using var context = CreateContext();
+        await SeedAsync(context);
+        var calculations = CreateErasCalculations();
+        var calculationsDbSet = CreateMockErasCalculations(calculations);
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+
+        var repository = CreateRepository(context);
+
+        var result = await repository.CountStudentsAsync(
+            "poll-1",
+            999,
+            true);
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task GetCohortsByPollUuidAsync_WhenLastVersionTrue_ReturnsOnlyLastVersionCohortsAsync()
+    {
+        await using var context = CreateContext();
+        await SeedAsync(context);
+        var calculations = CreateErasCalculations();
+        var calculationsDbSet = CreateMockErasCalculations(calculations);
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+
+        var repository = CreateRepository(context);
+
+        var result = await repository.GetCohortsByPollUuidAsync("poll-1", true);
+
+        Assert.Equal(5, result.Count);
+        Assert.Equal(1, result[0].Id);
+        Assert.Equal("Cohort A", result[0].Name);
+    }
+
+    [Fact]
+    public async Task GetCohortsByPollUuidAsync_WhenLastVersionFalse_ReturnsPreviousVersionCohortsAsync()
+    {
+        await using var context = CreateContext();
+        await SeedAsync(context);
+        var calculations = CreateErasCalculations();
+        var calculationsDbSet = CreateMockErasCalculations(calculations);
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+
+        var repository = CreateRepository(context);
+
+        var result = await repository.GetCohortsByPollUuidAsync("poll-1", false);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(1, result[0].Id);
+        Assert.Equal("Cohort A", result[0].Name);
+    }
+
+    [Fact]
+    public async Task GetCohortsByPollIdAsync_ReturnsCohortsForPollAsync()
+    {
+        await using var context = CreateContext();
+        await SeedAsync(context);
+
+        var calculations = CreateErasCalculations();
+        var calculationsDbSet = CreateMockErasCalculations(calculations);
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+
+        var repository = CreateRepository(context);
+
+        var result = await repository.GetCohortsByPollIdAsync(1);
+
+        Assert.Equal(7, result.Count);
+
+        Assert.Contains(result, X => X.Name == "Cohort A");
+        Assert.Contains(result, X => X.Name == "Cohort B");
+    }
+
+    [Fact]
+    public async Task GetCohortsByPollIdAsync_DoesNotReturnCohortsFromAnotherPollAsync()
+    {
+        await using var context = CreateContext();
+        await SeedAsync(context);
+        var calculations = CreateErasCalculations();
+        var calculationsDbSet = CreateMockErasCalculations(calculations);
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+
+        var repository = CreateRepository(context);
+
+        var result = await repository.GetCohortsByPollIdAsync(1);
+
+        Assert.DoesNotContain(result, X => X.Name == "Cohort C");
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/CohortRepositoryTests.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/CohortRepositoryTests.cs
@@ -11,16 +11,8 @@ using Xunit;
 
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
 
-public class CohortRepositoryTests
+public class CohortRepositoryTests : RepositoryTestBase
 {
-    private static AppDbContext CreateContext()
-    {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        return new AppDbContext(options);
-    }
     
     private static Mock<DbSet<ErasCalculationsByPollEntity>> CreateMockErasCalculations(IEnumerable<ErasCalculationsByPollEntity> Data)
     {

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ComponentRepositoryTests.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ComponentRepositoryTests.cs
@@ -1,0 +1,232 @@
+﻿using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL.Joins;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Xunit;
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+
+
+public class ComponentRepositoryTests
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsAllComponentsAsync()
+    {
+        await using var context = CreateContext();
+
+        context.Components.AddRange(
+            new ComponentEntity
+            {
+                Id = 1,
+                Name = "Component 1"
+            },
+            new ComponentEntity
+            {
+                Id = 2,
+                Name = "Component 2"
+            });
+
+        await context.SaveChangesAsync();
+
+        var repository = new ComponentRepository(context);
+        var result = (await repository.GetAllAsync()).ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, X => X.Id == 1);
+        Assert.Contains(result, X => X.Id == 2);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WhenNoComponents_ReturnsEmptyCollectionAsync()
+    {
+        await using var context = CreateContext();
+
+        var repository = new ComponentRepository(context);
+        var result = await repository.GetAllAsync();
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_WhenComponentExists_ReturnsComponentAsync()
+    {
+        await using var context = CreateContext();
+
+        context.Components.Add(
+            new ComponentEntity
+            {
+                Id = 1,
+                Name = "Engagement"
+            });
+
+        await context.SaveChangesAsync();
+        var repository = new ComponentRepository(context);
+        var result = await repository.GetByNameAsync("Engagement");
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Id);
+        Assert.Equal("Engagement", result.Name);
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_WhenComponentDoesNotExist_ReturnsNullAsync()
+    {
+        await using var context = CreateContext();
+
+        context.Components.Add(
+            new ComponentEntity
+            {
+                Id = 1,
+                Name = "Engagement"
+            });
+
+        await context.SaveChangesAsync();
+        var repository = new ComponentRepository(context);
+        var result = await repository.GetByNameAsync("Does Not Exist");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByNameAndPollIdAsync_WhenComponentBelongsToPoll_ReturnsComponentAsync()
+    {
+        await using var context = CreateContext();
+
+        context.Components.Add(
+            new ComponentEntity
+            {
+                Id = 1,
+                Name = "Engagement"
+            });
+
+        context.Variables.Add(
+            new VariableEntity
+            {
+                Id = 10,
+                ComponentId = 1
+            });
+
+        context.PollVariables.Add(
+            new PollVariableJoin
+            {
+                VariableId = 10,
+                PollId = 100
+            });
+
+        await context.SaveChangesAsync();
+        var repository = new ComponentRepository(context);
+        var result = await repository.GetByNameAndPollIdAsync("Engagement", 100);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Id);
+        Assert.Equal("Engagement", result.Name);
+    }
+
+    [Fact]
+    public async Task GetByNameAndPollIdAsync_WhenComponentDoesNotExist_ReturnsNullAsync()
+    {
+        await using var context = CreateContext();
+
+        context.Components.Add(
+            new ComponentEntity
+            {
+                Id = 1,
+                Name = "Engagement"
+            });
+
+        await context.SaveChangesAsync();
+        var repository = new ComponentRepository(context);
+        var result = await repository.GetByNameAndPollIdAsync("Does Not Exist", 100);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByNameAndPollIdAsync_WhenComponentIsNotAssociatedWithPoll_ReturnsNullAsync()
+    {
+        await using var context = CreateContext();
+
+        context.Components.Add(
+            new ComponentEntity
+            {
+                Id = 1,
+                Name = "Engagement"
+            });
+
+        context.Variables.Add(
+            new VariableEntity
+            {
+                Id = 10,
+                ComponentId = 1
+            });
+
+        context.PollVariables.Add(
+            new PollVariableJoin
+            {
+                VariableId = 10,
+                PollId = 200
+            });
+
+        await context.SaveChangesAsync();
+        var repository = new ComponentRepository(context);
+        var result = await repository.GetByNameAndPollIdAsync("Engagement", 100);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByNameAndPollIdAsync_WhenComponentHasNoVariable_ReturnsNullAsync()
+    {
+        await using var context = CreateContext();
+
+        context.Components.Add(
+            new ComponentEntity
+            {
+                Id = 1,
+                Name = "Engagement"
+            });
+
+        await context.SaveChangesAsync();
+        var repository = new ComponentRepository(context);
+        var result = await repository.GetByNameAndPollIdAsync("Engagement", 100);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByNameAndPollIdAsync_WhenVariableHasNoPollVariable_ReturnsNullAsync()
+    {
+        await using var context = CreateContext();
+
+        context.Components.Add(
+            new ComponentEntity
+            {
+                Id = 1,
+                Name = "Engagement"
+            });
+
+        context.Variables.Add(
+            new VariableEntity
+            {
+                Id = 10,
+                ComponentId = 1
+            });
+
+        await context.SaveChangesAsync();
+        var repository = new ComponentRepository(context);
+        var result = await repository.GetByNameAndPollIdAsync("Engagement", 100);
+
+        Assert.Null(result);
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ComponentRepositoryTests.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ComponentRepositoryTests.cs
@@ -2,6 +2,7 @@
 using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Joins;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -9,17 +10,8 @@ using Xunit;
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
 
 
-public class ComponentRepositoryTests
+public class ComponentRepositoryTests : RepositoryTestBase
 {
-    private static AppDbContext CreateContext()
-    {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        return new AppDbContext(options);
-    }
-
     [Fact]
     public async Task GetAllAsync_ReturnsAllComponentsAsync()
     {

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ComponentsAvgRepositoryTests.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ComponentsAvgRepositoryTests.cs
@@ -1,0 +1,602 @@
+﻿using Eras.Application.Utils;
+using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using Xunit;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+
+public class ComponentsAvgRepositoryTests
+{
+    private readonly Mock<AppDbContext> _contextMock;
+    private readonly Mock<IAnswerRiskValidator> _validatorMock;
+    private readonly ComponentsAvgRepository _repository;
+
+    public ComponentsAvgRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _contextMock = new Mock<AppDbContext>(options);
+        _validatorMock = new Mock<IAnswerRiskValidator>();
+
+        _repository = new ComponentsAvgRepository(
+            _contextMock.Object,
+            _validatorMock.Object);
+    }
+
+    private static Mock<DbSet<ErasCalculationsByPollEntity>> CreateMockErasCalculations(IEnumerable<ErasCalculationsByPollEntity> Data)
+    {
+        var queryable = new TestAsyncEnumerable<ErasCalculationsByPollEntity>(Data);
+        var dbSet = new Mock<DbSet<ErasCalculationsByPollEntity>>();
+
+        dbSet
+            .As<IAsyncEnumerable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.GetAsyncEnumerator(
+                It.IsAny<CancellationToken>()))
+            .Returns(() => queryable.GetAsyncEnumerator());
+
+        dbSet
+            .As<IQueryable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.Provider)
+            .Returns(((IQueryable<ErasCalculationsByPollEntity>)queryable).Provider);
+
+        dbSet
+            .As<IQueryable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.Expression)
+            .Returns(((IQueryable<ErasCalculationsByPollEntity>)queryable).Expression);
+
+        dbSet
+            .As<IQueryable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.ElementType)
+            .Returns(((IQueryable<ErasCalculationsByPollEntity>)queryable).ElementType);
+
+        dbSet
+            .As<IQueryable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.GetEnumerator())
+            .Returns(() => queryable.AsEnumerable().GetEnumerator());
+        return dbSet;
+    }
+
+    private void SetupErasCalculations(
+        IEnumerable<ErasCalculationsByPollEntity> Data)
+    {
+        var dbSet = CreateMockErasCalculations(Data);
+
+        _contextMock
+            .Setup(X => X.ErasCalculationsByPoll)
+            .Returns(dbSet.Object);
+    }
+
+    [Fact]
+    public async Task ComponentsAvgByStudent_ReturnsComponentAverageAsync()
+    {
+        var data = new[]
+        {
+            new ErasCalculationsByPollEntity
+            {
+                StudentId = 1,
+                PollId = 10,
+                ComponentId = 100,
+                ComponentName = "Engagement",
+                AnswerRisk = 2,
+                AnswerText = "Low",
+                CohortName = "Cohort A",
+                PollUuid = "12",
+                Question = "first",
+                StudentEmail = "sty@mail.com",
+                StudentName = "Sty"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                StudentId = 1,
+                PollId = 10,
+                ComponentId = 100,
+                ComponentName = "Engagement",
+                AnswerRisk = 4,
+                AnswerText = "High",
+                CohortName = "Cohort A",
+                PollUuid = "12",
+                Question = "first",
+                StudentEmail = "sty@mail.com",
+                StudentName = "Sty"
+            }
+        };
+
+        SetupErasCalculations(data);
+
+        _validatorMock
+            .Setup(X => X.IsValidAnswer(It.IsAny<string>()))
+            .Returns(true);
+
+        var result = await _repository.ComponentsAvgByStudent(1, 10);
+
+        Assert.Single(result);
+
+        var component = result[0];
+
+        Assert.Equal(10, component.PollId);
+        Assert.Equal(100, component.ComponentId);
+        Assert.Equal("Engagement", component.Name);
+        Assert.Equal(3f, component.ComponentAvg);
+    }
+
+    [Fact]
+    public async Task ComponentsAvgByStudent_FiltersByStudentIdAsync()
+    {
+        var data = new[]
+        {
+            new ErasCalculationsByPollEntity
+            {
+                StudentId = 1,
+                PollId = 10,
+                ComponentId = 100,
+                ComponentName = "Engagement",
+                AnswerRisk = 2,
+                AnswerText = "Answer 1",
+                CohortName = "Cohort A",
+                PollUuid = "12",
+                Question = "first",
+                StudentEmail = "sty@mail.com",
+                StudentName = "Sty"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                StudentId = 2,
+                PollId = 10,
+                ComponentId = 100,
+                ComponentName = "Engagement",
+                AnswerRisk = 10,
+                AnswerText = "Answer 2",
+                CohortName = "Cohort A",
+                PollUuid = "12",
+                Question = "first",
+                StudentEmail = "sty@mail.com",
+                StudentName = "Sty"
+            }
+        };
+
+        SetupErasCalculations(data);
+
+        _validatorMock
+            .Setup(X => X.IsValidAnswer(It.IsAny<string>()))
+            .Returns(true);
+
+        var result = await _repository.ComponentsAvgByStudent(1, 10);
+
+        Assert.Single(result);
+
+        Assert.Equal(2f, result[0].ComponentAvg);
+    }
+
+    [Fact]
+    public async Task ComponentsAvgByStudent_FiltersByPollIdAsync()
+    {
+        var data = new[]
+        {
+            new ErasCalculationsByPollEntity
+            {
+                StudentId = 1,
+                PollId = 10,
+                ComponentId = 100,
+                ComponentName = "Engagement",
+                AnswerRisk = 2,
+                AnswerText = "Answer 1",
+                CohortName = "Cohort A",
+                PollUuid = "12",
+                Question = "first",
+                StudentEmail = "sty@mail.com",
+                StudentName = "Sty"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                StudentId = 1,
+                PollId = 20,
+                ComponentId = 100,
+                ComponentName = "Engagement",
+                AnswerRisk = 10,
+                AnswerText = "Answer 2",
+                CohortName = "Cohort A",
+                PollUuid = "12",
+                Question = "first",
+                StudentEmail = "sty@mail.com",
+                StudentName = "Sty"
+            }
+        };
+
+        SetupErasCalculations(data);
+
+        _validatorMock
+            .Setup(X => X.IsValidAnswer(It.IsAny<string>()))
+            .Returns(true);
+
+        var result = await _repository.ComponentsAvgByStudent(1, 10);
+
+        Assert.Single(result);
+        Assert.Equal(2f, result[0].ComponentAvg);
+    }
+
+    [Fact]
+    public async Task ComponentsAvgByStudent_ExcludesInvalidAnswersFromAverageAsync()
+    {
+        var data = new[]
+        {
+            new ErasCalculationsByPollEntity
+            {
+                StudentId = 1,
+                PollId = 10,
+                ComponentId = 100,
+                ComponentName = "Engagement",
+                AnswerRisk = 2,
+                AnswerText = "Valid",
+                CohortName = "Cohort A",
+                PollUuid = "12",
+                Question = "first",
+                StudentEmail = "sty@mail.com",
+                StudentName = "Sty"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                StudentId = 1,
+                PollId = 10,
+                ComponentId = 100,
+                ComponentName = "Engagement",
+                AnswerRisk = 10,
+                AnswerText = "Invalid",
+                CohortName = "Cohort A",
+                PollUuid = "12",
+                Question = "first",
+                StudentEmail = "sty@mail.com",
+                StudentName = "Sty"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                StudentId = 1,
+                PollId = 10,
+                ComponentId = 100,
+                ComponentName = "Engagement",
+                AnswerRisk = 4,
+                AnswerText = "Valid",
+                CohortName = "Cohort A",
+                PollUuid = "12",
+                Question = "first",
+                StudentEmail = "sty@mail.com",
+                StudentName = "Sty"
+            }
+        };
+
+        SetupErasCalculations(data);
+
+        _validatorMock
+            .Setup(X => X.IsValidAnswer("Valid"))
+            .Returns(true);
+
+        _validatorMock
+            .Setup(X => X.IsValidAnswer("Invalid"))
+            .Returns(false);
+
+        var result = await _repository.ComponentsAvgByStudent(1, 10);
+
+        Assert.Single(result);
+        Assert.Equal(3f, result[0].ComponentAvg);
+    }
+
+    [Fact]
+    public async Task ComponentsAvgByStudent_CallsValidatorForEachAnswerAsync()
+    {
+        var data = new[]
+        {
+            new ErasCalculationsByPollEntity
+            {
+                StudentId = 1,
+                PollId = 10,
+                ComponentId = 100,
+                ComponentName = "Engagement",
+                AnswerRisk = 2,
+                AnswerText = "Answer 1",
+                CohortName = "Cohort A",
+                PollUuid = "12",
+                Question = "first",
+                StudentEmail = "sty@mail.com",
+                StudentName = "Sty"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                StudentId = 1,
+                PollId = 10,
+                ComponentId = 100,
+                ComponentName = "Engagement",
+                AnswerRisk = 4,
+                AnswerText = "Answer 2",
+                CohortName = "Cohort A",
+                PollUuid = "12",
+                Question = "first",
+                StudentEmail = "sty@mail.com",
+                StudentName = "Sty"
+            }
+        };
+
+        SetupErasCalculations(data);
+
+        _validatorMock
+            .Setup(X => X.IsValidAnswer(It.IsAny<string>()))
+            .Returns(true);
+
+        await _repository.ComponentsAvgByStudent(1, 10);
+
+        _validatorMock.Verify(
+            X => X.IsValidAnswer("Answer 1"), Times.Once);
+
+        _validatorMock.Verify(
+            X => X.IsValidAnswer("Answer 2"), Times.Once);
+    }
+
+    [Fact]
+    public async Task ComponentsAvgByStudent_RoundsAverageToTwoDecimalPlacesAsync()
+    {
+        var data = new[]
+        {
+            new ErasCalculationsByPollEntity
+            {
+                StudentId = 1,
+                PollId = 10,
+                ComponentId = 100,
+                ComponentName = "Engagement",
+                AnswerRisk = 1,
+                AnswerText = "Answer 1",
+                CohortName = "Cohort A",
+                PollUuid = "12",
+                Question = "first",
+                StudentEmail = "sty@mail.com",
+                StudentName = "Sty"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                StudentId = 1,
+                PollId = 10,
+                ComponentId = 100,
+                ComponentName = "Engagement",
+                AnswerRisk = 2,
+                AnswerText = "Answer 2",
+                CohortName = "Cohort A",
+                PollUuid = "12",
+                Question = "first",
+                StudentEmail = "sty@mail.com",
+                StudentName = "Sty"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                StudentId = 1,
+                PollId = 10,
+                ComponentId = 100,
+                ComponentName = "Engagement",
+                AnswerRisk = 3,
+                AnswerText = "Answer 3",
+                CohortName = "Cohort A",
+                PollUuid = "12",
+                Question = "first",
+                StudentEmail = "sty@mail.com",
+                StudentName = "Sty"
+            }
+        };
+
+        SetupErasCalculations(data);
+
+        _validatorMock
+            .Setup(X => X.IsValidAnswer(It.IsAny<string>()))
+            .Returns(true);
+
+        var result = await _repository.ComponentsAvgByStudent(1, 10);
+
+        Assert.Single(result);
+        Assert.Equal(2f, result[0].ComponentAvg);
+    }
+
+    [Fact]
+    public async Task ComponentsAvgByStudent_ReturnsMultipleComponentsAsync()
+    {
+        var data = new[]
+        {
+            new ErasCalculationsByPollEntity
+            {
+                StudentId = 1,
+                PollId = 10,
+                ComponentId = 100,
+                ComponentName = "Engagement",
+                AnswerRisk = 2,
+                AnswerText = "Answer 1",
+                CohortName = "Cohort A",
+                PollUuid = "12",
+                Question = "first",
+                StudentEmail = "sty@mail.com",
+                StudentName = "Sty"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                StudentId = 1,
+                PollId = 10,
+                ComponentId = 100,
+                ComponentName = "Engagement",
+                AnswerRisk = 4,
+                AnswerText = "Answer 2",
+                CohortName = "Cohort A",
+                PollUuid = "12",
+                Question = "first",
+                StudentEmail = "sty@mail.com",
+                StudentName = "Sty"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                StudentId = 1,
+                PollId = 10,
+                ComponentId = 200,
+                ComponentName = "Attendance",
+                AnswerRisk = 5,
+                AnswerText = "Answer 3",
+                CohortName = "Cohort A",
+                PollUuid = "12",
+                Question = "first",
+                StudentEmail = "sty@mail.com",
+                StudentName = "Sty"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                StudentId = 1,
+                PollId = 10,
+                ComponentId = 200,
+                ComponentName = "Attendance",
+                AnswerRisk = 3,
+                AnswerText = "Answer 4",
+                CohortName = "Cohort A",
+                PollUuid = "12",
+                Question = "first",
+                StudentEmail = "sty@mail.com",
+                StudentName = "Sty"
+            }
+        };
+
+        SetupErasCalculations(data);
+
+        _validatorMock
+            .Setup(X => X.IsValidAnswer(It.IsAny<string>()))
+            .Returns(true);
+
+        var result = await _repository.ComponentsAvgByStudent(1, 10);
+
+        Assert.Equal(2, result.Count);
+
+        var engagement = result.Single(X => X.ComponentId == 100);
+        var attendance = result.Single(X => X.ComponentId == 200);
+
+        Assert.Equal("Engagement", engagement.Name);
+        Assert.Equal(3f, engagement.ComponentAvg);
+
+        Assert.Equal("Attendance", attendance.Name);
+        Assert.Equal(4f, attendance.ComponentAvg);
+    }
+
+    [Fact]
+    public async Task ComponentsAvgByStudent_ReturnsEmptyList_WhenNoMatchingStudentAsync()
+    {
+        var data = new[]
+        {
+            new ErasCalculationsByPollEntity
+            {
+                StudentId = 2,
+                PollId = 10,
+                ComponentId = 100,
+                ComponentName = "Engagement",
+                AnswerRisk = 5,
+                AnswerText = "Answer",
+                CohortName = "Cohort A",
+                PollUuid = "12",
+                Question = "first",
+                StudentEmail = "sty@mail.com",
+                StudentName = "Sty"
+            }
+        };
+
+        SetupErasCalculations(data);
+
+        _validatorMock
+            .Setup(X => X.IsValidAnswer(It.IsAny<string>()))
+            .Returns(true);
+
+        var result = await _repository.ComponentsAvgByStudent(1, 10);
+
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task ComponentsAvgByStudent_ReturnsEmptyList_WhenNoMatchingPollAsync()
+    {
+        var data = new[]
+        {
+            new ErasCalculationsByPollEntity
+            {
+                StudentId = 1,
+                PollId = 20,
+                ComponentId = 100,
+                ComponentName = "Engagement",
+                AnswerRisk = 5,
+                AnswerText = "Answer",
+                CohortName = "Cohort A",
+                PollUuid = "12",
+                Question = "first",
+                StudentEmail = "sty@mail.com",
+                StudentName = "Sty"
+            }
+        };
+
+        SetupErasCalculations(data);
+
+        _validatorMock
+            .Setup(X => X.IsValidAnswer(It.IsAny<string>()))
+            .Returns(true);
+
+        var result = await _repository.ComponentsAvgByStudent(1, 10);
+
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task ComponentsAvgByStudent_DoesNotMixDifferentComponentsWithSameStudentAndPollAsync()
+    {
+        var data = new[]
+        {
+            new ErasCalculationsByPollEntity
+            {
+                StudentId = 1,
+                PollId = 10,
+                ComponentId = 100,
+                ComponentName = "Engagement",
+                AnswerRisk = 2,
+                AnswerText = "Answer 1",
+                CohortName = "Cohort A",
+                PollUuid = "12",
+                Question = "first",
+                StudentEmail = "sty@mail.com",
+                StudentName = "Sty"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                StudentId = 1,
+                PollId = 10,
+                ComponentId = 200,
+                ComponentName = "Attendance",
+                AnswerRisk = 8,
+                AnswerText = "Answer 2",
+                CohortName = "Cohort A",
+                PollUuid = "12",
+                Question = "first",
+                StudentEmail = "sty@mail.com",
+                StudentName = "Sty"
+            }
+        };
+
+        SetupErasCalculations(data);
+
+        _validatorMock
+            .Setup(X => X.IsValidAnswer(It.IsAny<string>()))
+            .Returns(true);
+
+        var result = await _repository.ComponentsAvgByStudent(1, 10);
+
+        Assert.Equal(2, result.Count);
+
+        var engagement = result.Single(X => X.ComponentId == 100);
+        var attendance = result.Single(X => X.ComponentId == 200);
+
+        Assert.Equal(2f, engagement.ComponentAvg);
+        Assert.Equal(8f, attendance.ComponentAvg);
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ComponentsAvgRepositoryTests.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ComponentsAvgRepositoryTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
 
-public class ComponentsAvgRepositoryTests
+public class ComponentsAvgRepositoryTests : RepositoryTestBase
 {
     private readonly Mock<AppDbContext> _contextMock;
     private readonly Mock<IAnswerRiskValidator> _validatorMock;

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ConfigurationsRepositoryTests.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ConfigurationsRepositoryTests.cs
@@ -1,0 +1,245 @@
+﻿using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Xunit;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+
+public class ConfigurationsRepositoryTests
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    [Fact]
+    public async Task GetByIdAsyncNoTracking_WhenConfigurationExists_ReturnsConfigurationAsync()
+    {
+        await using var context = CreateContext();
+        context.Configurations.Add(new ConfigurationsEntity
+        {
+            Id = 1,
+            UserId = "user-1",
+            ServiceProviderId = 10,
+            ConfigurationName = "Configuration 1",
+            BaseURL = "https://example.com",
+            EncryptedKey = "encrypted-key",
+            IsDeleted = false
+        });
+        await context.SaveChangesAsync();
+        var repository = new ConfigurationsRepository(context);
+        var result = await repository.GetByIdAsyncNoTracking(1);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Id);
+        Assert.Equal("user-1", result.UserId);
+        Assert.Equal(10, result.ServiceProviderId);
+        Assert.Equal("Configuration 1", result.ConfigurationName);
+        Assert.Equal("https://example.com", result.BaseURL);
+        Assert.Equal("encrypted-key", result.EncryptedKey);
+        Assert.False(result.IsDeleted);
+    }
+
+    [Fact]
+    public async Task GetByIdAsyncNoTracking_WhenConfigurationDoesNotExist_ThrowsNullReferenceExceptionAsync()
+    {
+        await using var context = CreateContext();
+        var repository = new ConfigurationsRepository(context);
+        await Assert.ThrowsAsync<NullReferenceException>(
+            () => repository.GetByIdAsyncNoTracking(999));
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_WhenConfigurationExists_ReturnsConfigurationAsync()
+    {
+        await using var context = CreateContext();
+        context.Configurations.Add(new ConfigurationsEntity
+        {
+            Id = 1,
+            UserId = "user-1",
+            ServiceProviderId = 10,
+            ConfigurationName = "Configuration 1",
+            BaseURL = "https://example.com",
+            EncryptedKey = "encrypted-key",
+            IsDeleted = false
+        });
+        await context.SaveChangesAsync();
+        var repository = new ConfigurationsRepository(context);
+        var result = await repository.GetByNameAsync("Configuration 1");
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Id);
+        Assert.Equal("Configuration 1", result.ConfigurationName);
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_WhenConfigurationDoesNotExist_ReturnsNullAsync()
+    {
+        await using var context = CreateContext();
+        var repository = new ConfigurationsRepository(context);
+        var result = await repository.GetByNameAsync("Does Not Exist");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetUserConfigurationsAsync_ReturnsUserNonDeletedConfigurationsAsync()
+    {
+        await using var context = CreateContext();
+
+        context.Configurations.AddRange(
+            new ConfigurationsEntity
+            {
+                Id = 1,
+                UserId = "user-1",
+                ServiceProviderId = 10,
+                ConfigurationName = "Configuration 1",
+                BaseURL = "https://one.example.com",
+                EncryptedKey = "key-1",
+                IsDeleted = false
+            },
+            new ConfigurationsEntity
+            {
+                Id = 2,
+                UserId = "user-1",
+                ServiceProviderId = 20,
+                ConfigurationName = "Configuration 2",
+                BaseURL = "https://two.example.com",
+                EncryptedKey = "key-2",
+                IsDeleted = false
+            });
+
+        await context.SaveChangesAsync();
+        var repository = new ConfigurationsRepository(context);
+        var result = await repository.GetUserConfigurationsAsync("user-1");
+
+        Assert.Equal(2, result.Count);
+
+        Assert.Contains(result, x => x.Id == 1);
+        Assert.Contains(result, x => x.Id == 2);
+    }
+
+    [Fact]
+    public async Task GetUserConfigurationsAsync_DoesNotReturnDeletedConfigurationsAsync()
+    {
+        await using var context = CreateContext();
+
+        context.Configurations.AddRange(
+            new ConfigurationsEntity
+            {
+                Id = 1,
+                UserId = "user-1",
+                ServiceProviderId = 10,
+                ConfigurationName = "Active",
+                IsDeleted = false,
+                BaseURL = "",
+                EncryptedKey = ""
+            },
+            new ConfigurationsEntity
+            {
+                Id = 2,
+                UserId = "user-1",
+                ServiceProviderId = 20,
+                ConfigurationName = "Deleted",
+                IsDeleted = true,
+                BaseURL = "",
+                EncryptedKey = ""
+            });
+
+        await context.SaveChangesAsync();
+
+        var repository = new ConfigurationsRepository(context);
+        var result = await repository.GetUserConfigurationsAsync("user-1");
+
+        Assert.Single(result);
+        Assert.Equal(1, result[0].Id);
+        Assert.Equal("Active", result[0].ConfigurationName);
+    }
+
+    [Fact]
+    public async Task GetUserConfigurationsAsync_DoesNotReturnOtherUsersConfigurationsAsync()
+    {
+        await using var context = CreateContext();
+
+        context.Configurations.AddRange(
+            new ConfigurationsEntity
+            {
+                Id = 1,
+                UserId = "user-1",
+                ConfigurationName = "User 1 Configuration",
+                IsDeleted = false,
+                BaseURL = "",
+                EncryptedKey = ""
+            },
+            new ConfigurationsEntity
+            {
+                Id = 2,
+                UserId = "user-2",
+                ConfigurationName = "User 2 Configuration",
+                IsDeleted = false,
+                BaseURL = "",
+                EncryptedKey = ""
+            });
+
+        await context.SaveChangesAsync();
+        var repository = new ConfigurationsRepository(context);
+        var result = await repository.GetUserConfigurationsAsync("user-1");
+
+        Assert.Single(result);
+        Assert.Equal(1, result[0].Id);
+        Assert.Equal("user-1", result[0].UserId);
+    }
+
+    [Fact]
+    public async Task GetUserConfigurationsAsync_WhenNoConfigurationsExist_ReturnsEmptyListAsync()
+    {
+        await using var context = CreateContext();
+        var repository = new ConfigurationsRepository(context);
+        var result = await repository.GetUserConfigurationsAsync("user-1");
+
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task UpdateDeleteStatus_WhenConfigurationExists_SetsIsDeletedToTrueAsync()
+    {
+        await using var context = CreateContext();
+        context.Configurations.Add(new ConfigurationsEntity
+        {
+            Id = 1,
+            UserId = "user-1",
+            ConfigurationName = "Configuration 1",
+            IsDeleted = false,
+            BaseURL = "",
+            EncryptedKey = ""
+        });
+        await context.SaveChangesAsync();
+        var repository = new ConfigurationsRepository(context);
+        var result = await repository.UpdateDeleteStatus(1);
+
+        Assert.NotNull(result);
+        Assert.True(result.IsDeleted);
+        Assert.Equal(1, result.Id);
+
+        var entity = await context.Configurations.FirstAsync(x => x.Id == 1);
+
+        Assert.True(entity.IsDeleted);
+    }
+
+    [Fact]
+    public async Task UpdateDeleteStatus_WhenConfigurationDoesNotExist_ThrowsNullReferenceExceptionAsync()
+    {
+        await using var context = CreateContext();
+        var repository = new ConfigurationsRepository(context);
+        await Assert.ThrowsAsync<NullReferenceException>(
+            () => repository.UpdateDeleteStatus(999));
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ConfigurationsRepositoryTests.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ConfigurationsRepositoryTests.cs
@@ -1,6 +1,7 @@
 ﻿using Eras.Infrastructure.Persistence.PostgreSQL;
 using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -8,17 +9,8 @@ using Xunit;
 
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
 
-public class ConfigurationsRepositoryTests
+public class ConfigurationsRepositoryTests : RepositoryTestBase
 {
-    private static AppDbContext CreateContext()
-    {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        return new AppDbContext(options);
-    }
-
     [Fact]
     public async Task GetByIdAsyncNoTracking_WhenConfigurationExists_ReturnsConfigurationAsync()
     {
@@ -52,7 +44,7 @@ public class ConfigurationsRepositoryTests
     {
         await using var context = CreateContext();
         var repository = new ConfigurationsRepository(context);
-        await Assert.ThrowsAsync<NullReferenceException>(
+        await Assert.ThrowsAsync<KeyNotFoundException>(
             () => repository.GetByIdAsyncNoTracking(999));
     }
 
@@ -239,7 +231,7 @@ public class ConfigurationsRepositoryTests
     {
         await using var context = CreateContext();
         var repository = new ConfigurationsRepository(context);
-        await Assert.ThrowsAsync<NullReferenceException>(
+        await Assert.ThrowsAsync<KeyNotFoundException>(
             () => repository.UpdateDeleteStatus(999));
     }
 }

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepositoryTest.cs
@@ -232,4 +232,1636 @@ public class ErasEvaluationDetailsViewRepositoryTest
         Assert.Equal(0, resultLength);
         Assert.Empty(result);
     }
+
+    [Fact]
+    public async Task GetByFiltersAsync_WhenAllFiltersMatch_ReturnsMatchingEntityAsync()
+    {
+        // Arrange
+        var data = new List<ErasEvaluationDetailsViewEntity>
+        {
+            new()
+            {
+                PollId = 10,
+                CohortId = 20,
+                ComponentId = 30,
+                VariableId = 40,
+                StudentId = 1,
+                StudentName = "Student 1",
+                ComponentName = "Academic",
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                PollUuid = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "Progress"
+            },
+            new()
+            {
+                PollId = 99,
+                CohortId = 20,
+                ComponentId = 30,
+                VariableId = 40,
+                StudentId = 2,
+                StudentName = "Student 2",
+                ComponentName = "Academic",
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                PollUuid = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "Done"
+            }
+        }.AsQueryable().BuildMockDbSet();
+
+        _mockContext
+            .Setup(C => C.Set<ErasEvaluationDetailsViewEntity>())
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = await _repository.GetByFiltersAsync(10, [30], [20], [40]);
+
+        // Assert
+        var item = Assert.Single(result);
+    }
+
+
+    [Fact]
+    public async Task GetByFiltersAsync_WhenPollIdIsNull_DoesNotFilterByPollAsync()
+    {
+        // Arrange
+        var data = new List<ErasEvaluationDetailsViewEntity>
+        {
+            new()
+            {
+                PollId = 10,
+                CohortId = 20,
+                ComponentId = 30,
+                VariableId = 40,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                PollUuid = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "Done",
+                StudentName = "student1",
+                ComponentName = "Academic"
+            },
+            new()
+            {
+                PollId = 20,
+                CohortId = 20,
+                ComponentId = 30,
+                VariableId = 40,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                PollUuid = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "Done",
+                StudentName = "studn2",
+                ComponentName = "academic"
+            }
+        }.AsQueryable().BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = await _repository.GetByFiltersAsync(null, [30], [20], [40]);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+    }
+
+
+    [Fact]
+    public async Task GetByFiltersAsync_WhenComponentIdsAreNull_DoesNotFilterByComponentAsync()
+    {
+        // Arrange
+        var data = new List<ErasEvaluationDetailsViewEntity>
+    {
+        new()
+        {
+            PollId = 10,
+            CohortId = 20,
+            ComponentId = 30,
+            VariableId = 40,
+            EvaluationName = "Eval1",
+            PollName = "Poll",
+            StudentEmail = "st@mail.com",
+            PollUuid = "1",
+            AnswerText = "I lN",
+            VariableName = "ofhr",
+            Status = "Done",
+            ComponentName = "Psyco",
+            StudentName = "abby"
+        },
+        new()
+        {
+            PollId = 10,
+            CohortId = 20,
+            ComponentId = 99,
+            VariableId = 40,
+            EvaluationName = "Eval1",
+            PollName = "Poll",
+            StudentEmail = "st@mail.com",
+            PollUuid = "1",
+            AnswerText = "I lN",
+            VariableName = "ofhr",
+            Status = "Done",
+            ComponentName = "Normal",
+            StudentName = "abby"
+        }
+    }.AsQueryable().BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = await _repository.GetByFiltersAsync(10, null, [20], [40]);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+    }
+
+
+    [Fact]
+    public async Task GetByFiltersAsync_WhenCohortIdsAreNull_DoesNotFilterByCohortAsync()
+    {
+        // Arrange
+        var data = new List<ErasEvaluationDetailsViewEntity>
+        {
+            new()
+            {
+                PollId = 10,
+                CohortId = 20,
+                ComponentId = 30,
+                VariableId = 40,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                PollUuid = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "Done",
+                ComponentName = "Normal",
+                StudentName = "stu1"
+            },
+            new()
+            {
+                PollId = 10,
+                CohortId = 99,
+                ComponentId = 30,
+                VariableId = 40,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                PollUuid = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "Done",
+                ComponentName = "Normal",
+                StudentName = "stu1"
+            }
+        }.AsQueryable().BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = await _repository.GetByFiltersAsync(10, [30], null, [40]);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+    }
+
+
+    [Fact]
+    public async Task GetByFiltersAsync_WhenVariableIdsAreNull_DoesNotFilterByVariableAsync()
+    {
+        // Arrange
+        var data = new List<ErasEvaluationDetailsViewEntity>
+        {
+            new()
+            {
+                PollId = 10,
+                CohortId = 20,
+                ComponentId = 30,
+                VariableId = 40,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                PollUuid = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "Done",
+                ComponentName = "Normal",
+                StudentName = "stu1"
+            },
+            new()
+            {
+                PollId = 10,
+                CohortId = 20,
+                ComponentId = 30,
+                VariableId = 99,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                PollUuid = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "Done",
+                ComponentName = "Normal",
+                StudentName = "stu1"
+            }
+        }.AsQueryable().BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = await _repository.GetByFiltersAsync(10, [30], [20], null);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+    }
+
+
+    [Fact]
+    public async Task GetByFiltersAsync_WhenOptionalListsAreEmpty_DoesNotApplyThoseFiltersAsync()
+    {
+        // Arrange
+        var data = new List<ErasEvaluationDetailsViewEntity>
+        {
+            new()
+            {
+                PollId = 10,
+                CohortId = 20,
+                ComponentId = 30,
+                VariableId = 40,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                PollUuid = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "Done",
+                ComponentName = "Normal",
+                StudentName = "stu1"
+            },
+            new()
+            {
+                PollId = 10,
+                CohortId = 99,
+                ComponentId = 99,
+                VariableId = 99,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                PollUuid = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "Done",
+                ComponentName = "Normal",
+                StudentName = "stu1"
+            }
+        }.AsQueryable().BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = await _repository.GetByFiltersAsync(10, [], [], []);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+    }
+
+
+    [Fact]
+    public async Task GetByFiltersAsync_WhenNoEntityMatches_ReturnsEmptyListAsync()
+    {
+        // Arrange
+        var data = new List<ErasEvaluationDetailsViewEntity>
+    {
+        new()
+        {
+            PollId = 10,
+            CohortId = 20,
+            ComponentId = 30,
+            VariableId = 40,
+            PollName = "Poll",
+            EvaluationName = "Eval1",
+            StudentEmail = "st@mail.com",
+            PollUuid = "1",
+            AnswerText = "I lN",
+            VariableName = "ofhr",
+            Status = "Done",
+            ComponentName = "Normal",
+            StudentName = "stu1"
+        }
+    }.AsQueryable().BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = await _repository.GetByFiltersAsync(999, [999], [999], [999]);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+
+    [Fact]
+    public async Task GetStudentsByEvaluationIdFilters_ReturnsMatchingStudentsAsync()
+    {
+        // Arrange
+        var startDate = new DateTime(2026, 1, 1);
+        var endDate = new DateTime(2026, 1, 31);
+
+        var data = new List<ErasEvaluationDetailsViewEntity>
+        {
+            new()
+            {
+                EvaluationId = 10,
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 15),
+                StudentId = 1,
+                StudentName = "Student 1",
+                StudentEmail = "student1@test.com",
+                AnswerId = 100,
+                AnswerText = "Yes",
+                RiskLevel = 2,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                PollUuid = "1",
+                VariableName = "ofhr",
+                Status = "Done"
+            },
+            new()
+            {
+                EvaluationId = 99,
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 15),
+                StudentId = 2,
+                StudentName = "Student 2",
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                PollUuid = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "InProgress"
+            }
+        }.AsQueryable().BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = await _repository.GetStudentsByEvaluationIdFilters(10, ["Academic"], [20], null, null, startDate, endDate);
+
+        // Assert
+        var student = Assert.Single(result);
+
+        Assert.Equal(1, student.Id);
+        Assert.Equal("Student 1", student.Name);
+        Assert.Equal("student1@test.com", student.Email);
+        Assert.Equal(100, student.AnswerId);
+        Assert.Equal("Yes", student.AnswerText);
+        Assert.Equal(2, student.RiskLevel);
+    }
+
+
+    [Fact]
+    public async Task GetStudentsByEvaluationIdFilters_WhenVariableIdsAreProvided_ReturnsOnlyMatchingVariablesAsync()
+    {
+        // Arrange
+        var startDate = new DateTime(2026, 1, 1);
+        var endDate = new DateTime(2026, 1, 31);
+
+        var data = new List<ErasEvaluationDetailsViewEntity>
+        {
+            new()
+            {
+                EvaluationId = 10,
+                CohortId = 20,
+                ComponentName = "Academic",
+                VariableId = 100,
+                FinishedAt = new DateTime(2026, 1, 15),
+                StudentId = 1,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                PollUuid = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "Done",
+                StudentName = "studen1",
+            },
+            new()
+            {
+                EvaluationId = 10,
+                CohortId = 20,
+                ComponentName = "Academic",
+                VariableId = 200,
+                FinishedAt = new DateTime(2026, 1, 15),
+                StudentId = 2,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                PollUuid = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "Done",
+                StudentName = "abby",
+            }
+        }.AsQueryable().BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = await _repository.GetStudentsByEvaluationIdFilters(10, ["Academic"], [20],[100], null, startDate, endDate);
+
+        // Assert
+        var student = Assert.Single(result);
+        Assert.Equal(1, student.Id);
+    }
+
+
+    [Fact]
+    public async Task GetStudentsByEvaluationIdFilters_WhenRiskLevelsProvided_FiltersByRiskGroupAsync()
+    {
+        // Arrange
+        var startDate = new DateTime(2026, 1, 1);
+        var endDate = new DateTime(2026, 1, 31);
+
+        var data = new List<ErasEvaluationDetailsViewEntity>
+        {
+            new()
+            {
+                EvaluationId = 10,
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 15),
+                StudentId = 1,
+                RiskLevel = 1.2m,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                PollUuid = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "Done",
+                StudentName = "studen1",
+            },
+            new()
+            {
+                EvaluationId = 10,
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 15),
+                StudentId = 2,
+                RiskLevel = 3.2m,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                PollUuid = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "Done",
+                StudentName = "studen1",
+            }
+        }.AsQueryable().BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = await _repository.GetStudentsByEvaluationIdFilters(10, ["Academic"], [20], null, [1], startDate, endDate);
+
+        // Assert
+        var student = Assert.Single(result);
+        Assert.Equal(1, student.Id);
+    }
+
+
+    [Fact]
+    public async Task GetStudentsByEvaluationIdFilters_WhenRiskLevelsAreNull_DoesNotFilterByRiskAsync()
+    {
+        // Arrange
+        var startDate = new DateTime(2026, 1, 1);
+        var endDate = new DateTime(2026, 1, 31);
+
+        var data = new List<ErasEvaluationDetailsViewEntity>
+        {
+            new()
+            {
+                EvaluationId = 10,
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 15),
+                StudentId = 1,
+                RiskLevel = 1,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                PollUuid = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "Done",
+                StudentName = "studen1",
+            },
+            new()
+            {
+                EvaluationId = 10,
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 15),
+                StudentId = 2,
+                RiskLevel = 5,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                PollUuid = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "Done",
+                StudentName = "studen1",
+            }
+        }.AsQueryable().BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = await _repository.GetStudentsByEvaluationIdFilters(10, ["Academic"], [20], null, null, startDate, endDate);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+    }
+
+
+    [Fact]
+    public async Task GetStudentsByEvaluationIdFilters_RemovesDuplicateResponsesAsync()
+    {
+        // Arrange
+        var startDate = new DateTime(2026, 1, 1);
+        var endDate = new DateTime(2026, 1, 31);
+
+        var data = new List<ErasEvaluationDetailsViewEntity>
+        {
+            new()
+            {
+                EvaluationId = 10,
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 15),
+                StudentId = 1,
+                StudentName = "Student 1",
+                StudentEmail = "student@test.com",
+                AnswerId = 100,
+                AnswerText = "Yes",
+                RiskLevel = 2,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                PollUuid = "1",
+                VariableName = "large",
+                Status = "Done",
+            },
+            new()
+            {
+                EvaluationId = 10,
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 15),
+                StudentId = 1,
+                StudentName = "Student 1",
+                StudentEmail = "student@test.com",
+                AnswerId = 100,
+                AnswerText = "No",
+                RiskLevel = 2,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                PollUuid = "1",
+                VariableName = "large",
+                Status = "Done"
+            }
+        }.AsQueryable().BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = await _repository.GetStudentsByEvaluationIdFilters(10, ["Academic"], [20], null, null, startDate, endDate);
+
+        // Assert
+        Assert.Equal(2,result.Count);
+    }
+
+
+    [Fact]
+    public async Task GetStudentsByFilters_WhenVariableIdsAreNull_ReturnsMatchingStudentsAsync()
+    {
+        // Arrange
+        var startDate = new DateTime(2026, 1, 1);
+        var endDate = new DateTime(2026, 1, 31);
+
+        var data = new List<ErasEvaluationDetailsViewEntity>
+        {
+            new()
+            {
+                PollUuid = "poll-1",
+                CohortId = 20,
+                ComponentName = "Academic",
+                VariableId = 100,
+                FinishedAt = new DateTime(2026, 1, 15),
+                StudentId = 1,
+                StudentName = "Student 1",
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                Status = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr"
+            },
+            new()
+            {
+                PollUuid = "poll-2",
+                CohortId = 20,
+                ComponentName = "Academic",
+                VariableId = 100,
+                FinishedAt = new DateTime(2026, 1, 15),
+                StudentId = 2,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                Status = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                StudentName = "k"
+            }
+        }.AsQueryable().BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = (await _repository.GetStudentsByFilters(
+            "poll-1", ["Academic"], [20], null, null, 1, 10, startDate, endDate)).ToList();
+
+        // Assert
+        var student = Assert.Single(result);
+        Assert.Equal(1, student.StudentId);
+    }
+
+
+    [Fact]
+    public async Task GetStudentsByFilters_WhenVariableIdsProvided_FiltersVariables()
+    {
+        // Arrange
+        var startDate = new DateTime(2026, 1, 1);
+        var endDate = new DateTime(2026, 1, 31);
+
+        var data = new List<ErasEvaluationDetailsViewEntity>
+        {
+            new()
+            {
+                PollUuid = "poll-1",
+                CohortId = 20,
+                ComponentName = "Academic",
+                VariableId = 100,
+                FinishedAt = new DateTime(2026, 1, 15),
+                StudentId = 1,
+                StudentName = "Student 1",
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                Status = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr"
+            },
+            new()
+            {
+                PollUuid = "poll-1",
+                CohortId = 20,
+                ComponentName = "Academic",
+                VariableId = 200,
+                FinishedAt = new DateTime(2026, 1, 15),
+                StudentId = 2,
+                StudentName = "Student 2",
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                Status = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr"
+            }
+        }.AsQueryable().BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = (await _repository.GetStudentsByFilters("poll-1",["Academic"], [20], [100],null,1, 10, startDate, endDate)).ToList();
+
+        // Assert
+        var student = Assert.Single(result);
+        Assert.Equal(1, student.StudentId);
+    }
+
+
+    [Fact]
+    public async Task GetStudentsByFilters_WhenEvaluationIdProvided_FiltersByEvaluationAsync()
+    {
+        // Arrange
+        var startDate = new DateTime(2026, 1, 1);
+        var endDate = new DateTime(2026, 1, 31);
+
+        var data = new List<ErasEvaluationDetailsViewEntity>
+        {
+            new()
+            {
+                PollUuid = "poll-1",
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 15),
+                EvaluationId = 10,
+                StudentId = 1,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                Status = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                StudentName = "studnet"
+            },
+            new()
+            {
+                PollUuid = "poll-1",
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 15),
+                EvaluationId = 20,
+                StudentId = 2,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                Status = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                StudentName = "studnet"
+            }
+        }.AsQueryable().BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = (await _repository.GetStudentsByFilters(
+            "poll-1", ["Academic"], [20], null, null, 1, 10,startDate, endDate, 10)).ToList();
+
+        // Assert
+        var student = Assert.Single(result);
+        Assert.Equal(1, student.StudentId);
+    }
+
+
+    [Fact]
+    public async Task GetStudentsByFilters_WhenEvaluationIdIsNull_DoesNotFilterByEvaluationAsync()
+    {
+        // Arrange
+        var startDate = new DateTime(2026, 1, 1);
+        var endDate = new DateTime(2026, 1, 31);
+
+        var data = new List<ErasEvaluationDetailsViewEntity>
+        {
+            new()
+            {
+                PollUuid = "poll-1",
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 15),
+                EvaluationId = 10,
+                StudentId = 1,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                Status = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                StudentName = "stu1"
+            },
+            new()
+            {
+                PollUuid = "poll-1",
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 15),
+                EvaluationId = 20,
+                StudentId = 2,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                Status = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                StudentName = "st2"
+            }
+        }.AsQueryable().BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = (await _repository.GetStudentsByFilters(
+            "poll-1",
+            ["Academic"],
+            [20],
+            null,
+            null,
+            1,
+            10,
+            startDate,
+            endDate)).ToList();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+    }
+
+
+    [Fact]
+    public async Task GetStudentsByFilters_WhenRiskLevelsProvided_FiltersStudentsAsync()
+    {
+        // Arrange
+        var startDate = new DateTime(2026, 1, 1);
+        var endDate = new DateTime(2026, 1, 31);
+
+        var data = new List<ErasEvaluationDetailsViewEntity>
+    {
+        new()
+        {
+            PollUuid = "poll-1",
+            CohortId = 20,
+            ComponentName = "Academic",
+            FinishedAt = new DateTime(2026, 1, 15),
+            StudentId = 1,
+            StudentName = "Student 1",
+            RiskLevel = 1,
+            EvaluationName = "Eval1",
+            PollName = "Poll",
+            StudentEmail = "st@mail.com",
+            Status = "1",
+            AnswerText = "I lN",
+            VariableName = "ofhr",
+        },
+        new()
+        {
+            PollUuid = "poll-1",
+            CohortId = 20,
+            ComponentName = "Academic",
+            FinishedAt = new DateTime(2026, 1, 15),
+            StudentId = 2,
+            StudentName = "Student 2",
+            RiskLevel = 5,
+            EvaluationName = "Eval1",
+            PollName = "Poll",
+            StudentEmail = "st@mail.com",
+            Status = "1",
+            AnswerText = "I lN",
+            VariableName = "ofhr"
+        }
+    }.AsQueryable().BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = (await _repository.GetStudentsByFilters("poll-1", ["Academic"], [20], null, [1], 1, 10, startDate, endDate)).ToList();
+
+        // Assert
+        var student = Assert.Single(result);
+        Assert.Equal(1, student.StudentId);
+    }
+
+
+    [Fact]
+    public async Task GetStudentsByFilters_WhenRiskLevelsAreEmpty_DoesNotFilterRisk()
+    {
+        // Arrange
+        var startDate = new DateTime(2026, 1, 1);
+        var endDate = new DateTime(2026, 1, 31);
+
+        var data = new List<ErasEvaluationDetailsViewEntity>
+        {
+            new()
+            {
+                PollUuid = "poll-1",
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 15),
+                StudentId = 1,
+                RiskLevel = 1,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                Status = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                StudentName = "stud1"
+            },
+            new()
+            {
+                PollUuid = "poll-1",
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 15),
+                StudentId = 2,
+                RiskLevel = 5,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                Status = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                StudentName = "stud2"
+            }
+        }.AsQueryable().BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = (await _repository.GetStudentsByFilters("poll-1", ["Academic"], [20], null, [], 1, 10, startDate, endDate)).ToList();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+    }
+
+
+    [Fact]
+    public async Task GetStudentsByFilters_GroupsByStudentAndReturnsFirstRecordAsync()
+    {
+        // Arrange
+        var startDate = new DateTime(2026, 1, 1);
+        var endDate = new DateTime(2026, 1, 31);
+
+        var data = new List<ErasEvaluationDetailsViewEntity>
+        {
+            new()
+            {
+                PollUuid = "poll-1",
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 15),
+                StudentId = 1,
+                StudentName = "Student 1",
+                RiskLevel = 2,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "Done"
+            },
+            new()
+            {
+                PollUuid = "poll-1",
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 16),
+                StudentId = 1,
+                StudentName = "Student 1",
+                RiskLevel = 3,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "Complete"
+            },
+            new()
+            {
+                PollUuid = "poll-1",
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 17),
+                StudentId = 2,
+                StudentName = "Student 2",
+                RiskLevel = 4,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "Done"
+            }
+        }.AsQueryable().BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = (await _repository.GetStudentsByFilters(
+            "poll-1", ["Academic"], [20], null, null, 1, 10, startDate, endDate)).ToList();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Equal(1, result[0].StudentId);
+        Assert.Equal(2, result[1].StudentId);
+    }
+
+
+    [Fact]
+    public async Task GetStudentsByFilters_AppliesPaginationAsync()
+    {
+        // Arrange
+        var startDate = new DateTime(2026, 1, 1);
+        var endDate = new DateTime(2026, 1, 31);
+
+        var data = new List<ErasEvaluationDetailsViewEntity>
+        {
+            new()
+            {
+                PollUuid = "poll-1",
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 15),
+                StudentId = 1,
+                StudentName = "Alice",
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "Done"
+            },
+            new()
+            {
+                PollUuid = "poll-1",
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 15),
+                StudentId = 2,
+                StudentName = "Bob",
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "Done"
+            },
+            new()
+            {
+                PollUuid = "poll-1",
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 15),
+                StudentId = 3,
+                StudentName = "Charlie",
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "Done"
+            }
+        }.AsQueryable().BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = (await _repository.GetStudentsByFilters(
+            "poll-1", ["Academic"], [20], null, null, 2, 1, startDate, endDate)).ToList();
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal(2, result[0].StudentId);
+    }
+
+
+    [Fact]
+    public async Task CountStudentsByFilters_ReturnsDistinctStudentCountAsync()
+    {
+        // Arrange
+        var startDate = new DateTime(2026, 1, 1);
+        var endDate = new DateTime(2026, 1, 31);
+
+        var data = new List<ErasEvaluationDetailsViewEntity>
+        {
+            new()
+            {
+                PollUuid = "poll-1",
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 15),
+                StudentId = 1,
+                RiskLevel = 2,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "Done",
+                StudentName = "total2"
+            },
+            new()
+            {
+                PollUuid = "poll-1",
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 16),
+                StudentId = 1,
+                RiskLevel = 3,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                AnswerText = "I lN",
+                VariableName = "ofhr",
+                Status = "Done",
+                StudentName = "total2"
+            },
+            new()
+            {
+                PollUuid = "poll-1",
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 17),
+                StudentId = 2,
+                RiskLevel = 4,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                AnswerText = "back",
+                VariableName = "ofhr",
+                Status = "Done",
+                StudentName = "total2"
+            }
+        }.AsQueryable().BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = await _repository.CountStudentsByFilters(
+            "poll-1", ["Academic"], [20], null, null, startDate, endDate);
+
+        // Assert
+        Assert.Equal(2, result);
+    }
+
+
+    [Fact]
+    public async Task CountStudentsByFilters_WhenRiskFilterProvided_ReturnsOnlyMatchingStudentsAsync()
+    {
+        // Arrange
+        var startDate = new DateTime(2026, 1, 1);
+        var endDate = new DateTime(2026, 1, 31);
+
+        var data = new List<ErasEvaluationDetailsViewEntity>
+        {
+            new()
+            {
+                PollUuid = "poll-1",
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 15),
+                StudentId = 1,
+                RiskLevel = 1,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                AnswerText = "I lN",
+                Status = "Done",
+                StudentName = "total2",
+                VariableName = "ofhr",
+            },
+            new()
+            {
+                PollUuid = "poll-1",
+                CohortId = 20,
+                ComponentName = "Academic",
+                FinishedAt = new DateTime(2026, 1, 15),
+                StudentId = 2,
+                RiskLevel = 5,
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                AnswerText = "ctablN",
+                VariableName = "ofhr",
+                Status = "Done",
+                StudentName = "total2"
+            }
+        }.AsQueryable().BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = await _repository.CountStudentsByFilters("poll-1", ["Academic"], [20], null, [1], startDate, endDate);
+
+        // Assert
+        Assert.Equal(1, result);
+    }
+
+
+    [Fact]
+    public async Task CountStudentsByFilters_WhenEvaluationIdProvided_OnlyCountsEvaluationAsync()
+    {
+        // Arrange
+        var startDate = new DateTime(2026, 1, 1);
+        var endDate = new DateTime(2026, 1, 31);
+
+        var data = new List<ErasEvaluationDetailsViewEntity>
+    {
+        new()
+        {
+            PollUuid = "poll-1",
+            CohortId = 20,
+            ComponentName = "Academic",
+            FinishedAt = new DateTime(2026, 1, 15),
+            EvaluationId = 10,
+            StudentId = 1,
+            EvaluationName = "Eval1",
+            PollName = "Poll",
+            StudentEmail = "st@mail.com",
+            AnswerText = "Icomp lN",
+            VariableName = "ofhr",
+            Status = "Done",
+            StudentName = "stu1"
+        },
+        new()
+        {
+            PollUuid = "poll-1",
+            CohortId = 20,
+            ComponentName = "Academic",
+            FinishedAt = new DateTime(2026, 1, 15),
+            EvaluationId = 20,
+            StudentId = 2,
+            EvaluationName = "Eval1",
+            PollName = "Poll",
+            StudentEmail = "st@mail.com",
+            AnswerText = "ntrinN",
+            VariableName = "ofhr",
+            Status = "Done",
+            StudentName = "stu1"
+        }
+    }.AsQueryable().BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = await _repository.CountStudentsByFilters(
+            "poll-1", ["Academic"], [20], null, null, startDate, endDate, 10);
+
+        // Assert
+        Assert.Equal(1, result);
+    }
+
+
+    [Fact]
+    public async Task CountRecentAlerts_ReturnsNumberOfGroupedStudentComponentsAsync()
+    {
+        // Arrange
+        var data = new List<ErasEvaluationDetailsViewEntity>
+    {
+        new()
+        {
+            StudentId = 1,
+            StudentName = "Student 1",
+            ComponentName = "Academic",
+            Status = "Completed",
+            RiskLevel = 2,
+            FinishedAt = new DateTime(2026, 1, 1),
+            EvaluationName = "Eval1",
+            PollName = "Poll",
+            StudentEmail = "st@mail.com",
+            PollUuid = "1",
+            AnswerText = "ceacepma",
+            VariableName = "vk"
+        },
+        new()
+        {
+            StudentId = 1,
+            StudentName = "Student 1",
+            ComponentName = "Academic",
+            Status = "Completed",
+            RiskLevel = 4,
+            FinishedAt = new DateTime(2026, 1, 2),
+            EvaluationName = "Eval1",
+            PollName = "Poll",
+            StudentEmail = "st@mail.com",
+            PollUuid = "1",
+            AnswerText = "comp",
+            VariableName = "motiv"
+        },
+        new()
+        {
+            StudentId = 1,
+            StudentName = "Student 1",
+            ComponentName = "Attendance",
+            Status = "Completed",
+            RiskLevel = 3,
+            FinishedAt = new DateTime(2026, 1, 3),
+            EvaluationName = "Eval1",
+            PollName = "Poll",
+            StudentEmail = "st@mail.com",
+            PollUuid = "1",
+            AnswerText = "evalu",
+            VariableName = "presebr"
+        }
+    }.AsQueryable().BuildMockDbSet();
+
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _mockContext = new Mock<AppDbContext>(options);
+
+        _mockContext
+            .Setup(c => c.ErasEvaluationDetailsView)
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = await _repository.CountRecentAlerts();
+
+        // Assert
+        Assert.Equal(2, result);
+    }
+
+
+    [Fact]
+    public async Task GetRecentAlertsStudentAsync_GroupsByStudentAndComponent()
+    {
+        // Arrange
+        var data = new List<ErasEvaluationDetailsViewEntity>
+    {
+        new()
+        {
+            StudentId = 1,
+            StudentName = "Student 1",
+            ComponentName = "Academic",
+            Status = "Completed",
+            RiskLevel = 2,
+            FinishedAt = new DateTime(2026, 1, 1),
+            EvaluationName = "Eval1",
+            PollName = "Poll",
+            StudentEmail = "st@mail.com",
+            PollUuid = "1",
+            AnswerText = "imyaaf",
+            VariableName = "ofhr"
+        },
+        new()
+        {
+            StudentId = 1,
+            StudentName = "Student 1",
+            ComponentName = "Academic",
+            Status = "Completed",
+            RiskLevel = 4,
+            FinishedAt = new DateTime(2026, 1, 2),
+            EvaluationName = "Eval1",
+            PollName = "Poll",
+            StudentEmail = "st@mail.com",
+            PollUuid = "1",
+            AnswerText = "obc",
+            VariableName = "desesp"
+            }
+        }.AsQueryable().BuildMockDbSet();
+
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _mockContext = new Mock<AppDbContext>(options);
+
+        _mockContext
+            .Setup(c => c.ErasEvaluationDetailsView)
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = (await _repository.GetRecentAlertsStudentAsync(1, 10)).ToList();
+
+        // Assert
+        var item = Assert.Single(result);
+
+        Assert.Equal("1", item.StudentId);
+        Assert.Equal("Student 1", item.StudentName);
+        Assert.Equal("Academic", item.Category);
+    }
+
+
+    [Fact]
+    public async Task GetRecentAlertsStudentAsync_ExcludesInvalidStatusesAsync()
+    {
+        // Arrange
+        var data = new List<ErasEvaluationDetailsViewEntity>
+        {
+            new()
+            {
+                StudentId = 1,
+                StudentName = "Student 1",
+                ComponentName = "Academic",
+                Status = "Pending",
+                RiskLevel = 5,
+                FinishedAt = new DateTime(2026, 1, 1),
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                PollUuid = "1",
+                AnswerText = "I lN",
+                VariableName = "ofhr"
+            },
+            new()
+            {
+                StudentId = 2,
+                StudentName = "Student 2",
+                ComponentName = "Academic",
+                Status = "Cancelled",
+                RiskLevel = 5,
+                FinishedAt = new DateTime(2026, 1, 2),
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                PollUuid = "1",
+                AnswerText = "Iiaq",
+                VariableName = "ofhr"
+            }
+        }.AsQueryable().BuildMockDbSet();
+
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _mockContext = new Mock<AppDbContext>(options);
+
+        _mockContext
+            .Setup(c => c.ErasEvaluationDetailsView)
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = await _repository.GetRecentAlertsStudentAsync(1, 10);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+
+    [Fact]
+    public async Task GetRecentAlertsStudentAsync_OrdersByRiskThenDateDescendingAsync()
+    {
+        // Arrange
+        var data = new List<ErasEvaluationDetailsViewEntity>
+        {
+            new()
+            {
+                StudentId = 1,
+                StudentName = "Low Risk",
+                ComponentName = "Academic",
+                Status = "Completed",
+                RiskLevel = 1,
+                FinishedAt = new DateTime(2026, 1, 10),
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                PollUuid = "1",
+                AnswerText = "mracftf",
+                VariableName = "oc"
+            },
+            new()
+            {
+                StudentId = 2,
+                StudentName = "High Risk",
+                ComponentName = "Academic",
+                Status = "Completed",
+                RiskLevel = 5,
+                FinishedAt = new DateTime(2026, 1, 1),
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                PollUuid = "1",
+                AnswerText = "apmvN",
+                VariableName = "depl"
+            },
+            new()
+            {
+                StudentId = 3,
+                StudentName = "High Risk Recent",
+                ComponentName = "Academic",
+                Status = "Completed",
+                RiskLevel = 5,
+                FinishedAt = new DateTime(2026, 1, 20),
+                EvaluationName = "Eval1",
+                PollName = "Poll",
+                StudentEmail = "st@mail.com",
+                PollUuid = "1",
+                AnswerText = "ttbmpN",
+                VariableName = "irntsbmf"
+            }
+        }.AsQueryable().BuildMockDbSet();
+
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _mockContext = new Mock<AppDbContext>(options);
+
+        _mockContext
+            .Setup(c => c.ErasEvaluationDetailsView)
+            .Returns(data.Object);
+
+        _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
+
+        // Act
+        var result = (await _repository.GetRecentAlertsStudentAsync(1, 10)).ToList();
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        Assert.Equal("3", result[0].StudentId);
+        Assert.Equal("2", result[1].StudentId);
+        Assert.Equal("1", result[2].StudentId);
+    }
 }

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepositoryTest.cs
@@ -2,6 +2,7 @@
 using Eras.Infrastructure.Persistence.PostgreSQL;
 using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -11,7 +12,7 @@ using Moq;
 
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
 
-public class ErasEvaluationDetailsViewRepositoryTest
+public class ErasEvaluationDetailsViewRepositoryTest : RepositoryTestBase
 {
     private Mock<AppDbContext> _mockContext;
     private IErasEvaluationDetailsViewRepository? _repository;

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ErasEvaluationDetailsViewRepositoryTest.cs
@@ -22,7 +22,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
     }
 
     [Fact]
-    public async Task GetRecentAlertsStudentAsync_Should_Return_First_Page()
+    public async Task GetRecentAlertsStudentAsync_Should_Return_First_PageAsync()
     {
         // Arrange
         var data = new List<ErasEvaluationDetailsViewEntity>
@@ -78,7 +78,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         _mockContext = new Mock<AppDbContext>(options);
 
         _mockContext
-            .Setup(c => c.ErasEvaluationDetailsView)
+            .Setup(C => C.ErasEvaluationDetailsView)
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -93,7 +93,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         Assert.Equal("2", result[1].StudentId);
     }
     [Fact]
-    public async Task GetRecentAlertsStudentAsync_Should_Return_Second_Page()
+    public async Task GetRecentAlertsStudentAsync_Should_Return_Second_PageAsync()
     {
         // Arrange
         var data = new List<ErasEvaluationDetailsViewEntity>
@@ -162,7 +162,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         _mockContext = new Mock<AppDbContext>(options);
 
         _mockContext
-            .Setup(c => c.ErasEvaluationDetailsView)
+            .Setup(C => C.ErasEvaluationDetailsView)
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -178,7 +178,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
     }
 
     [Fact]
-    public async Task GetRecentAlertsStudentAsync_Should_Return_Empty_When_Evaluations_AreNot_Completed_InProgresss()
+    public async Task GetRecentAlertsStudentAsync_Should_ReturnEmpty_EvaluationsAreNotCompleted_InProgresssAsync()
     {
         // Arrange
         var data = new List<ErasEvaluationDetailsViewEntity>
@@ -218,7 +218,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         _mockContext = new Mock<AppDbContext>(options);
 
         _mockContext
-            .Setup(c => c.ErasEvaluationDetailsView)
+            .Setup(C => C.ErasEvaluationDetailsView)
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -330,7 +330,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         }.AsQueryable().BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Setup(C => C.Set<ErasEvaluationDetailsViewEntity>())
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -384,7 +384,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
     }.AsQueryable().BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Setup(C => C.Set<ErasEvaluationDetailsViewEntity>())
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -438,7 +438,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         }.AsQueryable().BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Setup(C => C.Set<ErasEvaluationDetailsViewEntity>())
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -492,7 +492,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         }.AsQueryable().BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Setup(C => C.Set<ErasEvaluationDetailsViewEntity>())
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -546,7 +546,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         }.AsQueryable().BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Setup(C => C.Set<ErasEvaluationDetailsViewEntity>())
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -584,7 +584,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
     }.AsQueryable().BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Setup(C => C.Set<ErasEvaluationDetailsViewEntity>())
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -643,7 +643,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         }.AsQueryable().BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Setup(C => C.Set<ErasEvaluationDetailsViewEntity>())
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -682,24 +682,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
                 StudentId = 1,
                 EvaluationName = "Eval1",
                 PollName = "Poll",
-                StudentEmail = "st@mail.com",
-                PollUuid = "1",
-                AnswerText = "I lN",
-                VariableName = "ofhr",
-                Status = "Done",
-                StudentName = "studen1",
-            },
-            new()
-            {
-                EvaluationId = 10,
-                CohortId = 20,
-                ComponentName = "Academic",
-                VariableId = 200,
-                FinishedAt = new DateTime(2026, 1, 15),
-                StudentId = 2,
-                EvaluationName = "Eval1",
-                PollName = "Poll",
-                StudentEmail = "st@mail.com",
+                StudentEmail = "abb@mail.com",
                 PollUuid = "1",
                 AnswerText = "I lN",
                 VariableName = "ofhr",
@@ -707,9 +690,8 @@ public class ErasEvaluationDetailsViewRepositoryTest
                 StudentName = "abby",
             }
         }.AsQueryable().BuildMockDbSet();
-
         _mockContext
-            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Setup(C => C.Set<ErasEvaluationDetailsViewEntity>())
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -769,7 +751,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         }.AsQueryable().BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Setup(C => C.Set<ErasEvaluationDetailsViewEntity>())
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -829,7 +811,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         }.AsQueryable().BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Setup(C => C.Set<ErasEvaluationDetailsViewEntity>())
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -890,7 +872,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         }.AsQueryable().BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Setup(C => C.Set<ErasEvaluationDetailsViewEntity>())
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -947,7 +929,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         }.AsQueryable().BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Setup(C => C.Set<ErasEvaluationDetailsViewEntity>())
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -963,7 +945,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
 
 
     [Fact]
-    public async Task GetStudentsByFilters_WhenVariableIdsProvided_FiltersVariables()
+    public async Task GetStudentsByFilters_WhenVariableIdsProvided_FiltersVariablesAsync()
     {
         // Arrange
         var startDate = new DateTime(2026, 1, 1);
@@ -1006,7 +988,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         }.AsQueryable().BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Setup(C => C.Set<ErasEvaluationDetailsViewEntity>())
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -1064,7 +1046,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         }.AsQueryable().BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Setup(C => C.Set<ErasEvaluationDetailsViewEntity>())
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -1123,7 +1105,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         }.AsQueryable().BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Setup(C => C.Set<ErasEvaluationDetailsViewEntity>())
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -1189,7 +1171,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
     }.AsQueryable().BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Setup(C => C.Set<ErasEvaluationDetailsViewEntity>())
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -1204,7 +1186,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
 
 
     [Fact]
-    public async Task GetStudentsByFilters_WhenRiskLevelsAreEmpty_DoesNotFilterRisk()
+    public async Task GetStudentsByFilters_WhenRiskLevelsAreEmpty_DoesNotFilterRiskAsync()
     {
         // Arrange
         var startDate = new DateTime(2026, 1, 1);
@@ -1247,7 +1229,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         }.AsQueryable().BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Setup(C => C.Set<ErasEvaluationDetailsViewEntity>())
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -1320,7 +1302,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         }.AsQueryable().BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Setup(C => C.Set<ErasEvaluationDetailsViewEntity>())
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -1393,7 +1375,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         }.AsQueryable().BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Setup(C => C.Set<ErasEvaluationDetailsViewEntity>())
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -1468,7 +1450,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         }.AsQueryable().BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Setup(C => C.Set<ErasEvaluationDetailsViewEntity>())
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -1526,7 +1508,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         }.AsQueryable().BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Setup(C => C.Set<ErasEvaluationDetailsViewEntity>())
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -1583,7 +1565,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
     }.AsQueryable().BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.Set<ErasEvaluationDetailsViewEntity>())
+            .Setup(C => C.Set<ErasEvaluationDetailsViewEntity>())
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -1657,7 +1639,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         _mockContext = new Mock<AppDbContext>(options);
 
         _mockContext
-            .Setup(c => c.ErasEvaluationDetailsView)
+            .Setup(C => C.ErasEvaluationDetailsView)
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -1671,7 +1653,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
 
 
     [Fact]
-    public async Task GetRecentAlertsStudentAsync_GroupsByStudentAndComponent()
+    public async Task GetRecentAlertsStudentAsync_GroupsByStudentAndComponentAsync()
     {
         // Arrange
         var data = new List<ErasEvaluationDetailsViewEntity>
@@ -1715,7 +1697,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         _mockContext = new Mock<AppDbContext>(options);
 
         _mockContext
-            .Setup(c => c.ErasEvaluationDetailsView)
+            .Setup(C => C.ErasEvaluationDetailsView)
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -1777,7 +1759,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         _mockContext = new Mock<AppDbContext>(options);
 
         _mockContext
-            .Setup(c => c.ErasEvaluationDetailsView)
+            .Setup(C => C.ErasEvaluationDetailsView)
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);
@@ -1850,7 +1832,7 @@ public class ErasEvaluationDetailsViewRepositoryTest
         _mockContext = new Mock<AppDbContext>(options);
 
         _mockContext
-            .Setup(c => c.ErasEvaluationDetailsView)
+            .Setup(C => C.ErasEvaluationDetailsView)
             .Returns(data.Object);
 
         _repository = new ErasEvaluationDetailsViewRepository(_mockContext.Object);

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/EvaluationPollRepositoryTests.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/EvaluationPollRepositoryTests.cs
@@ -8,12 +8,13 @@ using Eras.Application.Contracts.Persistence;
 using Eras.Domain.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
 
 using Microsoft.EntityFrameworkCore;
 
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
 
-public class EvaluationPollRepositoryTests
+public class EvaluationPollRepositoryTests : RepositoryTestBase
 {
     private readonly AppDbContext _context;
     private readonly IEvaluationPollRepository _repository;

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/EvaluationPollRepositoryTests.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/EvaluationPollRepositoryTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Eras.Application.Contracts.Persistence;
+using Eras.Domain.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+
+public class EvaluationPollRepositoryTests
+{
+    private readonly AppDbContext _context;
+    private readonly IEvaluationPollRepository _repository;
+
+    public EvaluationPollRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new AppDbContext(options);
+        _repository = new EvaluationPollRepository(_context);
+    }
+
+    [Fact]
+    public async Task Add_Should_Save_EvaluationAsync()
+    {
+        // Arrange
+        var evaluation = new Evaluation
+        {
+            Id = 1,
+            Name = "Test"
+        };
+
+        // Act
+        await _repository.AddAsync(evaluation);
+
+        // Assert
+        var result = await _repository.GetByIdAsync(evaluation.Id);
+
+        Assert.NotNull(result);
+        Assert.Equal(evaluation.Id, result.Id);
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/EvaluationRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/EvaluationRepositoryTest.cs
@@ -7,47 +7,751 @@ using Microsoft.EntityFrameworkCore;
 using MockQueryable.Moq;
 using Moq;
 
-namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
+using Xunit;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+
+public class EvaluationRepositoryTest
 {
-    public class EvaluationRepositoryTest
+    private Mock<DbSet<EvaluationEntity>> _mockSet;
+    protected Mock<AppDbContext> _mockContext;
+    private IEvaluationRepository? _repository;
+
+    public EvaluationRepositoryTest()
     {
-        private Mock<DbSet<EvaluationEntity>> _mockSet;
-        protected Mock<AppDbContext> _mockContext;
-        private IEvaluationRepository? _repository;
+        _mockSet = new Mock<DbSet<EvaluationEntity>>();
+        _mockContext = new Mock<AppDbContext>(
+            new DbContextOptions<AppDbContext>());
+    }
 
-        public EvaluationRepositoryTest()
-        {
-            _mockSet = new Mock<DbSet<EvaluationEntity>>();
-            _mockContext = new Mock<AppDbContext>(new DbContextOptions<AppDbContext>());
-        }
+    private void SetupEvaluations(IEnumerable<EvaluationEntity> evaluations)
+    {
+        var data = evaluations
+            .AsQueryable()
+            .BuildMockDbSet();
 
+        _mockContext
+            .Setup(c => c.Evaluations)
+            .Returns(data.Object);
+    }
 
-        [Fact]
-        public void GetByName_Should_Return()
-        {
-            // Arrange
-            var data = new List<EvaluationEntity>
+    private void CreateRepository()
+    {
+        _repository = new EvaluationRepository(_mockContext.Object);
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_WhenEvaluationExists_ReturnsEvaluationAsync()
+    {
+        // Arrange
+        SetupEvaluations(
+        [
+            new EvaluationEntity
             {
-                new EvaluationEntity { Id = 1, Name = "Evaluation1" },
-                new EvaluationEntity { Id = 2, Name = "Evaluation2" }
-            }.AsQueryable().BuildMockDbSet();
+                Id = 1,
+                Name = "Evaluation1"
+            },
+            new EvaluationEntity
+            {
+                Id = 2,
+                Name = "Evaluation2"
+            }
+        ]);
+        CreateRepository();
 
-            var options = new DbContextOptionsBuilder<AppDbContext>()
-                .UseInMemoryDatabase(databaseName: "EvaluationTest")
-                .Options;
+        // Act
+        var result = await _repository!.GetByNameAsync("Evaluation1");
 
-            _mockContext = new Mock<AppDbContext>(options);
-            _mockContext
-                .Setup(C => C.Evaluations)
-                .Returns(data.Object);
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Id);
+        Assert.Equal("Evaluation1", result.Name);
+    }
 
-            _repository = new EvaluationRepository(_mockContext.Object);
+    [Fact]
+    public async Task GetByNameAsync_WhenEvaluationDoesNotExist_ReturnsNullAsync()
+    {
+        // Arrange
+        SetupEvaluations([
+            new EvaluationEntity
+            {
+                Id = 1,
+                Name = "Evaluation1"
+            }
+        ]);
 
-            // Act
-            var result = _repository.GetByNameAsync("Evaluation1").Result;
+        CreateRepository();
 
-            Assert.NotNull(result);
-            Assert.Equal("Evaluation1", result.Name);
+        // Act
+        var result = await _repository!.GetByNameAsync("DoesNotExist");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByIdForUpdateAsync_WhenEvaluationExists_ReturnsEvaluationAsync()
+    {
+        // Arrange
+        SetupEvaluations(
+        [
+            new EvaluationEntity
+            {
+                Id = 10,
+                Name = "Evaluation 10"
+            }
+        ]);
+
+        CreateRepository();
+
+        // Act
+        var result = await _repository!.GetByIdForUpdateAsync(10);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(10, result.Id);
+        Assert.Equal("Evaluation 10", result.Name);
+    }
+
+    [Fact]
+    public async Task GetByIdForUpdateAsync_WhenEvaluationDoesNotExist_ReturnsNullAsync()
+    {
+        // Arrange
+        SetupEvaluations(
+        [
+            new EvaluationEntity
+            {
+                Id = 10,
+                Name = "Evaluation 10"
+            }
+        ]);
+
+        CreateRepository();
+
+        // Act
+        var result = await _repository!.GetByIdForUpdateAsync(999);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetPagedAsync_ReturnsEvaluationsOrderedByName()
+    {
+        // Arrange
+        var poll1 = new PollEntity
+        {
+            Uuid = "poll-1"
+        };
+        var poll2 = new PollEntity
+        {
+            Uuid = "poll-2"
+        };
+
+        var evaluations = new List<EvaluationEntity>
+        {
+            new()
+            {
+                Id = 1,
+                Name = "Z Evaluation",
+                EvaluationPolls =
+                [
+                    new EvaluationPollJoin
+                    {
+                        EvaluationId = 1,
+                        Poll = poll1
+                    }
+                ]
+            },
+            new()
+            {
+                Id = 2,
+                Name = "A Evaluation",
+                EvaluationPolls =
+                [
+                    new EvaluationPollJoin
+                    {
+                        EvaluationId = 2,
+                        Poll = poll2
+                    }
+                ]
+            }
+        };
+        SetupEvaluations(evaluations);
+        CreateRepository();
+
+        // Act
+        var result = (await _repository!.GetPagedAsync(1, 10)).ToList();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Equal("A Evaluation", result[0].Name);
+        Assert.Equal("Z Evaluation", result[1].Name);
+        Assert.Single(result[0].Polls);
+        Assert.Equal("poll-2", result[0].Polls.First().Uuid);
+        Assert.Single(result[1].Polls);
+        Assert.Equal("poll-1", result[1].Polls.First().Uuid);
+    }
+
+    [Fact]
+    public async Task GetPagedAsync_ReturnsCorrectPageAsync()
+    {
+        // Arrange
+        SetupEvaluations(
+        [
+            new EvaluationEntity
+            {
+                Id = 1,
+                Name = "A"
+            },
+            new EvaluationEntity
+            {
+                Id = 2,
+                Name = "B"
+            },
+            new EvaluationEntity
+            {
+                Id = 3,
+                Name = "C"
+            }
+        ]);
+        CreateRepository();
+
+        // Act
+        var result = (await _repository!.GetPagedAsync(2, 1)).ToList();
+
+        // Assert
+        var evaluation = Assert.Single(result);
+        Assert.Equal(2, evaluation.Id);
+        Assert.Equal("B", evaluation.Name);
+    }
+
+    [Fact]
+    public async Task GetPagedAsync_WhenPageIsBeyondData_ReturnsEmptyAsync()
+    {
+        // Arrange
+        SetupEvaluations(
+        [
+            new EvaluationEntity
+            {
+                Id = 1,
+                Name = "A"
+            }
+        ]);
+
+        CreateRepository();
+
+        // Act
+        var result = (await _repository!.GetPagedAsync(10, 10)).ToList();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetByNameForUpdateAsync_ReturnsEvaluationWithSameNameButDifferentIdAsync()
+    {
+        // Arrange
+        SetupEvaluations(
+        [
+            new EvaluationEntity
+        {
+            Id = 1,
+            Name = "Existing"
+        },
+        new EvaluationEntity
+        {
+            Id = 2,
+            Name = "Another"
         }
+        ]);
+
+        CreateRepository();
+
+        // Act
+        var result = await _repository!.GetByNameForUpdateAsync(2, "Existing");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Id);
+        Assert.Equal("Existing", result.Name);
+    }
+
+    [Fact]
+    public async Task GetByNameForUpdateAsync_DoesNotReturnSameEvaluationAsync()
+    {
+        // Arrange
+        SetupEvaluations(
+        [
+            new EvaluationEntity
+            {
+                Id = 1,
+                Name = "Existing"
+            }
+        ]);
+
+        CreateRepository();
+
+        // Act
+        var result = await _repository!.GetByNameForUpdateAsync(1, "Existing");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByNameForUpdateAsync_WhenNameDoesNotExist_ReturnsNullAsync()
+    {
+        // Arrange
+        SetupEvaluations(
+        [
+            new EvaluationEntity
+        {
+            Id = 1,
+            Name = "Existing"
+        }
+        ]);
+
+        CreateRepository();
+
+        // Act
+        var result = await _repository!.GetByNameForUpdateAsync(1, "DoesNotExist");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetStatusById_WhenEvaluationExists_ReturnsEvaluationAsync()
+    {
+        // Arrange
+        SetupEvaluations(
+        [
+            new EvaluationEntity
+            {
+                Id = 10,
+                Name = "Evaluation",
+                Status = "Completed",
+                PollName = "Poll",
+                Country = "Bolivia",
+                ConfigurationId = 5
+            }
+        ]);
+        CreateRepository();
+
+        // Act
+        var result = await _repository!.GetStatusById(10);
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Equal(10, result.Id);
+        Assert.Equal("Evaluation", result.Name);
+        Assert.Equal("Completed", result.Status);
+        Assert.Equal("Poll", result.PollName);
+        Assert.Equal("Bolivia", result.Country);
+        Assert.Equal(5, result.ConfigurationId);
+    }
+
+    [Fact]
+    public async Task GetStatusById_WhenEvaluationDoesNotExist_ReturnsNullAsync()
+    {
+        // Arrange
+        SetupEvaluations(
+        [
+            new EvaluationEntity
+            {
+                Id = 10,
+                Name = "Evaluation"
+            }
+        ]);
+        CreateRepository();
+
+        // Act
+        var result = await _repository!.GetStatusById(999);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WhenEvaluationDoesNotExist_ReturnsNullAsync()
+    {
+        // Arrange
+        SetupEvaluations(
+        [
+            new EvaluationEntity
+        {
+            Id = 1,
+            Name = "Evaluation"
+        }
+        ]);
+
+        var evaluationPolls = new List<EvaluationPollJoin>()
+            .AsQueryable()
+            .BuildMockDbSet();
+
+        var pollInstances = new List<PollInstanceEntity>()
+            .AsQueryable()
+            .BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.EvaluationPolls)
+            .Returns(evaluationPolls.Object);
+
+        _mockContext
+            .Setup(c => c.PollInstances)
+            .Returns(pollInstances.Object);
+
+        CreateRepository();
+
+        // Act
+        var result = await _repository!.GetByIdAsync(999);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WhenEvaluationExists_ReturnsEvaluationAsync()
+    {
+        // Arrange
+        var poll = new PollEntity
+        {
+            Uuid = "poll-1"
+        };
+
+        var evaluation = new EvaluationEntity
+        {
+            Id = 1,
+            Name = "Evaluation",
+            Status = "Completed"
+        };
+
+        SetupEvaluations([evaluation]);
+
+        var evaluationPolls = new List<EvaluationPollJoin>
+        {
+            new()
+            {
+                EvaluationId = 1,
+                Poll = poll
+            }
+        }
+        .AsQueryable()
+        .BuildMockDbSet();
+
+        var pollInstances = new List<PollInstanceEntity>
+        {
+            new()
+            {
+                Uuid = "poll-1"
+            },
+            new()
+            {
+                Uuid = "other-poll"
+            }
+        }
+        .AsQueryable()
+        .BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.EvaluationPolls)
+            .Returns(evaluationPolls.Object);
+
+        _mockContext
+            .Setup(c => c.PollInstances)
+            .Returns(pollInstances.Object);
+
+        CreateRepository();
+
+        // Act
+        var result = await _repository!.GetByIdAsync(1);
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Equal(1, result.Id);
+        Assert.Equal("Evaluation", result.Name);
+        Assert.Equal("Completed", result.Status);
+
+        Assert.Single(result.Polls);
+        Assert.Equal("poll-1", result.Polls.First().Uuid);
+
+        Assert.Single(result.PollInstances);
+        Assert.Equal("poll-1", result.PollInstances.First().Uuid);
+    }
+
+    [Fact]
+    public async Task GetByDateRange_ReturnsEvaluationsWithinDateRangeAsync()
+    {
+        // Arrange
+        var startDate = new DateTime(2026, 1, 1);
+        var endDate = new DateTime(2026, 1, 31);
+
+        SetupEvaluations(
+        [
+            new EvaluationEntity
+        {
+            Id = 1,
+            Name = "Inside",
+            StartDate = new DateTime(2026, 1, 10)
+        },
+        new EvaluationEntity
+        {
+            Id = 2,
+            Name = "Outside",
+            StartDate = new DateTime(2026, 2, 10)
+        }
+        ]);
+
+        var evaluationPolls = new List<EvaluationPollJoin>()
+            .AsQueryable()
+            .BuildMockDbSet();
+
+        var pollInstances = new List<PollInstanceEntity>()
+            .AsQueryable()
+            .BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.EvaluationPolls)
+            .Returns(evaluationPolls.Object);
+
+        _mockContext
+            .Setup(c => c.PollInstances)
+            .Returns(pollInstances.Object);
+
+        CreateRepository();
+
+        // Act
+        var result = await _repository!.GetByDateRange(startDate, endDate);
+
+        // Assert
+        var evaluation = Assert.Single(result);
+
+        Assert.Equal(1, evaluation.Id);
+        Assert.Equal("Inside", evaluation.Name);
+    }
+
+    [Fact]
+    public async Task GetByDateRange_IncludesBoundaryDatesAsync()
+    {
+        // Arrange
+        var startDate = new DateTime(2026, 1, 1);
+        var endDate = new DateTime(2026, 1, 31);
+
+        SetupEvaluations(
+        [
+            new EvaluationEntity
+        {
+            Id = 1,
+            Name = "Start",
+            StartDate = startDate
+        },
+        new EvaluationEntity
+        {
+            Id = 2,
+            Name = "End",
+            StartDate = endDate
+        }
+        ]);
+
+        var evaluationPolls = new List<EvaluationPollJoin>()
+            .AsQueryable()
+            .BuildMockDbSet();
+
+        var pollInstances = new List<PollInstanceEntity>()
+            .AsQueryable()
+            .BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.EvaluationPolls)
+            .Returns(evaluationPolls.Object);
+
+        _mockContext
+            .Setup(c => c.PollInstances)
+            .Returns(pollInstances.Object);
+
+        CreateRepository();
+
+        // Act
+        var result = await _repository!.GetByDateRange(startDate, endDate);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public async Task GetByDateRange_WhenNoEvaluationsMatch_ReturnsEmptyAsync()
+    {
+        // Arrange
+        SetupEvaluations(
+        [
+            new EvaluationEntity
+            {
+                Id = 1,
+                Name = "Evaluation",
+                StartDate = new DateTime(2026, 3, 1)
+            }
+        ]);
+
+        var evaluationPolls = new List<EvaluationPollJoin>()
+            .AsQueryable()
+            .BuildMockDbSet();
+
+        var pollInstances = new List<PollInstanceEntity>()
+            .AsQueryable()
+            .BuildMockDbSet();
+
+        _mockContext
+            .Setup(c => c.EvaluationPolls)
+            .Returns(evaluationPolls.Object);
+
+        _mockContext
+            .Setup(c => c.PollInstances)
+            .Returns(pollInstances.Object);
+
+        CreateRepository();
+
+        // Act
+        var result = await _repository!.GetByDateRange(
+            new DateTime(2026, 1, 1),
+            new DateTime(2026, 1, 31));
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task CountByDateRangeAsync_ReturnsNumberOfEvaluationsInRangeAsync()
+    {
+        // Arrange
+        SetupEvaluations(
+        [
+            new EvaluationEntity
+            {
+                Id = 1,
+                StartDate = new DateTime(2026, 1, 10)
+            },
+            new EvaluationEntity
+            {
+                Id = 2,
+                StartDate = new DateTime(2026, 1, 20)
+            },
+            new EvaluationEntity
+            {
+                Id = 3,
+                StartDate = new DateTime(2026, 2, 10)
+            }
+        ]);
+        CreateRepository();
+
+        // Act
+        var result = await _repository!.CountByDateRangeAsync(
+            new DateTime(2026, 1, 1),
+            new DateTime(2026, 1, 31));
+
+        // Assert
+        Assert.Equal(2, result);
+    }
+
+    [Fact]
+    public async Task CountByDateRangeAsync_WhenNoEvaluationsMatch_ReturnsZeroAsync()
+    {
+        // Arrange
+        SetupEvaluations(
+        [
+            new EvaluationEntity
+            {
+                Id = 1,
+                StartDate = new DateTime(2026, 3, 10)
+            }
+        ]);
+
+        CreateRepository();
+
+        // Act
+        var result = await _repository!.CountByDateRangeAsync(
+            new DateTime(2026, 1, 1),
+            new DateTime(2026, 1, 31));
+
+        // Assert
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task GetExpiredWithPendingStatusAsync_ReturnsMatchingStatusesBeforeDateAsync()
+    {
+        // Arrange
+        var endDateBefore = new DateTime(2026, 2, 1);
+        var evaluations = new List<EvaluationEntity>
+        {
+            new()
+            {
+                Id = 1,
+                Name = "Expired Pending",
+                Status = "Pending",
+                EndDate = new DateTime(2026, 1, 10)
+            },
+            new()
+            {
+                Id = 2,
+                Name = "Expired Completed",
+                Status = "Completed",
+                EndDate = new DateTime(2026, 1, 15)
+            },
+            new()
+            {
+                Id = 3,
+                Name = "Not Expired",
+                Status = "Pending",
+                EndDate = new DateTime(2026, 3, 10)
+            },
+            new()
+            {
+                Id = 4,
+                Name = "Wrong Status",
+                Status = "Cancelled",
+                EndDate = new DateTime(2026, 1, 10)
+            }
+        };
+        SetupEvaluations(evaluations);
+        CreateRepository();
+
+        // Act
+        var result = (await _repository!
+            .GetExpiredWithPendingStatusAsync(["Pending", "Completed"], endDateBefore))
+            .ToList();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, e => e.Id == 1);
+        Assert.Contains(result, e => e.Id == 2);
+        Assert.DoesNotContain(result, e => e.Id == 3);
+        Assert.DoesNotContain(result, e => e.Id == 4);
+    }
+
+    [Fact]
+    public async Task GetExpiredWithPendingStatusAsync_WhenNothingMatches_ReturnsEmptyAsync()
+    {
+        // Arrange
+        SetupEvaluations(
+        [
+            new EvaluationEntity
+            {
+                Id = 1,
+                Name = "Evaluation",
+                Status = "Completed",
+                EndDate = new DateTime(2026, 3, 1)
+            }
+        ]);
+        CreateRepository();
+
+        // Act
+        var result = await _repository!
+            .GetExpiredWithPendingStatusAsync(["Pending"], new DateTime(2026, 1, 1));
+
+        // Assert
+        Assert.Empty(result);
     }
 }

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/EvaluationRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/EvaluationRepositoryTest.cs
@@ -24,14 +24,14 @@ public class EvaluationRepositoryTest
             new DbContextOptions<AppDbContext>());
     }
 
-    private void SetupEvaluations(IEnumerable<EvaluationEntity> evaluations)
+    private void SetupEvaluations(IEnumerable<EvaluationEntity> Evaluations)
     {
-        var data = evaluations
+        var data = Evaluations
             .AsQueryable()
             .BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.Evaluations)
+            .Setup(C => C.Evaluations)
             .Returns(data.Object);
     }
 
@@ -136,7 +136,7 @@ public class EvaluationRepositoryTest
     }
 
     [Fact]
-    public async Task GetPagedAsync_ReturnsEvaluationsOrderedByName()
+    public async Task GetPagedAsync_ReturnsEvaluationsOrderedByNameAsync()
     {
         // Arrange
         var poll1 = new PollEntity
@@ -396,11 +396,11 @@ public class EvaluationRepositoryTest
             .BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.EvaluationPolls)
+            .Setup(C => C.EvaluationPolls)
             .Returns(evaluationPolls.Object);
 
         _mockContext
-            .Setup(c => c.PollInstances)
+            .Setup(C => C.PollInstances)
             .Returns(pollInstances.Object);
 
         CreateRepository();
@@ -456,11 +456,11 @@ public class EvaluationRepositoryTest
         .BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.EvaluationPolls)
+            .Setup(C => C.EvaluationPolls)
             .Returns(evaluationPolls.Object);
 
         _mockContext
-            .Setup(c => c.PollInstances)
+            .Setup(C => C.PollInstances)
             .Returns(pollInstances.Object);
 
         CreateRepository();
@@ -478,8 +478,8 @@ public class EvaluationRepositoryTest
         Assert.Single(result.Polls);
         Assert.Equal("poll-1", result.Polls.First().Uuid);
 
-        Assert.Single(result.PollInstances);
-        Assert.Equal("poll-1", result.PollInstances.First().Uuid);
+        Assert.Single(result.PollInstances!);
+        Assert.Equal("poll-1", result.PollInstances!.First().Uuid);
     }
 
     [Fact]
@@ -514,11 +514,11 @@ public class EvaluationRepositoryTest
             .BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.EvaluationPolls)
+            .Setup(C => C.EvaluationPolls)
             .Returns(evaluationPolls.Object);
 
         _mockContext
-            .Setup(c => c.PollInstances)
+            .Setup(C => C.PollInstances)
             .Returns(pollInstances.Object);
 
         CreateRepository();
@@ -565,11 +565,11 @@ public class EvaluationRepositoryTest
             .BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.EvaluationPolls)
+            .Setup(C => C.EvaluationPolls)
             .Returns(evaluationPolls.Object);
 
         _mockContext
-            .Setup(c => c.PollInstances)
+            .Setup(C => C.PollInstances)
             .Returns(pollInstances.Object);
 
         CreateRepository();
@@ -604,11 +604,11 @@ public class EvaluationRepositoryTest
             .BuildMockDbSet();
 
         _mockContext
-            .Setup(c => c.EvaluationPolls)
+            .Setup(C => C.EvaluationPolls)
             .Returns(evaluationPolls.Object);
 
         _mockContext
-            .Setup(c => c.PollInstances)
+            .Setup(C => C.PollInstances)
             .Returns(pollInstances.Object);
 
         CreateRepository();
@@ -725,10 +725,10 @@ public class EvaluationRepositoryTest
 
         // Assert
         Assert.Equal(2, result.Count);
-        Assert.Contains(result, e => e.Id == 1);
-        Assert.Contains(result, e => e.Id == 2);
-        Assert.DoesNotContain(result, e => e.Id == 3);
-        Assert.DoesNotContain(result, e => e.Id == 4);
+        Assert.Contains(result, E => E.Id == 1);
+        Assert.Contains(result, E => E.Id == 2);
+        Assert.DoesNotContain(result, E => E.Id == 3);
+        Assert.DoesNotContain(result, E => E.Id == 4);
     }
 
     [Fact]

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/EvaluationRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/EvaluationRepositoryTest.cs
@@ -3,15 +3,18 @@ using Eras.Infrastructure.Persistence.PostgreSQL;
 using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Joins;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
+
 using Microsoft.EntityFrameworkCore;
+
 using MockQueryable.Moq;
+
 using Moq;
 
 using Xunit;
-
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
 
-public class EvaluationRepositoryTest
+public class EvaluationRepositoryTest : RepositoryTestBase
 {
     private Mock<DbSet<EvaluationEntity>> _mockSet;
     protected Mock<AppDbContext> _mockContext;

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/FeatureFlagRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/FeatureFlagRepositoryTest.cs
@@ -1,0 +1,131 @@
+﻿using Eras.Application.Contracts.Persistence;
+using Eras.Domain.Entities.FeatureFlagManagement;
+using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using MockQueryable.Moq;
+
+using Moq;
+
+using Xunit;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+
+public class FeatureFlagRepositoryTest
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_WhenFeatureFlagExists_ReturnsFeatureFlagAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        context.FeatureFlags.AddRange(
+            new FeatureFlag
+            {
+                Id = 1,
+                Name = "FeatureA"
+            },
+            new FeatureFlag
+            {
+                Id = 2,
+                Name = "FeatureB"
+            });
+        await context.SaveChangesAsync();
+        var repository = new FeatureFlagRepository(context);
+
+        // Act
+        var result = await repository.GetByNameAsync("FeatureA");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Id);
+        Assert.Equal("FeatureA", result.Name);
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_WhenFeatureFlagDoesNotExist_ReturnsNullAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        context.FeatureFlags.Add(
+            new FeatureFlag
+            {
+                Id = 1,
+                Name = "FeatureA"
+            });
+
+        await context.SaveChangesAsync();
+        var repository = new FeatureFlagRepository(context);
+
+        // Act
+        var result = await repository.GetByNameAsync("DoesNotExist");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByIdNoTrackingAsync_WhenFeatureFlagExists_ReturnsFeatureFlagAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        context.FeatureFlags.AddRange(
+            new FeatureFlag
+            {
+                Id = 1,
+                Name = "FeatureA"
+            },
+            new FeatureFlag
+            {
+                Id = 2,
+                Name = "FeatureB"
+            });
+
+        await context.SaveChangesAsync();
+        var repository = new FeatureFlagRepository(context);
+
+        // Act
+        var result = await repository.GetByIdNoTrackingAsync(2);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Id);
+        Assert.Equal("FeatureB", result.Name);
+    }
+
+    [Fact]
+    public async Task GetByIdNoTrackingAsync_WhenFeatureFlagDoesNotExist_ReturnsNullAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        context.FeatureFlags.Add(
+            new FeatureFlag
+            {
+                Id = 1,
+                Name = "FeatureA"
+            });
+
+        await context.SaveChangesAsync();
+        var repository = new FeatureFlagRepository(context);
+
+        // Act
+        var result = await repository.GetByIdNoTrackingAsync(999);
+
+        // Assert
+        Assert.Null(result);
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/FeatureFlagRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/FeatureFlagRepositoryTest.cs
@@ -2,6 +2,7 @@
 using Eras.Domain.Entities.FeatureFlagManagement;
 using Eras.Infrastructure.Persistence.PostgreSQL;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -13,16 +14,8 @@ using Xunit;
 
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
 
-public class FeatureFlagRepositoryTest
+public class FeatureFlagRepositoryTest : RepositoryTestBase
 {
-    private static AppDbContext CreateContext()
-    {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        return new AppDbContext(options);
-    }
 
     [Fact]
     public async Task GetByNameAsync_WhenFeatureFlagExists_ReturnsFeatureFlagAsync()

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/HeatMapRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/HeatMapRepositoryTest.cs
@@ -12,7 +12,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
     public class HeatMapRepositoryTest
     {
         private readonly Mock<AppDbContext> _mockContext;
-        private readonly HeatMapRespository _repository;
+        private readonly HeatMapRepository _repository;
 
         public HeatMapRepositoryTest()
         {
@@ -20,7 +20,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
                 .UseInMemoryDatabase(databaseName: "HeatMapTest")
                 .Options;
             _mockContext = new Mock<AppDbContext>(options);
-            _repository = new HeatMapRespository(_mockContext.Object);
+            _repository = new HeatMapRepository(_mockContext.Object);
 
             SeedData();
         }
@@ -35,7 +35,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
 
             var variables = new List<VariableEntity>
             {
-                new VariableEntity { Id = 1, ComponentId = 1 }
+                new VariableEntity { Id = 1, ComponentId = 1, Name = "Variable1"}
             }.AsQueryable().BuildMockDbSet();
 
             var components = new List<ComponentEntity>
@@ -66,6 +66,12 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
                 new CohortEntity { Id = 2, Name = "Cohort2", CourseCode = "Course2" }
             }.AsQueryable().BuildMockDbSet();
 
+            var students = new List<StudentEntity> 
+            { 
+                new StudentEntity { Id = 1 },
+                new StudentEntity { Id = 2 }
+            }.AsQueryable().BuildMockDbSet();
+
             _mockContext.Setup(C => C.PollInstances).Returns(pollInstances.Object);
             _mockContext.Setup(C => C.Variables).Returns(variables.Object);
             _mockContext.Setup(C => C.Components).Returns(components.Object);
@@ -73,6 +79,8 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
             _mockContext.Setup(C => C.Answers).Returns(answers.Object);
             _mockContext.Setup(C => C.StudentCohorts).Returns(studentCohorts.Object);
             _mockContext.Setup(C => C.Cohorts).Returns(cohorts.Object);
+            _mockContext.Setup(C => C.PollVariables).Returns(pollVariableJoins.Object);
+            _mockContext.Setup(C => C.Students).Returns(students.Object);
         }
 
         [Fact]
@@ -120,5 +128,158 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
             Assert.NotNull(result);
             Assert.Equal(2, result.Count());
         }
+
+        [Fact]
+        public async Task GetHeatMapDataByComponentsShouldReturnDataAsync()
+        {
+            // Act
+            var result = await _repository.GetHeatMapDataByComponentsAsync("uuid1");
+
+            // Assert
+            Assert.NotNull(result);
+            var item = Assert.Single(result);
+
+            Assert.Equal(1, item.ComponentId);
+            Assert.Equal("Component1", item.ComponentName);
+            Assert.Equal(1, item.VariableId);
+            Assert.Equal("Answer1", item.AnswerText);
+            Assert.Equal(1, item.AnswerRiskLevel);
+        }
+
+        [Fact]
+        public async Task GetHeatMapDataByComponentsShouldReturnEmptyWhenPollUuidDoesNotExistAsync()
+        {
+            // Act
+            var result = await _repository.GetHeatMapDataByComponentsAsync("unknown-uuid");
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task GetHeatMapDataByCohortAndDaysShouldReturnAllDataWhenCohortIdIsNullAsync()
+        {
+            // Act
+            var result = await _repository.GetHeatMapDataByCohortAndDaysAsync(null, 0);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count());
+        }
+
+        [Fact]
+        public async Task GetHeatMapDataByCohortAndDaysShouldReturnAllDataWhenDaysIsNullAsync()
+        {
+            // Act
+            var result = await _repository.GetHeatMapDataByCohortAndDaysAsync(0, null);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count());
+        }
+
+        [Fact]
+        public async Task GetHeatMapDataByCohortAndDaysShouldReturnDataWhenCohortIdAndDaysAreNullAsync()
+        {
+            // Act
+            var result = await _repository.GetHeatMapDataByCohortAndDaysAsync(null, null);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count());
+        }
+
+        [Fact]
+        public async Task GetPollInstancesByCohortIdAndLastDaysShouldReturnAllInstancesWhenFiltersAreNotProvidedAsync()
+        {
+            // Act
+            var result = await _repository.GetPollInstancesByCohortIdAndLastDaysAsync(null, null);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count());
+        }
+
+        [Fact]
+        public async Task GetPollInstancesByCohortIdAndLastDaysShouldFilterByCohortAsync()
+        {
+            // Act
+            var result = await _repository.GetPollInstancesByCohortIdAndLastDaysAsync(1, null);
+
+            // Assert
+            Assert.NotNull(result);
+            var item = Assert.Single(result);
+
+            Assert.Equal(1, item.Id);
+            Assert.Equal("uuid1", item.Uuid);
+        }
+
+        [Fact]
+        public async Task GetPollInstancesByCohortIdAndLastDaysShouldFilterByDaysAsync()
+        {
+            // Act
+            var result = await _repository.GetPollInstancesByCohortIdAndLastDaysAsync(null, 7);
+
+            // Assert
+            Assert.NotNull(result);
+            var item = Assert.Single(result);
+
+            Assert.Equal(1, item.Id);
+            Assert.Equal("uuid1", item.Uuid);
+        }
+
+        [Fact]
+        public async Task GetHeatMapByPollUuidAndVariableIdsShouldReturnHeatMapDataAsync()
+        {
+            // Act
+            var result = await _repository.GetHeatMapByPollUuidAndVariableIds("uuid1", new List<int> { 1 });
+
+            // Assert
+            Assert.NotNull(result);
+            var heatMap = Assert.Single(result);
+            Assert.Equal("Variable1", heatMap.Name);
+            var serie = Assert.Single(heatMap.Data);
+
+            Assert.Equal("Answer1", serie.X);
+            Assert.Equal(1, serie.Y);
+            Assert.Equal(1, serie.Count);
+        }
+
+        [Fact]
+        public async Task GetHeatMapByPollUuidAndVariableIdsShouldReturnEmptyWhenVariableDoesNotExistAsync()
+        {
+            // Act
+            var result = await _repository.GetHeatMapByPollUuidAndVariableIds("uuid1", new List<int> { 999 });
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task GetHeatMapByPollUuidAndVariableIdsShouldReturnEmptyWhenPollUuidDoesNotExistAsync()
+        {
+            // Act
+            var result = await _repository.GetHeatMapByPollUuidAndVariableIds("unknown-uuid", new List<int> { 1 });
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Empty(result);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public async Task GetHeatMapAnswersPercentageByVariableShouldThrowWhenPollUuidIsInvalidAsync(string PollUuid)
+        {
+            var exception = await Assert.ThrowsAsync<ArgumentException>(
+                () => _repository.GetHeatMapAnswersPercentageByVariableAsync(PollUuid));
+
+            Assert.Equal("PollUUID", exception.ParamName);
+            Assert.Equal("The Poll UUID can't be null or empty. (Parameter 'PollUUID')",exception.Message);
+        }
+
     }
 }

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/HeatMapRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/HeatMapRepositoryTest.cs
@@ -1,15 +1,19 @@
 ﻿
+using Eras.Infrastructure.Persistence.PostgreSQL;
 using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Joins;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
-using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
+
 using Microsoft.EntityFrameworkCore;
-using Moq;
+
 using MockQueryable.Moq;
+
+using Moq;
 
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
 {
-    public class HeatMapRepositoryTest
+    public class HeatMapRepositoryTest : RepositoryTestBase
     {
         private readonly Mock<AppDbContext> _mockContext;
         private readonly HeatMapRepository _repository;

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ImportJobItemRepositoryTests.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ImportJobItemRepositoryTests.cs
@@ -2,6 +2,7 @@
 using Eras.Infrastructure.Persistence.PostgreSQL;
 using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -9,18 +10,14 @@ using Xunit;
 
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
 
-public class ImportJobItemRepositoryTests
+public class ImportJobItemRepositoryTests : RepositoryTestBase
 {
     private readonly AppDbContext _context;
     private readonly ImportJobItemRepository _repository;
 
     public ImportJobItemRepositoryTests()
     {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _context = new AppDbContext(options);
+        _context = CreateContext();
         _repository = new ImportJobItemRepository(_context);
 
         SeedData();

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ImportJobItemRepositoryTests.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ImportJobItemRepositoryTests.cs
@@ -1,0 +1,255 @@
+﻿using Eras.Domain.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Xunit;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+
+public class ImportJobItemRepositoryTests
+{
+    private readonly AppDbContext _context;
+    private readonly ImportJobItemRepository _repository;
+
+    public ImportJobItemRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new AppDbContext(options);
+        _repository = new ImportJobItemRepository(_context);
+
+        SeedData();
+    }
+
+    private void SeedData()
+    {
+        var items = new List<ImportJobItemEntity>
+        {
+            new ImportJobItemEntity
+            {
+                Id = 1,
+                ImportJobId = 100,
+                Status = ImportJobStatus.Extracted,
+                ErrorMessage = null,
+                RetryCount = 0,
+                UpdatedAtUtc = DateTime.UtcNow.AddMinutes(-5)
+            },
+            new ImportJobItemEntity
+            {
+                Id = 2,
+                ImportJobId = 100,
+                Status = ImportJobStatus.Queued,
+                ErrorMessage = null,
+                RetryCount = 0,
+                UpdatedAtUtc = DateTime.UtcNow.AddMinutes(-4)
+            },
+            new ImportJobItemEntity
+            {
+                Id = 3,
+                ImportJobId = 100,
+                Status = ImportJobStatus.Running,
+                ErrorMessage = null,
+                RetryCount = 0,
+                UpdatedAtUtc = DateTime.UtcNow.AddMinutes(-3)
+            },
+            new ImportJobItemEntity
+            {
+                Id = 4,
+                ImportJobId = 100,
+                Status = ImportJobStatus.Completed,
+                ErrorMessage = null,
+                RetryCount = 0,
+                UpdatedAtUtc = DateTime.UtcNow.AddMinutes(-2)
+            },
+            new ImportJobItemEntity
+            {
+                Id = 5,
+                ImportJobId = 100,
+                Status = ImportJobStatus.Failed,
+                ErrorMessage = "Import failed",
+                RetryCount = 1,
+                UpdatedAtUtc = DateTime.UtcNow.AddMinutes(-1)
+            },
+
+            new ImportJobItemEntity
+            {
+                Id = 6,
+                ImportJobId = 200,
+                Status = ImportJobStatus.Extracted,
+                ErrorMessage = null,
+                RetryCount = 0,
+                UpdatedAtUtc = DateTime.UtcNow
+            },
+
+            new ImportJobItemEntity
+            {
+                Id = 7,
+                ImportJobId = 100,
+                Status = ImportJobStatus.Failed,
+                ErrorMessage = "Another failure",
+                RetryCount = 3,
+                UpdatedAtUtc = DateTime.UtcNow.AddMinutes(-10)
+            }
+        };
+
+        _context.Set<ImportJobItemEntity>().AddRange(items);
+        _context.SaveChanges();
+    }
+
+    [Fact]
+    public async Task GetByJobIdAsyncShouldReturnItemsForJobAsync()
+    {
+        // Act
+        var result = await _repository.GetByJobIdAsync(100);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(6, result.Count);
+
+        Assert.All(result, Item => Assert.Equal(100, Item.ImportJobId));
+    }
+
+    [Fact]
+    public async Task GetByJobIdAsyncShouldOrderItemsByIdAsync()
+    {
+        // Act
+        var result = await _repository.GetByJobIdAsync(100);
+
+        // Assert
+        Assert.Equal(new[] { 1, 2, 3, 4, 5, 7 }, result.Select(Item => Item.Id));
+    }
+
+    [Fact]
+    public async Task GetByJobIdAsyncShouldReturnEmptyWhenJobDoesNotExistAsync()
+    {
+        // Act
+        var result = await _repository.GetByJobIdAsync(999);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetByJobIdAndStatusAsyncShouldReturnItemsWithRequestedStatusAsync()
+    {
+        // Act
+        var result = await _repository.GetByJobIdAndStatusAsync(100, ImportJobStatus.Failed);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Equal(new[] { 5, 7 }, result.Select(Item => Item.Id));
+
+        Assert.All(result, Item => Assert.Equal(ImportJobStatus.Failed, Item.Status));
+    }
+
+    [Fact]
+    public async Task GetByJobIdAndStatusAsyncShouldReturnEmptyWhenStatusDoesNotMatchAsync()
+    {
+        // Act
+        var result = await _repository.GetByJobIdAndStatusAsync(100, ImportJobStatus.Skipped);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetByJobIdAndStatusAsyncShouldNotReturnItemsFromAnotherJobAsync()
+    {
+        // Act
+        var result = await _repository.GetByJobIdAndStatusAsync(200, ImportJobStatus.Extracted);
+
+        // Assert
+        var item = Assert.Single(result);
+        Assert.Equal(6, item.Id);
+        Assert.Equal(200, item.ImportJobId);
+        Assert.Equal(ImportJobStatus.Extracted, item.Status);
+    }
+
+    [Fact]
+    public async Task GetByIdsAsyncShouldReturnMatchingItemsAsync()
+    {
+        // Act
+        var result = await _repository.GetByIdsAsync(100, new List<int> { 1, 3, 5 });
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        Assert.Equal(new[] { 1, 3, 5 }, result.Select(Item => Item.Id).OrderBy(Id => Id));
+    }
+
+    [Fact]
+    public async Task GetByIdsAsyncShouldOnlyReturnItemsFromRequestedJobAsync()
+    {
+        // Act
+        var result = await _repository.GetByIdsAsync(100, new List<int> { 1, 6 });
+
+        // Assert
+        var item = Assert.Single(result);
+        Assert.Equal(1, item.Id);
+        Assert.Equal(100, item.ImportJobId);
+    }
+
+    [Fact]
+    public async Task GetByIdsAsyncShouldReturnEmptyWhenIdsAreEmptyAsync()
+    {
+        // Act
+        var result = await _repository.GetByIdsAsync(100, new List<int>());
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetByIdsAsyncShouldReturnEmptyWhenNoIdsMatchAsync()
+    {
+        // Act
+        var result = await _repository.GetByIdsAsync(100, new List<int> { 999, 1000 });
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetImportPhaseCountsAsyncShouldReturnCorrectCountsAsync()
+    {
+        // Act
+        var result = await _repository.GetImportPhaseCountsAsync(100);
+
+        // Assert
+        Assert.Equal(2, result.Pending);
+        Assert.Equal(1, result.Completed);
+        Assert.Equal(2, result.Failed);
+    }
+
+    [Fact]
+    public async Task GetImportPhaseCountsAsyncShouldReturnZerosWhenJobDoesNotExistAsync()
+    {
+        // Act
+        var result = await _repository.GetImportPhaseCountsAsync(999);
+
+        // Assert
+        Assert.Equal(0, result.Pending);
+        Assert.Equal(0, result.Completed);
+        Assert.Equal(0, result.Failed);
+    }
+
+    [Fact]
+    public async Task GetImportPhaseCountsAsyncShouldNotCountItemsFromAnotherJobAsync()
+    {
+        // Act
+        var result = await _repository.GetImportPhaseCountsAsync(200);
+
+        // Assert
+        Assert.Equal(0, result.Pending);
+        Assert.Equal(0, result.Completed);
+        Assert.Equal(0, result.Failed);
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ImportJobRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ImportJobRepositoryTest.cs
@@ -2,26 +2,18 @@
 using Eras.Infrastructure.Persistence.PostgreSQL;
 using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
 
 using Microsoft.EntityFrameworkCore;
 
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
 
-public class ImportJobRepositoryTest
+public class ImportJobRepositoryTest : RepositoryTestBase
 {
-    private static AppDbContext BuildContext()
-    {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        return new AppDbContext(options);
-    }
-
     [Fact]
     public async Task GetLatestImportJobIdsByEvaluationIdsAsync_ShouldReturnLatestJobPerEvaluationAsync()
     {
-        using var context = BuildContext();
+        using var context = CreateContext();
 
         var baseTime = DateTime.UtcNow;
 
@@ -81,7 +73,7 @@ public class ImportJobRepositoryTest
     [Fact]
     public async Task GetLatestImportJobIdsByEvaluationIdsAsync_ShouldIgnoreOtherEvaluationsAsync()
     {
-        using var context = BuildContext();
+        using var context = CreateContext();
 
         var baseTime = DateTime.UtcNow;
 
@@ -114,7 +106,7 @@ public class ImportJobRepositoryTest
     [Fact]
     public async Task GetLatestImportJobIdsByEvaluationIdsAsync_ShouldReturnEmpty_WhenNoEvaluationMatchesAsync()
     {
-        using var context = BuildContext();
+        using var context = CreateContext();
 
         context.ImportJobs.Add(new ImportJobEntity
         {
@@ -136,7 +128,7 @@ public class ImportJobRepositoryTest
     [Fact]
     public async Task GetLatestImportJobIdsByEvaluationIdsAsync_ShouldReturnEmpty_WhenInputIsEmptyAsync()
     {
-        using var context = BuildContext();
+        using var context = CreateContext();
 
         context.ImportJobs.Add(new ImportJobEntity
         {

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ImportJobRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ImportJobRepositoryTest.cs
@@ -1,0 +1,157 @@
+﻿using Eras.Domain.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+
+public class ImportJobRepositoryTest
+{
+    private static AppDbContext BuildContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    [Fact]
+    public async Task GetLatestImportJobIdsByEvaluationIdsAsync_ShouldReturnLatestJobPerEvaluationAsync()
+    {
+        using var context = BuildContext();
+
+        var baseTime = DateTime.UtcNow;
+
+        context.ImportJobs.AddRange(
+            new ImportJobEntity
+            {
+                Id = 1,
+                EvaluationId = 10,
+                CreatedAtUtc = baseTime.AddMinutes(-30)
+            },
+            new ImportJobEntity
+            {
+                Id = 2,
+                EvaluationId = 10,
+                CreatedAtUtc = baseTime.AddMinutes(-10)
+            },
+            new ImportJobEntity
+            {
+                Id = 3,
+                EvaluationId = 10,
+                CreatedAtUtc = baseTime.AddMinutes(-20)
+            },
+            new ImportJobEntity
+            {
+                Id = 4,
+                EvaluationId = 20,
+                CreatedAtUtc = baseTime.AddMinutes(-30)
+            },
+            new ImportJobEntity
+            {
+                Id = 5,
+                EvaluationId = 20,
+                CreatedAtUtc = baseTime.AddMinutes(-5)
+            },
+            new ImportJobEntity
+            {
+                Id = 6,
+                EvaluationId = 30,
+                CreatedAtUtc = baseTime.AddMinutes(-1)
+            }
+        );
+
+        await context.SaveChangesAsync();
+
+        var repository = new ImportJobRepository(context);
+
+        var result = await repository.GetLatestImportJobIdsByEvaluationIdsAsync(
+            new[] { 10, 20, 30 });
+
+        Assert.Equal(3, result.Count);
+
+        Assert.Equal(2, result[10]);
+        Assert.Equal(5, result[20]);
+        Assert.Equal(6, result[30]);
+    }
+
+    [Fact]
+    public async Task GetLatestImportJobIdsByEvaluationIdsAsync_ShouldIgnoreOtherEvaluationsAsync()
+    {
+        using var context = BuildContext();
+
+        var baseTime = DateTime.UtcNow;
+
+        context.ImportJobs.AddRange(
+            new ImportJobEntity
+            {
+                Id = 1,
+                EvaluationId = 10,
+                CreatedAtUtc = baseTime
+            },
+            new ImportJobEntity
+            {
+                Id = 2,
+                EvaluationId = 20,
+                CreatedAtUtc = baseTime.AddMinutes(1)
+            });
+
+        await context.SaveChangesAsync();
+
+        var repository = new ImportJobRepository(context);
+
+        var result = await repository.GetLatestImportJobIdsByEvaluationIdsAsync(
+            new[] { 10 });
+
+        Assert.Single(result);
+        Assert.Equal(1, result[10]);
+        Assert.DoesNotContain(20, result.Keys);
+    }
+
+    [Fact]
+    public async Task GetLatestImportJobIdsByEvaluationIdsAsync_ShouldReturnEmpty_WhenNoEvaluationMatchesAsync()
+    {
+        using var context = BuildContext();
+
+        context.ImportJobs.Add(new ImportJobEntity
+        {
+            Id = 1,
+            EvaluationId = 10,
+            CreatedAtUtc = DateTime.UtcNow
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new ImportJobRepository(context);
+
+        var result = await repository.GetLatestImportJobIdsByEvaluationIdsAsync(
+            new[] { 999 });
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetLatestImportJobIdsByEvaluationIdsAsync_ShouldReturnEmpty_WhenInputIsEmptyAsync()
+    {
+        using var context = BuildContext();
+
+        context.ImportJobs.Add(new ImportJobEntity
+        {
+            Id = 1,
+            EvaluationId = 10,
+            CreatedAtUtc = DateTime.UtcNow
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new ImportJobRepository(context);
+
+        var result = await repository.GetLatestImportJobIdsByEvaluationIdsAsync(
+            Array.Empty<int>());
+
+        Assert.Empty(result);
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/JUInterventionRepositoryTests.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/JUInterventionRepositoryTests.cs
@@ -3,6 +3,7 @@ using Eras.Domain.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL;
 using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -10,17 +11,8 @@ using Xunit;
 
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
 
-public class InterventionRepositoryTests
+public class InterventionRepositoryTests : RepositoryTestBase
 {
-    private static AppDbContext CreateContext()
-    {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        return new AppDbContext(options);
-    }
-
     private static InterventionRepository CreateRepository(AppDbContext Context)
     {
         return new InterventionRepository(Context);

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/JUInterventionRepositoryTests.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/JUInterventionRepositoryTests.cs
@@ -1,0 +1,266 @@
+﻿using Eras.Domain.Common;
+using Eras.Domain.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Xunit;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+
+public class InterventionRepositoryTests
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    private static InterventionRepository CreateRepository(AppDbContext Context)
+    {
+        return new InterventionRepository(Context);
+    }
+
+    private static async Task SeedAsync(AppDbContext Context)
+    {
+        Context.JUInterventions.AddRange(
+            new JUInterventionEntity
+            {
+                Id = 1,
+                StudentId = 1,
+                Student = new StudentEntity()
+                {
+                    Email = "stu@mail.com",
+                    Name = "Test",
+                    Uuid = "123"
+                },
+                Audit = new AuditInfo()
+            },
+            new JUInterventionEntity
+            {
+                Id = 2,
+                Student = new StudentEntity()
+                {
+                    Email = "stu2@mail.com",
+                    Name = "Test2",
+                    Uuid = "1234"
+                },
+                StudentId = 2,
+                Audit = new AuditInfo()
+            },
+            new JUInterventionEntity
+            {
+                Id = 3,
+                StudentId = 3,
+                Student = new StudentEntity()
+                {
+                    Email = "stu3@mail.com",
+                    Name = "Test3",
+                    Uuid = "12345"
+                },
+                Audit = new AuditInfo()
+            }
+        );
+
+        await Context.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WhenInterventionsExist_ReturnsAllInterventionsAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedAsync(context);
+
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = (await repository.GetAllAsync()).ToList();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(3, result.Count);
+
+        Assert.Contains(result, X => X.Id == 1);
+        Assert.Contains(result, X => X.Id == 2);
+        Assert.Contains(result, X => X.Id == 3);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WhenNoInterventionsExist_ReturnsEmptyListAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = (await repository.GetAllAsync()).ToList();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetPagedAsync_ReturnsRequestedPageAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedAsync(context);
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = (await repository.GetPagedAsync(0, 2)).ToList();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+
+        Assert.Equal(1, result[0].Id);
+        Assert.Equal(2, result[1].Id);
+    }
+
+    [Fact]
+    public async Task GetPagedAsync_ReturnsSecondPageAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedAsync(context);
+
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = (await repository.GetPagedAsync(2, 2)).ToList();
+
+        // Assert
+        var intervention = Assert.Single(result);
+
+        Assert.Equal(3, intervention.Id);
+    }
+
+    [Fact]
+    public async Task GetPagedAsync_WhenPageIsOutsideRange_ReturnsEmptyAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedAsync(context);
+
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = (await repository.GetPagedAsync(10, 10)).ToList();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetPagedAsync_WhenNoInterventionsExist_ReturnsEmptyAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = (await repository.GetPagedAsync(1, 10)).ToList();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WhenInterventionExists_ReturnsInterventionAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedAsync(context);
+
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = await repository.GetByIdAsync(2);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Id);
+        Assert.Equal(2, result.StudentId);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WhenInterventionDoesNotExist_ReturnsNullAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedAsync(context);
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = await repository.GetByIdAsync(999);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WhenInterventionExists_UpdatesEntityAsync()
+    {
+        await using var context = CreateContext();
+        await SeedAsync(context);
+        var repository = CreateRepository(context);
+        var entity = await repository.GetByIdAsync(1);
+
+        Assert.NotNull(entity);
+
+        entity.StudentId = 99;
+
+        var result = await repository.UpdateAsync(entity);
+
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Id);
+        Assert.Equal(99, result.StudentId);
+
+        var updatedEntity = await context
+            .Set<JUInterventionEntity>()
+            .AsNoTracking()
+            .SingleAsync(X => X.Id == 1);
+
+        Assert.Equal(99, updatedEntity.StudentId);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WhenInterventionDoesNotExist_ReturnsInputWithoutSavingAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var repository = CreateRepository(context);
+
+        var entity = new JUIntervention
+        {
+            Id = 999,
+            StudentId = 100
+        };
+
+        // Act
+        var result = await repository.UpdateAsync(entity);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(999, result.Id);
+        Assert.Equal(100, result.StudentId);
+
+        var databaseEntity = await context
+            .Set<JUInterventionEntity>()
+            .FirstOrDefaultAsync(X => X.Id == 999);
+
+        Assert.Null(databaseEntity);
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/JUProfessionalRepositoryTests.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/JUProfessionalRepositoryTests.cs
@@ -2,6 +2,7 @@
 using Eras.Infrastructure.Persistence.PostgreSQL;
 using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -10,16 +11,8 @@ using Xunit;
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
 
 
-public class ProfessionalRepositoryTests
+public class ProfessionalRepositoryTests : RepositoryTestBase
 {
-    private static AppDbContext CreateContext()
-    {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        return new AppDbContext(options);
-    }
 
     private static ProfessionalRepository CreateRepository(AppDbContext Context)
     {

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/JUProfessionalRepositoryTests.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/JUProfessionalRepositoryTests.cs
@@ -1,0 +1,175 @@
+﻿using Eras.Domain.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Xunit;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+
+
+public class ProfessionalRepositoryTests
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    private static ProfessionalRepository CreateRepository(AppDbContext Context)
+    {
+        return new ProfessionalRepository(Context);
+    }
+
+    private static async Task SeedAsync(AppDbContext Context)
+    {
+        Context.Professionals.AddRange(
+            new JUProfessionalEntity
+            {
+                Id = 1
+            },
+            new JUProfessionalEntity
+            {
+                Id = 2
+            },
+            new JUProfessionalEntity
+            {
+                Id = 3
+            }
+        );
+
+        await Context.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WhenProfessionalsExist_ReturnsAllProfessionalsAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedAsync(context);
+
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = (await repository.GetAllAsync()).ToList();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(3, result.Count);
+
+        Assert.Contains(result, X => X.Id == 1);
+        Assert.Contains(result, X => X.Id == 2);
+        Assert.Contains(result, X => X.Id == 3);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WhenNoProfessionalsExist_ReturnsEmptyListAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = (await repository.GetAllAsync()).ToList();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WhenProfessionalExists_ReturnsProfessionalAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedAsync(context);
+
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = await repository.GetByIdAsync(2);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Id);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WhenProfessionalDoesNotExist_ReturnsNullAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedAsync(context);
+
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = await repository.GetByIdAsync(999);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WhenProfessionalExists_UpdatesEntityAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedAsync(context);
+
+        var repository = CreateRepository(context);
+
+        var entity = await repository.GetByIdAsync(1);
+
+        Assert.NotNull(entity);
+        entity.Name = "Updated Professional";
+
+        // Act
+        var result = await repository.UpdateAsync(entity);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Id);
+
+        var updatedEntity = await context
+            .Set<JUProfessionalEntity>()
+            .AsNoTracking()
+            .SingleAsync(X => X.Id == 1);
+
+        Assert.Equal(1, updatedEntity.Id);
+        Assert.Equal("Updated Professional", updatedEntity.Name);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WhenProfessionalDoesNotExist_ReturnsInputWithoutCreatingEntityAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var repository = CreateRepository(context);
+
+        var entity = new JUProfessional
+        {
+            Id = 999
+        };
+
+        // Act
+        var result = await repository.UpdateAsync(entity);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(999, result.Id);
+
+        var databaseEntity = await context
+            .Set<JUProfessionalEntity>()
+            .FirstOrDefaultAsync(X => X.Id == 999);
+
+        Assert.Null(databaseEntity);
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/JUServiceRepositoryTests.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/JUServiceRepositoryTests.cs
@@ -1,0 +1,136 @@
+﻿using Eras.Domain.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Xunit;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+
+
+public class JUServiceRepositoryTests
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    private static JUServiceRepository CreateRepository(AppDbContext Context)
+    {
+        return new JUServiceRepository(Context);
+    }
+
+    private static async Task SeedAsync(AppDbContext Context)
+    {
+        Context.JUServices.AddRange(
+            new JUServiceEntity
+            {
+                Id = 1,
+                Name = "Workshop"
+            },
+            new JUServiceEntity
+            {
+                Id = 2,
+                Name = "Game"
+            }
+        );
+
+        await Context.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WhenServiceExists_ReturnsServiceAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedAsync(context);
+
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = await repository.GetByIdAsync(1);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Id);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WhenServiceDoesNotExist_ReturnsNullAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedAsync(context);
+
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = await repository.GetByIdAsync(999);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WhenServiceExists_UpdatesEntityAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedAsync(context);
+
+        var repository = CreateRepository(context);
+
+        var entity = await repository.GetByIdAsync(1);
+
+        Assert.NotNull(entity);
+        entity.Name = "Updated Service";
+
+        // Act
+        var result = await repository.UpdateAsync(entity);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Id);
+
+        var updatedEntity = await context
+            .Set<JUServiceEntity>()
+            .AsNoTracking()
+            .SingleAsync(X => X.Id == 1);
+
+        Assert.Equal(1, updatedEntity.Id);
+        Assert.Equal("Updated Service", updatedEntity.Name);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WhenServiceDoesNotExist_ReturnsInputWithoutCreatingEntityAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var repository = CreateRepository(context);
+
+        var entity = new JUService
+        {
+            Id = 999
+        };
+
+        // Act
+        var result = await repository.UpdateAsync(entity);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(999, result.Id);
+
+        var databaseEntity = await context
+            .Set<JUServiceEntity>()
+            .FirstOrDefaultAsync(X => X.Id == 999);
+
+        Assert.Null(databaseEntity);
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/JUServiceRepositoryTests.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/JUServiceRepositoryTests.cs
@@ -2,6 +2,7 @@
 using Eras.Infrastructure.Persistence.PostgreSQL;
 using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -10,16 +11,8 @@ using Xunit;
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
 
 
-public class JUServiceRepositoryTests
+public class JUServiceRepositoryTests : RepositoryTestBase
 {
-    private static AppDbContext CreateContext()
-    {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        return new AppDbContext(options);
-    }
 
     private static JUServiceRepository CreateRepository(AppDbContext Context)
     {

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/PollCohortRepositoryTests.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/PollCohortRepositoryTests.cs
@@ -11,16 +11,8 @@ using Moq;
 
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
 
-public class PollCohortRepositoryTests
+public class PollCohortRepositoryTests : RepositoryTestBase
 {
-    private static AppDbContext CreateContext()
-    {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        return new AppDbContext(options);
-    }
 
     private static PollCohortRepository CreateRepository(AppDbContext Context)
     {

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/PollCohortRepositoryTests.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/PollCohortRepositoryTests.cs
@@ -1,0 +1,690 @@
+﻿using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL.Joins;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+
+using Moq;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+
+public class PollCohortRepositoryTests
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    private static PollCohortRepository CreateRepository(AppDbContext Context)
+    {
+        return new PollCohortRepository(Context);
+    }
+
+    private static Mock<DbSet<ErasCalculationsByPollEntity>> CreateMockErasCalculations(
+        IEnumerable<ErasCalculationsByPollEntity> Data)
+    {
+        var queryable = new TestAsyncEnumerable<ErasCalculationsByPollEntity>(Data);
+
+        var dbSet = new Mock<DbSet<ErasCalculationsByPollEntity>>();
+
+        dbSet
+            .As<IAsyncEnumerable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
+            .Returns(() => queryable.GetAsyncEnumerator());
+
+        dbSet
+            .As<IQueryable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.Provider)
+            .Returns(((IQueryable<ErasCalculationsByPollEntity>)queryable).Provider);
+
+        dbSet
+            .As<IQueryable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.Expression)
+            .Returns(((IQueryable<ErasCalculationsByPollEntity>)queryable).Expression);
+
+        dbSet
+            .As<IQueryable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.ElementType)
+            .Returns(((IQueryable<ErasCalculationsByPollEntity>)queryable).ElementType);
+
+        dbSet
+            .As<IQueryable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.GetEnumerator())
+            .Returns(() => queryable.AsEnumerable().GetEnumerator());
+
+        return dbSet;
+    }
+
+    private static List<ErasCalculationsByPollEntity> CreateErasCalculations()
+    {
+        return
+        [
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-1",
+                PollId = 1,
+                PollVersion = 2,
+                CohortId = 1,
+                CohortName = "Cohort A",
+                PollInstanceId = 101,
+                StudentName = "Alice",
+                ComponentName = "Engagement",
+                AverageRiskByCohortComponent = 3,
+                Question = "Question",
+                AnswerText = "text",
+                StudentEmail = "ali@mail.com"
+            },
+
+            // Duplicate logical result to verify Distinct()
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-1",
+                PollId = 1,
+                PollVersion = 2,
+                CohortId = 1,
+                CohortName = "Cohort A",
+                PollInstanceId = 101,
+                StudentName = "Alice",
+                ComponentName = "Engagement",
+                AverageRiskByCohortComponent = 3,
+                Question = "Question2",
+                AnswerText = "text5",
+                StudentEmail = "ali@mail.com"
+            },
+
+            // Last version - Cohort B / Attendance
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-1",
+                PollId = 1,
+                PollVersion = 2,
+                CohortId = 2,
+                CohortName = "Cohort B",
+                PollInstanceId = 102,
+                StudentName = "Bob",
+                ComponentName = "Attendance",
+                AverageRiskByCohortComponent = 4,
+                Question = "Question",
+                AnswerText = "text",
+                StudentEmail = "bob@mail.com"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-1",
+                PollId = 1,
+                PollVersion = 1,
+                CohortId = 1,
+                CohortName = "Cohort A",
+                PollInstanceId = 91,
+                StudentName = "Alice",
+                ComponentName = "Engagement",
+                AverageRiskByCohortComponent = 2,
+                Question = "Question",
+                AnswerText = "text",
+                StudentEmail = "ali@mail.com"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-1",
+                PollId = 1,
+                PollVersion = 1,
+                CohortId = 2,
+                CohortName = "Cohort B",
+                PollInstanceId = 92,
+                StudentName = "Bob",
+                ComponentName = "Attendance",
+                AverageRiskByCohortComponent = 1,
+                Question = "Question",
+                AnswerText = "text",
+                StudentEmail = "bob@mail.com"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-2",
+                PollId = 2,
+                PollVersion = 1,
+                CohortId = 1,
+                CohortName = "Cohort A",
+                PollInstanceId = 201,
+                StudentName = "Charlie",
+                ComponentName = "Engagement",
+                AverageRiskByCohortComponent = 5,
+                Question = "Question",
+                AnswerText = "text",
+                StudentEmail = "charl@mail.com"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-risk",
+                PollId = 3,
+                PollVersion = 1,
+                CohortId = 1,
+                CohortName = "Cohort A",
+                PollInstanceId = 301,
+                StudentName = "Alice",
+                PollInstanceRiskSum = 10,
+                Question = "Question",
+                AnswerText = "text",
+                StudentEmail = "ali@mail.com",
+                ComponentName = "Section"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-risk",
+                PollId = 3,
+                PollVersion = 1,
+                CohortId = 1,
+                CohortName = "Cohort A",
+                PollInstanceId = 301,
+                StudentName = "Alice",
+                PollInstanceRiskSum = 10,
+                Question = "Question",
+                AnswerText = "text",
+                StudentEmail = "ali@mail.com",
+                ComponentName = "Third"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-risk",
+                PollId = 3,
+                PollVersion = 1,
+                CohortId = 1,
+                CohortName = "Cohort A",
+                PollInstanceId = 302,
+                StudentName = "Bob",
+                PollInstanceRiskSum = 7,
+                Question = "Question",
+                AnswerText = "text",
+                StudentEmail = "ali@mail.com",
+                ComponentName = "Academic"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-risk",
+                PollId = 3,
+                PollVersion = 1,
+                CohortId = 2,
+                CohortName = "Cohort B",
+                PollInstanceId = 303,
+                StudentName = "Charlie",
+                PollInstanceRiskSum = 20,
+                Question = "Question",
+                AnswerText = "text",
+                StudentEmail = "ali@mail.com",
+                ComponentName = "Individual"
+            }
+        ];
+    }
+
+    private static async Task SeedPollDataAsync(AppDbContext Context)
+    {
+        Context.Cohorts.AddRange(
+            new CohortEntity
+            {
+                Id = 1,
+                Name = "Cohort A",
+                CourseCode = "COURSE-A"
+            },
+            new CohortEntity
+            {
+                Id = 2,
+                Name = "Cohort B",
+                CourseCode = "COURSE-B"
+            });
+
+        Context.Students.AddRange(
+            new StudentEntity
+            {
+                Id = 1,
+                Email = "Alice@mail.com",
+                Name = "alice",
+                Uuid = "123"
+            },
+            new StudentEntity
+            {
+                Id = 2,
+                Email = "Bob@mail.com",
+                Name = "Bob",
+                Uuid = "1234"
+            });
+
+        Context.StudentCohorts.AddRange(
+            new StudentCohortJoin
+            {
+                Id = 1,
+                StudentId = 1,
+                CohortId = 1,
+                //Student = new StudentEntity()
+                //{
+                //    Id = 1,
+                //    Email = "stu@mail.com",
+                //    Name = "Alice",
+                //    Uuid = "123"
+                //}
+            },
+            new StudentCohortJoin
+            {
+                Id = 2,
+                StudentId = 2,
+                CohortId = 2,
+                //Student = new StudentEntity()
+                //{
+                //    Id = 2,
+                //    Email = "stu2@mail.com",
+                //    Name = "Bob",
+                //    Uuid = "1234"
+                //}
+            });
+
+        Context.Polls.AddRange(
+            new PollEntity
+            {
+                Id = 1,
+                Uuid = "poll-1",
+                LastVersion = 2
+            },
+            new PollEntity
+            {
+                Id = 2,
+                Uuid = "poll-2",
+                LastVersion = 1
+            });
+
+        Context.PollInstances.AddRange(
+            new PollInstanceEntity
+            {
+                Id = 101,
+                StudentId = 1
+            },
+            new PollInstanceEntity
+            {
+                Id = 102,
+                StudentId = 2
+            });
+
+        Context.Variables.AddRange(
+            new VariableEntity
+            {
+                Id = 1,
+                Name = "Variable 1"
+            },
+            new VariableEntity
+            {
+                Id = 2,
+                Name = "Variable 2"
+            });
+
+        Context.PollVariables.AddRange(
+            new PollVariableJoin
+            {
+                Id = 1,
+                PollId = 1,
+                VariableId = 1
+            },
+            new PollVariableJoin
+            {
+                Id = 2,
+                PollId = 1,
+                VariableId = 2
+            });
+
+        Context.Answers.AddRange(
+            new AnswerEntity
+            {
+                Id = 1,
+                PollInstanceId = 101,
+                PollVariableId = 1,
+                AnswerText = "Yes",
+                RiskLevel = 1
+            },
+            new AnswerEntity
+            {
+                Id = 2,
+                PollInstanceId = 101,
+                PollVariableId = 2,
+                AnswerText = "No",
+                RiskLevel = 2
+            },
+            new AnswerEntity
+            {
+                Id = 3,
+                PollInstanceId = 102,
+                PollVariableId = 1,
+                AnswerText = "Yes",
+                RiskLevel = 3
+            });
+
+        await Context.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task GetPollsByCohortIdAsync_WhenCohortHasPolls_ReturnsDistinctPollsAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedPollDataAsync(context);
+
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = await repository.GetPollsByCohortIdAsync(1);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result);
+
+        Assert.Equal(1, result[0].Id);
+    }
+
+    [Fact]
+    public async Task GetPollsByCohortIdAsync_WhenCohortDoesNotExist_ReturnsEmptyListAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedPollDataAsync(context);
+
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = await repository.GetPollsByCohortIdAsync(999);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetPollsByCohortIdAsync_WhenCohortHasNoStudents_ReturnsEmptyListAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedPollDataAsync(context);
+
+        context.Cohorts.Add(new CohortEntity
+        {
+            Id = 10,
+            Name = "Empty Cohort",
+            CourseCode = "EMPTY"
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = await repository.GetPollsByCohortIdAsync(10);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetPollVariablesAsync_WhenPollAndCohortHaveAnswers_ReturnsVariablesAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedPollDataAsync(context);
+
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = await repository.GetPollVariablesAsync(1, 1);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count);
+
+        Assert.Contains(result, X =>X.PollId == 1 && X.VariableId == 1 && X.VariableName == "Variable 1");
+
+        Assert.Contains(
+            result,
+            X => X.PollId == 1 && X.VariableId == 2 && X.VariableName == "Variable 2");
+    }
+
+    [Fact]
+    public async Task GetPollVariablesAsync_WhenCohortDoesNotMatch_ReturnsEmptyListAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedPollDataAsync(context);
+
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = await repository.GetPollVariablesAsync(1, 3);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetPollVariablesAsync_WhenPollDoesNotExist_ReturnsEmptyListAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedPollDataAsync(context);
+
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = await repository.GetPollVariablesAsync(999, 1);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+
+    [Fact]
+    public async Task GetCohortComponentsByPoll_WhenLastVersionIsTrue_ReturnsOnlyLastVersionAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedPollDataAsync(context);
+
+        var calculations = CreateErasCalculations();
+        context.ErasCalculationsByPoll =
+            CreateMockErasCalculations(calculations).Object;
+
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = await repository.GetCohortComponentsByPoll("poll-1", true);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(3, result.Count);
+
+        Assert.Contains(result,
+            X => X.CohortId == 1
+                && X.CohortName == "Cohort A"
+                && X.ComponentName == "Engagement"
+                && X.AverageRiskByCohortComponent == 3);
+
+        Assert.Contains(result,
+            X => X.CohortId == 2
+                && X.CohortName == "Cohort B"
+                && X.ComponentName == "Attendance"
+                && X.AverageRiskByCohortComponent == 4);
+    }
+
+    [Fact]
+    public async Task GetCohortComponentsByPoll_WhenPollDoesNotExist_ReturnsEmptyListAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedPollDataAsync(context);
+        var calculations = CreateErasCalculations();
+        context.ErasCalculationsByPoll = CreateMockErasCalculations(calculations).Object;
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = await repository.GetCohortComponentsByPoll("does-not-exist",true);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetCohortComponentsByPoll_WhenNoCalculationsExist_ReturnsEmptyListAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedPollDataAsync(context);
+
+        context.ErasCalculationsByPoll =
+            CreateMockErasCalculations(
+                Enumerable.Empty<ErasCalculationsByPollEntity>()
+            ).Object;
+
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = await repository.GetCohortComponentsByPoll("poll-1", true);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetCohortStudentsRiskByPoll_ReturnsStudentsOrderedByRiskAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedPollDataAsync(context);
+
+        var calculations = CreateErasCalculations();
+        context.ErasCalculationsByPoll =
+            CreateMockErasCalculations(calculations).Object;
+
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = await repository.GetCohortStudentsRiskByPoll("poll-risk", 1);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+
+        Assert.Equal(301, result[0].PollInstanceId);
+        Assert.Equal("Alice", result[0].StudentName);
+        Assert.Equal(10, result[0].PollInstanceRiskSum);
+
+        Assert.Equal(302, result[1].PollInstanceId);
+        Assert.Equal("Bob", result[1].StudentName);
+        Assert.Equal(7, result[1].PollInstanceRiskSum);
+    }
+
+    [Fact]
+    public async Task GetCohortStudentsRiskByPoll_DistinctByPollInstanceId_RemovesDuplicatesAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedPollDataAsync(context);
+
+        var calculations = new List<ErasCalculationsByPollEntity>
+        {
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-3",
+                PollVersion = 1,
+                CohortId = 1,
+                PollInstanceId = 500,
+                StudentName = "Alice",
+                PollInstanceRiskSum = 15,
+                Question = "Question",
+                AnswerText = "text",
+                StudentEmail = "ali@mail.com",
+                CohortName = "Cohort",
+                ComponentName = "academic",
+            },
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-3",
+                PollVersion = 1,
+                CohortId = 1,
+                PollInstanceId = 500,
+                StudentName = "Alice",
+                PollInstanceRiskSum = 15,
+                Question = "Question",
+                AnswerText = "text",
+                StudentEmail = "ali@mail.com",
+                CohortName = "Cohort",
+                ComponentName = "academic",
+            },
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-3",
+                PollVersion = 1,
+                CohortId = 1,
+                PollInstanceId = 501,
+                StudentName = "Bob",
+                PollInstanceRiskSum = 10,
+                Question = "Question",
+                AnswerText = "text",
+                StudentEmail = "bob@mail.com",
+                CohortName = "Cohort",
+                ComponentName = "academic",
+            }
+        };
+        context.ErasCalculationsByPoll = CreateMockErasCalculations(calculations).Object;
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = await repository.GetCohortStudentsRiskByPoll("poll-3", 1);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+
+        Assert.Equal(500, result[0].PollInstanceId);
+        Assert.Equal(501, result[1].PollInstanceId);
+    }
+
+    [Fact]
+    public async Task GetCohortStudentsRiskByPoll_WhenCohortDoesNotMatch_ReturnsEmptyListAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedPollDataAsync(context);
+
+        var calculations = CreateErasCalculations();
+        context.ErasCalculationsByPoll = CreateMockErasCalculations(calculations).Object;
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = await repository.GetCohortStudentsRiskByPoll("poll-risk", 999);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetCohortStudentsRiskByPoll_WhenPollDoesNotMatch_ReturnsEmptyListAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        await SeedPollDataAsync(context);
+
+        var calculations = CreateErasCalculations();
+        context.ErasCalculationsByPoll = CreateMockErasCalculations(calculations).Object;
+        var repository = CreateRepository(context);
+
+        // Act
+        var result = await repository.GetCohortStudentsRiskByPoll("does-not-exist", 1);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/PollInstanceRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/PollInstanceRepositoryTest.cs
@@ -4,6 +4,7 @@ using Eras.Infrastructure.Persistence.PostgreSQL;
 using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Joins;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -13,7 +14,7 @@ using Moq;
 
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
 {
-    public class PollInstanceRepositoryTest
+    public class PollInstanceRepositoryTest : RepositoryTestBase
     {
         protected Mock<AppDbContext> _mockContext;
         private PollInstanceRepository? _repository;
@@ -93,19 +94,10 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
             Assert.Single(result);
         }
 
-        private static AppDbContext BuildRealContext()
-        {
-            var options = new DbContextOptionsBuilder<AppDbContext>()
-                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
-                .Options;
-
-            return new AppDbContext(options);
-        }
-
         [Fact]
         public async Task GetByCohortIdAndLastDays_WithEvaluationId_Returns_Only_That_Evaluations_StudentsAsync()
         {
-            using var context = BuildRealContext();
+            using var context = CreateContext();
 
             var student = new StudentEntity { Id = 1, Uuid = "student-1-uuid", Name = "Student One", Email = "student1@test.com" };
 
@@ -139,7 +131,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         [Fact]
         public async Task GetByCohortIdAndLastDays_WithoutEvaluationId_Returns_All_Evaluations_For_PollAsync()
         {
-            using var context = BuildRealContext();
+            using var context = CreateContext();
 
             var student = new StudentEntity { Id = 1, Uuid = "student-1-uuid", Name = "Student One", Email = "student1@test.com" };
 
@@ -171,7 +163,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         [Fact]
         public async Task GetByCohortIdAndLastDays_Excludes_Students_Outside_CohortAsync()
         {
-            using var context = BuildRealContext();
+            using var context = CreateContext();
 
             var studentInCohort = new StudentEntity { Id = 1, Uuid = "student-1-uuid", Name = "Student In Cohort", Email = "in-cohort@test.com" };
             var studentOutsideCohort = new StudentEntity { Id = 2, Uuid = "student-2-uuid", Name = "Student Outside Cohort", Email = "outside-cohort@test.com" };
@@ -205,7 +197,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         [Fact]
         public async Task GetByCohortIdAndLastDays_WithDaysAndLastVersion_ReturnsRecentLastVersionAsync()
         {
-            using var context = BuildRealContext();
+            using var context = CreateContext();
 
             var now = DateTime.UtcNow;
 
@@ -242,7 +234,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         [Fact]
         public async Task GetByCohortIdAndLastDays_WithZeroDays_UsesNonLastVersionBranchAsync()
         {
-            using var context = BuildRealContext();
+            using var context = CreateContext();
 
             var student = new StudentEntity { Id = 1, Uuid = "student-1", Name = "Student", Email = "student@test.com"};
 
@@ -457,7 +449,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         [Fact]
         public async Task UpdateAsync_Persists_Changes_To_Existing_EntityAsync()
         {
-            using var context = BuildRealContext();
+            using var context = CreateContext();
 
             var student = new StudentEntity { Id = 1, Uuid = "student-1-uuid", Name = "Student One", Email = "student1@test.com" };
 
@@ -487,7 +479,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         [Fact]
         public async Task UpdateAsync_Returns_Input_When_Entity_Not_FoundAsync()
         {
-            using var context = BuildRealContext();
+            using var context = CreateContext();
             _repository = new PollInstanceRepository(context);
 
             var domainInstance = new Eras.Domain.Entities.PollInstance { Id = 999, Uuid = "missing-Uuid" };
@@ -500,7 +492,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         [Fact]
         public async Task SetSourceInstanceAsync_Sets_SourcePollInstanceIdAsync()
         {
-            using var context = BuildRealContext();
+            using var context = CreateContext();
 
             var student = new StudentEntity { Id = 1, Uuid = "student-1-uuid", Name = "Student One", Email = "student1@test.com" };
             var entity = new PollInstanceEntity { Uuid = "poll-Uuid", StudentId = 1, FinishedAt = DateTime.UtcNow, Student = student };
@@ -518,7 +510,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         [Fact]
         public async Task SetSourceInstanceAsync_Does_Nothing_When_Instance_Not_FoundAsync()
         {
-            using var context = BuildRealContext();
+            using var context = CreateContext();
             _repository = new PollInstanceRepository(context);
 
             await _repository.SetSourceInstanceAsync(999, 1);
@@ -527,7 +519,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         [Fact]
         public async Task FindMatchingSourceInstanceAsync_Finds_Match_By_Precomputed_HashAsync()
         {
-            using var context = BuildRealContext();
+            using var context = CreateContext();
 
             var student = new StudentEntity { Id = 1, Uuid = "student-1-uuid", Name = "Student One", Email = "student1@test.com" };
             var poll = BuildPollDTO(("Q1", "Yes"), ("Q2", "No"));
@@ -555,7 +547,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         [Fact]
         public async Task FindMatchingSourceInstanceAsync_Returns_Null_When_No_MatchAsync()
         {
-            using var context = BuildRealContext();
+            using var context = CreateContext();
 
             var student = new StudentEntity { Id = 1, Uuid = "student-1-uuid", Name = "Student One", Email = "student1@test.com" };
             context.PollInstances.Add(new PollInstanceEntity

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/PollInstanceRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/PollInstanceRepositoryTest.cs
@@ -1,10 +1,14 @@
-﻿using Eras.Infrastructure.Persistence.PostgreSQL;
-using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
-using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
-using Eras.Infrastructure.Persistence.PostgreSQL.Joins;
-using Microsoft.EntityFrameworkCore;
+﻿using Eras.Application.Models.Consolidator;
 using Eras.Domain.Common;
+using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL.Joins;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
 using MockQueryable.Moq;
+
 using Moq;
 
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
@@ -23,8 +27,6 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
             _mockContext = new Mock<AppDbContext>(options);
         }
 
-        // GetByLastDays
-
         [Fact]
         public void GetByLastDays_Should_Return_Only_Instances_Within_Range_And_Version()
         {
@@ -41,7 +43,6 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
 
             _mockContext.Setup(C => C.Polls).Returns(pollData.Object);
             _mockContext.Setup(C => C.PollInstances).Returns(pollInstanceData.Object);
-
 
             _repository = new PollInstanceRepository(_mockContext.Object);
 
@@ -66,8 +67,31 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
                 _repository.GetByLastDays(10, true, "missing-Uuid"));
         }
 
-        // GetByCohortIdAndLastDays — regression coverage for the
-        // "duplicate students across evaluations" bug fix.
+        [Fact]
+        public void GetByLastDays_ShouldReturn_OnlyInstances_Within_Range_And_VersionIsOld()
+        {
+            var pollData = new List<PollEntity>
+            {
+                new PollEntity { Uuid = "poll-Uuid", LastVersion = 1 }
+            }.AsQueryable().BuildMockDbSet();
+
+            var pollInstanceData = new List<PollInstanceEntity>
+            {
+                new PollInstanceEntity { Id = 1, Uuid = "poll-Uuid", FinishedAt = DateTime.UtcNow, StudentId = 1, LastVersion = 2 },
+                new PollInstanceEntity { Id = 2, Uuid = "poll-Uuid", FinishedAt = DateTime.UtcNow.AddDays(-100), StudentId = 1, LastVersion = 2 }
+            }.AsQueryable().BuildMockDbSet();
+
+            _mockContext.Setup(C => C.Polls).Returns(pollData.Object);
+            _mockContext.Setup(C => C.PollInstances).Returns(pollInstanceData.Object);
+
+
+            _repository = new PollInstanceRepository(_mockContext.Object);
+
+            var result = _repository.GetByLastDays(10, false, "poll-Uuid").Result;
+
+            Assert.NotNull(result);
+            Assert.Single(result);
+        }
 
         private static AppDbContext BuildRealContext()
         {
@@ -79,7 +103,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         }
 
         [Fact]
-        public async Task GetByCohortIdAndLastDays_WithEvaluationId_Returns_Only_That_Evaluations_Students()
+        public async Task GetByCohortIdAndLastDays_WithEvaluationId_Returns_Only_That_Evaluations_StudentsAsync()
         {
             using var context = BuildRealContext();
 
@@ -113,7 +137,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         }
 
         [Fact]
-        public async Task GetByCohortIdAndLastDays_WithoutEvaluationId_Returns_All_Evaluations_For_Poll()
+        public async Task GetByCohortIdAndLastDays_WithoutEvaluationId_Returns_All_Evaluations_For_PollAsync()
         {
             using var context = BuildRealContext();
 
@@ -145,7 +169,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         }
 
         [Fact]
-        public async Task GetByCohortIdAndLastDays_Excludes_Students_Outside_Cohort()
+        public async Task GetByCohortIdAndLastDays_Excludes_Students_Outside_CohortAsync()
         {
             using var context = BuildRealContext();
 
@@ -178,14 +202,76 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
             Assert.Equal(1, result.Items.First().Student!.Id);
         }
 
-        
+        [Fact]
+        public async Task GetByCohortIdAndLastDays_WithDaysAndLastVersion_ReturnsRecentLastVersionAsync()
+        {
+            using var context = BuildRealContext();
 
-        
+            var now = DateTime.UtcNow;
 
-        // GetByUuidAsync
+            var student = new StudentEntity
+            { Id = 1, Uuid = "student-1", Name = "Student", Email = "student@test.com"};
+
+            context.Polls.Add(new PollEntity { Uuid = "poll-Uuid", LastVersion = 2 });
+
+            context.StudentCohorts.Add(new StudentCohortJoin { StudentId = 1, CohortId = 100 });
+
+            context.PollInstances.AddRange(
+                new PollInstanceEntity
+                {
+                    Id = 1, Uuid = "poll-Uuid", StudentId = 1, EvaluationId = 10, FinishedAt = now.AddDays(-2), LastVersion = 2,Student = student
+                },
+                new PollInstanceEntity
+                {
+                    Id = 2, Uuid = "poll-Uuid", StudentId = 1, EvaluationId = 10, FinishedAt = now.AddDays(-10), LastVersion = 2, Student = student
+                },
+                new PollInstanceEntity
+                {
+                    Id = 3, Uuid = "poll-Uuid", StudentId = 1, EvaluationId = 10, FinishedAt = now.AddDays(-1), LastVersion = 1, Student = student
+                }
+            );
+
+            await context.SaveChangesAsync();
+            _repository = new PollInstanceRepository(context);
+            var result = await _repository.GetByCohortIdAndLastDays(1, 10, [100], 7, true, "poll-Uuid", null, null);
+
+            Assert.Equal(1, result.Count);
+            Assert.Single(result.Items);
+        }
 
         [Fact]
-        public async Task GetByUuidAsync_Returns_Matching_Instance()
+        public async Task GetByCohortIdAndLastDays_WithZeroDays_UsesNonLastVersionBranchAsync()
+        {
+            using var context = BuildRealContext();
+
+            var student = new StudentEntity { Id = 1, Uuid = "student-1", Name = "Student", Email = "student@test.com"};
+
+            context.Polls.Add(new PollEntity { Uuid = "poll-Uuid", LastVersion = 2 });
+
+            context.StudentCohorts.Add(new StudentCohortJoin { StudentId = 1, CohortId = 100 });
+
+            context.PollInstances.AddRange(
+                new PollInstanceEntity
+                {
+                    Id = 1, Uuid = "poll-Uuid", StudentId = 1, EvaluationId = 10, FinishedAt = DateTime.UtcNow, LastVersion = 1, Student = student
+                },
+                new PollInstanceEntity
+                {
+                    Id = 2, Uuid = "poll-Uuid", StudentId = 1, EvaluationId = 10, FinishedAt = DateTime.UtcNow, LastVersion = 2, Student = student
+                }
+            );
+
+            await context.SaveChangesAsync();
+
+            _repository = new PollInstanceRepository(context);
+
+            var result = await _repository.GetByCohortIdAndLastDays(1, 10, [100], 0, true, "poll-Uuid", null, null);
+
+            Assert.Equal(0, result.Count);
+        }
+
+        [Fact]
+        public async Task GetByUuidAsync_Returns_Matching_InstanceAsync()
         {
             var pollInstanceData = new List<PollInstanceEntity>
             {
@@ -203,7 +289,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         }
 
         [Fact]
-        public async Task GetByUuidAsync_Returns_Null_When_Not_Found()
+        public async Task GetByUuidAsync_Returns_Null_When_Not_FoundAsync()
         {
             var pollInstanceData = new List<PollInstanceEntity>
             {
@@ -218,10 +304,8 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
             Assert.Null(result);
         }
 
-        // GetByUuidAndStudentIdAsync (both overloads)
-
         [Fact]
-        public async Task GetByUuidAndStudentIdAsync_TwoArgs_Returns_Matching_Instance()
+        public async Task GetByUuidAndStudentIdAsync_TwoArgs_Returns_Matching_InstanceAsync()
         {
             var pollInstanceData = new List<PollInstanceEntity>
             {
@@ -239,7 +323,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         }
 
         [Fact]
-        public async Task GetByUuidAndStudentIdAsync_ThreeArgs_Filters_By_Evaluation_Too()
+        public async Task GetByUuidAndStudentIdAsync_ThreeArgs_Filters_By_Evaluation_TooAsync()
         {
             var pollInstanceData = new List<PollInstanceEntity>
             {
@@ -256,10 +340,8 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
             Assert.Equal(2, result!.Id);
         }
 
-        // GetImportedStudentsEmailsByPollName
-
         [Fact]
-        public async Task GetImportedStudentsEmailsByPollName_Returns_Distinct_Emails()
+        public async Task GetImportedStudentsEmailsByPollName_Returns_Distinct_EmailsAsync()
         {
             var student = new StudentEntity { Id = 1, Uuid = "student-1-uuid", Name = "Student One", Email = "student1@test.com" };
 
@@ -284,12 +366,10 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
             Assert.Equal("student1@test.com", result.First());
         }
 
-        // ExistsForStudentAndEvaluationAsync
-
         [Theory]
         [InlineData(5, 10, true)]
         [InlineData(999, 10, false)]
-        public async Task ExistsForStudentAndEvaluationAsync_Returns_Expected(int studentId, int evaluationId, bool expected)
+        public async Task ExistsForStudentAndEvaluationAsync_Returns_ExpectedAsync(int StudentId, int EvaluationId, bool Expected)
         {
             var pollInstanceData = new List<PollInstanceEntity>
             {
@@ -299,15 +379,13 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
             _mockContext.Setup(C => C.PollInstances).Returns(pollInstanceData.Object);
             _repository = new PollInstanceRepository(_mockContext.Object);
 
-            var result = await _repository.ExistsForStudentAndEvaluationAsync(studentId, "poll-Uuid", evaluationId);
+            var result = await _repository.ExistsForStudentAndEvaluationAsync(StudentId, "poll-Uuid", EvaluationId);
 
-            Assert.Equal(expected, result);
+            Assert.Equal(Expected, result);
         }
 
-        // CountByDateRangeAsync
-
         [Fact]
-        public async Task CountByDateRangeAsync_Counts_Instances_Within_Range()
+        public async Task CountByDateRangeAsync_Counts_Instances_Within_RangeAsync()
         {
             var now = DateTime.UtcNow;
 
@@ -324,8 +402,6 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
 
             Assert.Equal(1, result);
         }
-
-        // ComputeAnswersHash
 
         [Fact]
         public void ComputeAnswersHash_Is_Order_Independent()
@@ -355,7 +431,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
             Assert.NotEqual(hashA, hashB);
         }
 
-        private static Eras.Application.Dtos.PollDTO BuildPollDTO(params (string Question, string Answer)[] answers)
+        private static Eras.Application.Dtos.PollDTO BuildPollDTO(params (string Question, string Answer)[] Answers)
         {
             return new Eras.Application.Dtos.PollDTO
             {
@@ -365,11 +441,11 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
                     {
                         Variables =
                         [
-                            .. answers.Select(a => new Eras.Application.DTOs.VariableDTO
+                            .. Answers.Select(A => new Eras.Application.DTOs.VariableDTO
                             {
                                 Answer = new Eras.Application.DTOs.AnswerDTO
                                 {
-                                    Answer = a.Answer
+                                    Answer = A.Answer
                                 }
                             })
                         ]
@@ -378,10 +454,8 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
             };
         }
 
-        // UpdateAsync
-
         [Fact]
-        public async Task UpdateAsync_Persists_Changes_To_Existing_Entity()
+        public async Task UpdateAsync_Persists_Changes_To_Existing_EntityAsync()
         {
             using var context = BuildRealContext();
 
@@ -411,7 +485,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         }
 
         [Fact]
-        public async Task UpdateAsync_Returns_Input_When_Entity_Not_Found()
+        public async Task UpdateAsync_Returns_Input_When_Entity_Not_FoundAsync()
         {
             using var context = BuildRealContext();
             _repository = new PollInstanceRepository(context);
@@ -423,10 +497,8 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
             Assert.Equal("missing-Uuid", result.Uuid);
         }
 
-        // SetSourceInstanceAsync
-
         [Fact]
-        public async Task SetSourceInstanceAsync_Sets_SourcePollInstanceId()
+        public async Task SetSourceInstanceAsync_Sets_SourcePollInstanceIdAsync()
         {
             using var context = BuildRealContext();
 
@@ -444,19 +516,16 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         }
 
         [Fact]
-        public async Task SetSourceInstanceAsync_Does_Nothing_When_Instance_Not_Found()
+        public async Task SetSourceInstanceAsync_Does_Nothing_When_Instance_Not_FoundAsync()
         {
             using var context = BuildRealContext();
             _repository = new PollInstanceRepository(context);
 
-            // Should not throw when the poll instance doesn't exist.
             await _repository.SetSourceInstanceAsync(999, 1);
         }
 
-        // FindMatchingSourceInstanceAsync
-
         [Fact]
-        public async Task FindMatchingSourceInstanceAsync_Finds_Match_By_Precomputed_Hash()
+        public async Task FindMatchingSourceInstanceAsync_Finds_Match_By_Precomputed_HashAsync()
         {
             using var context = BuildRealContext();
 
@@ -484,7 +553,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         }
 
         [Fact]
-        public async Task FindMatchingSourceInstanceAsync_Returns_Null_When_No_Match()
+        public async Task FindMatchingSourceInstanceAsync_Returns_Null_When_No_MatchAsync()
         {
             using var context = BuildRealContext();
 
@@ -508,10 +577,8 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
             Assert.Null(result);
         }
 
-        // GetReportByPollCohortAsync
-
         [Fact]
-        public async Task GetReportByPollCohortAsync_Aggregates_Averages_By_Component()
+        public async Task GetReportByPollCohortAsync_Aggregates_Averages_By_ComponentAsync()
         {
             var student = new StudentEntity { Id = 1, Uuid = "student-1-uuid", Name = "Student One", Email = "student1@test.com" };
 
@@ -570,7 +637,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         }
 
         [Fact]
-        public async Task GetReportByPollCohortAsync_Excludes_NonApplicable_Answers_From_Averages()
+        public async Task GetReportByPollCohortAsync_Excludes_NonApplicable_Answers_From_AveragesAsync()
         {
             var student = new StudentEntity { Id = 1, Uuid = "student-1-uuid", Name = "Student One", Email = "student1@test.com" };
 
@@ -626,7 +693,62 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         }
 
         [Fact]
-        public async Task GetCountReportByVariablesAsync_Groups_Counts_By_Answer_Risk()
+        public async Task GetReportByPollCohortAsync_Excludes_NonApplicable_Answers_WithoutLastVersionAsync()
+        {
+            var student = new StudentEntity { Id = 1, Uuid = "student-1-uuid", Name = "Student One", Email = "student1@test.com" };
+
+            var pollInstanceData = new List<PollInstanceEntity>
+            {
+                new PollInstanceEntity { Id = 1, Uuid = "poll-Uuid", StudentId = 1, FinishedAt = DateTime.UtcNow, Student = student }
+            }.AsQueryable().BuildMockDbSet();
+
+            var studentCohortData = new List<StudentCohortJoin>
+            {
+                new StudentCohortJoin { StudentId = 1, CohortId = 100 }
+            }.AsQueryable().BuildMockDbSet();
+
+            var studentData = new List<StudentEntity> { student }.AsQueryable().BuildMockDbSet();
+
+            var calcData = new List<ErasCalculationsByPollEntity>
+            {
+                new ErasCalculationsByPollEntity
+                {
+                    PollUuid = "poll-Uuid", ComponentName = "Academic", Question = "Q1",
+                    AnswerText = "Ninguno", StudentEmail = "student1@test.com", AnswerRisk = 0,
+                    VariableAverageRisk = 0, AnswerPercentage = 100, PollInstanceId = 1,
+                    StudentName = "Student One", CohortName = "Cohort A",
+                    PollVersion = 1
+                },
+                new ErasCalculationsByPollEntity
+                {
+                    PollUuid = "poll-Uuid", ComponentName = "Academic", Question = "Q1",
+                    AnswerText = "Good", StudentEmail = "student1@test.com", AnswerRisk = 20,
+                    VariableAverageRisk = 20, AnswerPercentage = 100, PollInstanceId = 1,
+                    StudentName = "Student One", CohortName = "Cohort A",
+                    PollVersion = 1
+                }
+            }.AsQueryable().BuildMockDbSet();
+
+            var pollData = new List<PollEntity>
+            {
+                new PollEntity { Uuid = "poll-Uuid", LastVersion = 1 }
+            }.AsQueryable().BuildMockDbSet();
+
+            _mockContext.Setup(C => C.Polls).Returns(pollData.Object);
+            _mockContext.Setup(C => C.PollInstances).Returns(pollInstanceData.Object);
+            _mockContext.Setup(C => C.StudentCohorts).Returns(studentCohortData.Object);
+            _mockContext.Setup(C => C.Students).Returns(studentData.Object);
+            _mockContext.Setup(C => C.ErasCalculationsByPoll).Returns(calcData.Object);
+
+            _repository = new PollInstanceRepository(_mockContext.Object);
+
+            var result = await _repository.GetReportByPollCohortAsync(
+                "poll-Uuid", [100], false, DateTime.UtcNow.AddDays(-1), DateTime.UtcNow.AddDays(1));
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public async Task GetCountReportByVariablesAsync_Groups_Counts_By_Answer_RiskAsync()
         {
             var student = new StudentEntity { Id = 1, Uuid = "student-1-uuid", Name = "Student One", Email = "student1@test.com" };
 
@@ -677,11 +799,11 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
             var component = result.Components.First();
             Assert.Equal("ACADEMIC", component.Description);
             Assert.Single(component.Questions);
-            Assert.Equal(2, component.Questions.First().Answers.Sum(a => a.Count));
+            Assert.Equal(2, component.Questions.First().Answers.Sum(A => A.Count));
         }
 
         [Fact]
-        public async Task GetCountReportByVariablesAsync_Filters_By_EvaluationId()
+        public async Task GetCountReportByVariablesAsync_Filters_By_EvaluationIdAsync()
         {
             var student = new StudentEntity { Id = 1, Uuid = "student-1-uuid", Name = "Student One", Email = "student1@test.com" };
 
@@ -732,7 +854,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
                 "poll-Uuid", [100], [5], true,
                 DateTime.UtcNow.AddDays(-1), DateTime.UtcNow.AddDays(1), 10);
 
-            var totalCount = result.Components.First().Questions.First().Answers.Sum(a => a.Count);
+            var totalCount = result.Components.First().Questions.First().Answers.Sum(A => A.Count);
             Assert.Equal(1, totalCount);
         }
     }

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/PollRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/PollRepositoryTest.cs
@@ -2,6 +2,7 @@
 using Eras.Infrastructure.Persistence.PostgreSQL;
 using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -13,7 +14,7 @@ using Xunit;
 
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
 
-public class PollRepositoryTest
+public class PollRepositoryTest : RepositoryTestBase
 {
     private readonly Mock<AppDbContext> _mockContext;
     private readonly Mock<DbSet<PollEntity>> _mockSet;
@@ -210,11 +211,7 @@ public class PollRepositoryTest
     public async Task UpdateAsync_ShouldUpdateExistingPollAsync()
     {
         // Arrange
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        await using var context = new AppDbContext(options);
+        using var context = CreateContext();
 
         var existingPoll = new PollEntity
         {
@@ -257,11 +254,7 @@ public class PollRepositoryTest
     public async Task UpdateAsync_ShouldNotAddPoll_WhenPollDoesNotExistAsync()
     {
         // Arrange
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        await using var context = new AppDbContext(options);
+        using var context = CreateContext();
 
         var repository = new PollRepository(context);
 

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/PollRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/PollRepositoryTest.cs
@@ -1,0 +1,287 @@
+﻿using Eras.Domain.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using MockQueryable.Moq;
+
+using Moq;
+
+using Xunit;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+
+public class PollRepositoryTest
+{
+    private readonly Mock<AppDbContext> _mockContext;
+    private readonly Mock<DbSet<PollEntity>> _mockSet;
+    private readonly PollRepository _repository;
+
+    public PollRepositoryTest()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _mockContext = new Mock<AppDbContext>(options);
+        _mockSet = new Mock<DbSet<PollEntity>>();
+
+        _repository = new PollRepository(_mockContext.Object);
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_ShouldReturnPoll_WhenPollExistsAsync()
+    {
+        // Arrange
+        var data = new List<PollEntity>
+        {
+            new PollEntity
+            {
+                Id = 1,
+                Name = "Test Poll",
+                ParentId = "parent-1",
+                Uuid = "uuid-1"
+            }
+        }
+        .AsQueryable()
+        .BuildMockDbSet();
+
+        _mockContext
+            .Setup(X => X.Polls)
+            .Returns(data.Object);
+
+        // Act
+        var result = await _repository.GetByNameAsync("Test Poll");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Test Poll", result.Name);
+        Assert.Equal("parent-1", result.ParentId);
+        Assert.Equal("uuid-1", result.Uuid);
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_ShouldReturnNull_WhenPollDoesNotExistAsync()
+    {
+        // Arrange
+        var data = new List<PollEntity>
+        {
+            new PollEntity
+            {
+                Id = 1,
+                Name = "Test Poll",
+                ParentId = "parent-1",
+                Uuid = "uuid-1"
+            }
+        }
+        .AsQueryable()
+        .BuildMockDbSet();
+
+        _mockContext
+            .Setup(X => X.Polls)
+            .Returns(data.Object);
+
+        // Act
+        var result = await _repository.GetByNameAsync("Unknown Poll");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByParentIdAsync_ShouldReturnPoll_WhenPollExistsAsync()
+    {
+        // Arrange
+        var data = new List<PollEntity>
+        {
+            new PollEntity
+            {
+                Id = 1,
+                Name = "Test Poll",
+                ParentId = "parent-1",
+                Uuid = "uuid-1"
+            }
+        }
+        .AsQueryable()
+        .BuildMockDbSet();
+
+        _mockContext
+            .Setup(X => X.Polls)
+            .Returns(data.Object);
+
+        // Act
+        var result = await _repository.GetByParentIdAsync("parent-1");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Test Poll", result.Name);
+        Assert.Equal("parent-1", result.ParentId);
+    }
+
+    [Fact]
+    public async Task GetByParentIdAsync_ShouldReturnNull_WhenPollDoesNotExistAsync()
+    {
+        // Arrange
+        var data = new List<PollEntity>
+        {
+            new PollEntity
+            {
+                Id = 1,
+                Name = "Test Poll",
+                ParentId = "parent-1",
+                Uuid = "uuid-1"
+            }
+        }
+        .AsQueryable()
+        .BuildMockDbSet();
+
+        _mockContext
+            .Setup(X => X.Polls)
+            .Returns(data.Object);
+
+        // Act
+        var result = await _repository.GetByParentIdAsync("unknown-parent");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByUuidAsync_ShouldReturnPoll_WhenPollExistsAsync()
+    {
+        // Arrange
+        var data = new List<PollEntity>
+        {
+            new PollEntity
+            {
+                Id = 1,
+                Name = "Test Poll",
+                ParentId = "parent-1",
+                Uuid = "uuid-1"
+            }
+        }
+        .AsQueryable()
+        .BuildMockDbSet();
+
+        _mockContext
+            .Setup(X => X.Polls)
+            .Returns(data.Object);
+
+        // Act
+        var result = await _repository.GetByUuidAsync("uuid-1");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Test Poll", result.Name);
+        Assert.Equal("uuid-1", result.Uuid);
+    }
+
+    [Fact]
+    public async Task GetByUuidAsync_ShouldReturnNull_WhenPollDoesNotExistAsync()
+    {
+        // Arrange
+        var data = new List<PollEntity>
+        {
+            new PollEntity
+            {
+                Id = 1,
+                Name = "Test Poll",
+                ParentId = "parent-1",
+                Uuid = "uuid-1"
+            }
+        }
+        .AsQueryable()
+        .BuildMockDbSet();
+
+        _mockContext
+            .Setup(X => X.Polls)
+            .Returns(data.Object);
+
+        // Act
+        var result = await _repository.GetByUuidAsync("unknown-uuid");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ShouldUpdateExistingPollAsync()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        await using var context = new AppDbContext(options);
+
+        var existingPoll = new PollEntity
+        {
+            Id = 1,
+            Name = "Old Name",
+            ParentId = "old-parent",
+            Uuid = "old-uuid"
+        };
+
+        context.Polls.Add(existingPoll);
+        await context.SaveChangesAsync();
+
+        var repository = new PollRepository(context);
+
+        var poll = new Poll
+        {
+            Id = 1,
+            Name = "New Name",
+            ParentId = "new-parent",
+            Uuid = "new-uuid"
+        };
+
+        // Act
+        var result = await repository.UpdateAsync(poll);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Id);
+        Assert.Equal("New Name", result.Name);
+
+        var updatedEntity = await context.Polls.FindAsync(1);
+
+        Assert.NotNull(updatedEntity);
+        Assert.Equal("New Name", updatedEntity.Name);
+        Assert.Equal("new-parent", updatedEntity.ParentId);
+        Assert.Equal("new-uuid", updatedEntity.Uuid);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ShouldNotAddPoll_WhenPollDoesNotExistAsync()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        await using var context = new AppDbContext(options);
+
+        var repository = new PollRepository(context);
+
+        var poll = new Poll
+        {
+            Id = 999,
+            Name = "New Poll",
+            ParentId = "parent-1",
+            Uuid = "uuid-1"
+        };
+
+        // Act
+        var result = await repository.UpdateAsync(poll);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(999, result.Id);
+
+        var entity = await context.Polls.FindAsync(999);
+
+        Assert.Null(entity);
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/PollVariableRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/PollVariableRepositoryTest.cs
@@ -1,0 +1,687 @@
+﻿using Eras.Application.Utils;
+using Eras.Domain.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL.Joins;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using Xunit;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+
+public class PollVariableRepositoryTest
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    private static Mock<DbSet<ErasCalculationsByPollEntity>> CreateMockErasCalculations(IEnumerable<ErasCalculationsByPollEntity> Data)
+    {
+        var queryable = new TestAsyncEnumerable<ErasCalculationsByPollEntity>(Data);
+        var dbSet = new Mock<DbSet<ErasCalculationsByPollEntity>>();
+
+        dbSet
+            .As<IAsyncEnumerable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.GetAsyncEnumerator(
+                It.IsAny<CancellationToken>()))
+            .Returns(() => queryable.GetAsyncEnumerator());
+
+        dbSet
+            .As<IQueryable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.Provider)
+            .Returns(((IQueryable<ErasCalculationsByPollEntity>)queryable).Provider);
+
+        dbSet
+            .As<IQueryable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.Expression)
+            .Returns(((IQueryable<ErasCalculationsByPollEntity>)queryable).Expression);
+
+        dbSet
+            .As<IQueryable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.ElementType)
+            .Returns(((IQueryable<ErasCalculationsByPollEntity>)queryable).ElementType);
+
+        dbSet
+            .As<IQueryable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.GetEnumerator())
+            .Returns(() => queryable.AsEnumerable().GetEnumerator());
+        return dbSet;
+    }
+
+    private static List<ErasCalculationsByPollEntity> CreateErasCalculations()
+    {
+        return [
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-uuid",
+                PollVariableId = 100,
+                ComponentName = "Component 1",
+                Question = "Question 1",
+                Position = 1,
+                AnswerText = "Yes",
+                PollInstanceId = 1,
+                StudentName = "Student 1",
+                StudentEmail = "student@test.com",
+                StudentId = 1,
+                CohortId = 1,
+                AnswerRisk = 1,
+                PollInstanceRiskSum = 1,
+                PollInstanceAnswersCount = 1,
+                ComponentAverageRisk = 1,
+                VariableAverageRisk = 1,
+                AnswerCount = 1,
+                AnswerPercentage = 100,
+                CohortName = "Cohort A",
+            },
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-uuid",
+                PollVariableId = 101,
+                ComponentName = "Component 2",
+                Question = "Question 2",
+                Position = 2,
+                AnswerText = "No",
+                PollInstanceId = 2,
+                StudentName = "Student 2",
+                StudentEmail = "student2@test.com",
+                StudentId = 2,
+                CohortId = 1,
+                AnswerRisk = 2,
+                PollInstanceRiskSum = 2,
+                PollInstanceAnswersCount = 1,
+                ComponentAverageRisk = 2,
+                VariableAverageRisk = 2,
+                AnswerCount = 1,
+                AnswerPercentage = 100,
+                CohortName = "Cohort A",
+            },
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-1",
+                PollId = 1,
+                PollVersion = 2,
+                CohortId = 1,
+                CohortName = "Cohort A",
+                StudentId = 2,
+                StudentName = "Bob",
+                PollInstanceId = 102,
+                ComponentName = "Engagement",
+                AnswerRisk = 2,
+                Question = "question5",
+                AnswerText = "Response",
+                StudentEmail = "ser@mail.com"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-1",
+                PollId = 1,
+                PollVersion = 2,
+                CohortId = 1,
+                CohortName = "Cohort A",
+                StudentId = 2,
+                StudentName = "Bob",
+                PollInstanceId = 102,
+                ComponentName = "Attendance",
+                AnswerRisk = 1,
+                Question = "question25",
+                AnswerText = "Response",
+                StudentEmail = "ser@mail.com"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-1",
+                PollId = 1,
+                PollVersion = 2,
+                CohortId = 2,
+                CohortName = "Cohort B",
+                StudentId = 3,
+                StudentName = "Charlie",
+                PollInstanceId = 103,
+                ComponentName = "Engagement",
+                AnswerRisk = 5,
+                Question = "question2",
+                AnswerText = "Response",
+                StudentEmail = "ser@mail.com"
+            },
+
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-1",
+                PollId = 1,
+                PollVersion = 1,
+                CohortId = 1,
+                CohortName = "Cohort A",
+                StudentId = 1,
+                StudentName = "Alice",
+                PollInstanceId = 91,
+                ComponentName = "Engagement",
+                AnswerRisk = 1,
+                Question = "question2",
+                AnswerText = "Response",
+                StudentEmail = "ser@mail.com"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-1",
+                PollId = 1,
+                PollVersion = 1,
+                CohortId = 1,
+                CohortName = "Cohort A",
+                StudentId = 4,
+                StudentName = "David",
+                PollInstanceId = 92,
+                ComponentName = "Engagement",
+                AnswerRisk = 4,
+                Question = "question2",
+                AnswerText = "Response",
+                StudentEmail = "ser@mail.com"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                PollUuid = "poll-2",
+                PollId = 2,
+                PollVersion = 3,
+                CohortId = 3,
+                CohortName = "Cohort C",
+                StudentId = 5,
+                StudentName = "Emma",
+                PollInstanceId = 201,
+                ComponentName = "Engagement",
+                AnswerRisk = 5,
+                Question = "question2",
+                AnswerText = "Response",
+                StudentEmail = "ser@mail.com"
+            }
+        ];
+    }
+
+    [Fact]
+    public async Task GetByPollIdAndVariableIdAsync_ShouldReturnVariable_WhenExistsAsync()
+    {
+        await using var context = CreateContext();
+
+        var variable = new VariableEntity{ Id = 10 };
+
+        context.Variables.Add(variable);
+
+        context.PollVariables.Add(new PollVariableJoin
+        {
+            Id = 1,
+            PollId = 5,
+            VariableId = 10,
+            Variable = variable
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new PollVariableRepository(context);
+
+        var result = await repository.GetByPollIdAndVariableIdAsync(5, 10);
+
+        Assert.NotNull(result);
+        Assert.Equal(10, result.Id);
+    }
+
+    [Fact]
+    public async Task GetByPollIdAndVariableIdAsync_ShouldReturnNull_WhenDoesNotExistAsync()
+    {
+        await using var context = CreateContext();
+
+        context.PollVariables.Add(new PollVariableJoin
+        {
+            Id = 1,
+            PollId = 5,
+            VariableId = 10
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new PollVariableRepository(context);
+
+        var result = await repository.GetByPollIdAndVariableIdAsync(5, 999);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByPollUuidVariableIdAsync_ShouldReturnEmpty_WhenPollDoesNotExistAsync()
+    {
+        await using var context = CreateContext();
+
+        context.PollVariables.Add(new PollVariableJoin
+        {
+            Id = 100,
+            PollId = 1,
+            VariableId = 10
+        });
+
+        var calculations = CreateErasCalculations();
+        var calculationsDbSet = CreateMockErasCalculations(calculations);
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+
+        await context.SaveChangesAsync();
+
+        var repository = new PollVariableRepository(context);
+
+        var pagination = new Pagination
+        {
+            Page = 1,
+            PageSize = 10
+        };
+
+        var result = await repository.GetByPollUuidVariableIdAsync(
+            "unknown-poll",
+            [10],
+            pagination);
+
+        Assert.NotNull(result);
+        Assert.Equal(0, result.Count);
+        Assert.Empty(result.Items);
+    }
+
+    [Fact]
+    public async Task GetByPollUuidVariableIdAsync_ShouldReturnEmpty_WhenVariableIdsDoNotMatchAsync()
+    {
+        await using var context = CreateContext();
+
+        context.Polls.Add(new PollEntity
+        {
+            Id = 1,
+            Uuid = "poll-uuid"
+        });
+
+        context.PollVariables.Add(new PollVariableJoin
+        {
+            Id = 100,
+            PollId = 1,
+            VariableId = 10
+        });
+
+        var calculations = CreateErasCalculations();
+        var calculationsDbSet = CreateMockErasCalculations(calculations);
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+
+        await context.SaveChangesAsync();
+
+        var repository = new PollVariableRepository(context);
+
+        var pagination = new Pagination
+        {
+            Page = 1,
+            PageSize = 10
+        };
+
+        var result = await repository.GetByPollUuidVariableIdAsync(
+            "poll-uuid",
+            [999],
+            pagination);
+
+        Assert.NotNull(result);
+        Assert.Equal(0, result.Count);
+        Assert.Empty(result.Items);
+    }
+
+    [Fact]
+    public async Task GetByPollUuidAsync_ShouldReturnAnswersForRequestedPollAndVariablesAsync()
+    {
+        await using var context = CreateContext();
+
+        var student = new StudentEntity
+        {
+            Id = 1,
+            Uuid = "student-uuid",
+            Name = "Student 1",
+            Email = "student@test.com"
+        };
+
+        var variable = new VariableEntity
+        {
+            Id = 10
+        };
+
+        var component = new ComponentEntity
+        {
+            Id = 1
+        };
+
+        variable.ComponentId = component.Id;
+        variable.Component = component;
+
+        context.Students.Add(student);
+        context.Variables.Add(variable);
+        context.Components.Add(component);
+
+        context.PollInstances.Add(new PollInstanceEntity
+        {
+            Id = 1,
+            Uuid = "poll-instance-uuid",
+            StudentId = student.Id,
+            Student = student
+        });
+
+        context.PollVariables.Add(new PollVariableJoin
+        {
+            Id = 100,
+            VariableId = variable.Id,
+            Variable = variable
+        });
+
+        context.Answers.Add(new AnswerEntity
+        {
+            Id = 1,
+            PollInstanceId = 1,
+            PollVariableId = 100,
+            RiskLevel = 2
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new PollVariableRepository(context);
+
+        var result = await repository.GetByPollUuidAsync(
+            "poll-instance-uuid",
+            "10");
+
+        Assert.Single(result);
+        Assert.Equal(1, result[0].Answer.Id);
+        Assert.Equal(10, result[0].Variable.Id);
+        Assert.Equal(1, result[0].Student.Id);
+    }
+
+    [Fact]
+    public async Task GetByPollUuidAsync_ShouldGroupAnswersByStudentAsync()
+    {
+        await using var context = CreateContext();
+
+        var student = new StudentEntity
+        {
+            Id = 1,
+            Uuid = "student-uuid",
+            Name = "Student 1",
+            Email = "student@test.com"
+        };
+
+        var component = new ComponentEntity
+        {
+            Id = 1
+        };
+
+        var variable1 = new VariableEntity
+        {
+            Id = 10,
+            ComponentId = 1,
+            Component = component
+        };
+
+        var variable2 = new VariableEntity
+        {
+            Id = 20,
+            ComponentId = 1,
+            Component = component
+        };
+
+        context.Students.Add(student);
+        context.Components.Add(component);
+        context.Variables.AddRange(variable1, variable2);
+
+        context.PollInstances.Add(new PollInstanceEntity
+        {
+            Id = 1,
+            Uuid = "poll-instance-uuid",
+            StudentId = 1,
+            Student = student
+        });
+
+        context.PollVariables.AddRange(
+            new PollVariableJoin
+            {
+                Id = 100,
+                VariableId = 10,
+                Variable = variable1
+            },
+            new PollVariableJoin
+            {
+                Id = 200,
+                VariableId = 20,
+                Variable = variable2
+            });
+
+        context.Answers.AddRange(
+            new AnswerEntity
+            {
+                Id = 1,
+                PollInstanceId = 1,
+                PollVariableId = 100,
+                RiskLevel = 1
+            },
+            new AnswerEntity
+            {
+                Id = 2,
+                PollInstanceId = 1,
+                PollVariableId = 200,
+                RiskLevel = 3
+            });
+
+        await context.SaveChangesAsync();
+
+        var repository = new PollVariableRepository(context);
+
+        var result = await repository.GetByPollUuidAsync(
+            "poll-instance-uuid",
+            "10,20");
+
+        // The two answers belong to the same student, therefore
+        // GroupBy(Student.Name) produces one result.
+        Assert.Single(result);
+        Assert.Equal(1, result[0].Student.Id);
+    }
+
+    [Fact]
+    public async Task GetByPollUuidAsync_ShouldReturnEmpty_WhenPollDoesNotExistAsync()
+    {
+        await using var context = CreateContext();
+
+        var result = await new PollVariableRepository(context)
+            .GetByPollUuidAsync("unknown-poll", "1");
+
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetAnswersByPollUuidAsync_ShouldReturnAnswersAsync()
+    {
+        await using var context = CreateContext();
+
+        context.PollInstances.AddRange(
+            new PollInstanceEntity
+            {
+                Id = 1,
+                Uuid = "poll-uuid"
+            },
+            new PollInstanceEntity
+            {
+                Id = 2,
+                Uuid = "other-poll"
+            });
+
+        context.Answers.AddRange(
+            new AnswerEntity
+            {
+                Id = 1,
+                PollInstanceId = 1,
+                AnswerText = "Answer 1"
+            },
+            new AnswerEntity
+            {
+                Id = 2,
+                PollInstanceId = 2,
+                AnswerText = "Answer 2"
+            });
+
+        await context.SaveChangesAsync();
+
+        var repository = new PollVariableRepository(context);
+
+        var result = await repository.GetAnswersByPollUuidAsync("poll-uuid");
+
+        Assert.Single(result);
+        Assert.Equal(1, result[0].Id);
+        Assert.Equal("Answer 1", result[0].AnswerText);
+    }
+
+    [Fact]
+    public async Task GetAnswersByPollUuidAsync_ShouldReturnEmpty_WhenPollDoesNotExistAsync()
+    {
+        await using var context = CreateContext();
+
+        context.PollInstances.Add(new PollInstanceEntity
+        {
+            Id = 1,
+            Uuid = "poll-uuid"
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new PollVariableRepository(context);
+
+        var result = await repository.GetAnswersByPollUuidAsync("unknown-poll");
+
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetAllWithVariablesAsync_ShouldReturnPollVariablesAsync()
+    {
+        await using var context = CreateContext();
+
+        var variable = new VariableEntity
+        {
+            Id = 10
+        };
+
+        context.Variables.Add(variable);
+
+        context.PollVariables.Add(new PollVariableJoin
+        {
+            Id = 1,
+            PollId = 5,
+            VariableId = 10,
+            Variable = variable
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new PollVariableRepository(context);
+
+        var result = await repository.GetAllWithVariablesAsync();
+
+        Assert.Single(result);
+        Assert.Equal(10, result[0].Id);
+    }
+
+    [Fact]
+    public async Task GetAllWithVariablesAsync_ShouldReturnEmpty_WhenNoPollVariablesExistAsync()
+    {
+        await using var context = CreateContext();
+
+        var repository = new PollVariableRepository(context);
+
+        var result = await repository.GetAllWithVariablesAsync();
+
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetAllWithVariablesByPollIdAsync_ShouldReturnOnlyVariablesForPollAsync()
+    {
+        await using var context = CreateContext();
+
+        var variable1 = new VariableEntity
+        {
+            Id = 10
+        };
+
+        var variable2 = new VariableEntity
+        {
+            Id = 20
+        };
+
+        context.Variables.AddRange(variable1, variable2);
+
+        context.PollVariables.AddRange(
+            new PollVariableJoin
+            {
+                Id = 1,
+                PollId = 5,
+                VariableId = 10,
+                Variable = variable1
+            },
+            new PollVariableJoin
+            {
+                Id = 2,
+                PollId = 6,
+                VariableId = 20,
+                Variable = variable2
+            });
+
+        await context.SaveChangesAsync();
+
+        var repository = new PollVariableRepository(context);
+
+        var result = await repository.GetAllWithVariablesByPollIdAsync(5);
+
+        Assert.Single(result);
+        Assert.Equal(10, result[0].Id);
+    }
+
+    [Fact]
+    public async Task GetAllWithVariablesByPollIdAsync_ShouldReturnEmpty_WhenPollHasNoVariablesAsync()
+    {
+        await using var context = CreateContext();
+
+        context.PollVariables.Add(new PollVariableJoin
+        {
+            Id = 1,
+            PollId = 5,
+            VariableId = 10
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new PollVariableRepository(context);
+
+        var result = await repository.GetAllWithVariablesByPollIdAsync(999);
+
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task AddBatchPollVariablesAsync_ShouldThrow_WhenSaveChangesFailsAsync()
+    {
+        await using var context = CreateContext();
+
+        var repository = new PollVariableRepository(context);
+        var variables = new List<Variable>
+        {
+            new Variable()
+        };
+
+        await Assert.ThrowsAnyAsync<Exception>(
+            () => repository.AddBatchPollVariablesAsync(variables));
+    }
+}
+

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/PollVariableRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/PollVariableRepositoryTest.cs
@@ -14,16 +14,8 @@ using Xunit;
 
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
 
-public class PollVariableRepositoryTest
+public class PollVariableRepositoryTest : RepositoryTestBase
 {
-    private static AppDbContext CreateContext()
-    {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        return new AppDbContext(options);
-    }
 
     private static Mock<DbSet<ErasCalculationsByPollEntity>> CreateMockErasCalculations(IEnumerable<ErasCalculationsByPollEntity> Data)
     {

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ServiceProvidersRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ServiceProvidersRepositoryTest.cs
@@ -1,0 +1,123 @@
+﻿using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Xunit;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+
+public class ServiceProvidersRepositoryTest
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_ShouldReturnServiceProvider_WhenExistsAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        context.ServiceProviders.Add(new ServiceProvidersEntity
+        {
+            Id = 1,
+            ServiceProviderName = "Test Provider",
+            ServiceProviderLogo = "logo"
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new ServiceProvidersRepository(context);
+
+        // Act
+        var result = await repository.GetByNameAsync("Test Provider");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Test Provider", result.ServiceProviderName);
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_ShouldReturnNull_WhenServiceProviderDoesNotExistAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        context.ServiceProviders.Add(new ServiceProvidersEntity
+        {
+            Id = 1,
+            ServiceProviderName = "Test Provider",
+            ServiceProviderLogo = "logo"
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new ServiceProvidersRepository(context);
+
+        // Act
+        var result = await repository.GetByNameAsync("Unknown Provider");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_ShouldReturnFirstMatchingServiceProvider_WhenMultipleExistAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        context.ServiceProviders.AddRange(
+            new ServiceProvidersEntity
+            {
+                Id = 1,
+                ServiceProviderName = "Provider A",
+                ServiceProviderLogo = "logo"
+            },
+            new ServiceProvidersEntity
+            {
+                Id = 2,
+                ServiceProviderName = "Provider B",
+                ServiceProviderLogo = "logo"
+            },
+            new ServiceProvidersEntity
+            {
+                Id = 3,
+                ServiceProviderName = "Provider A",
+                ServiceProviderLogo = "logo"
+            });
+
+        await context.SaveChangesAsync();
+
+        var repository = new ServiceProvidersRepository(context);
+
+        // Act
+        var result = await repository.GetByNameAsync("Provider A");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Provider A", result.ServiceProviderName);
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_ShouldReturnNull_WhenDatabaseIsEmptyAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var repository = new ServiceProvidersRepository(context);
+
+        // Act
+        var result = await repository.GetByNameAsync("Test Provider");
+
+        // Assert
+        Assert.Null(result);
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ServiceProvidersRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/ServiceProvidersRepositoryTest.cs
@@ -1,6 +1,7 @@
 ﻿using Eras.Infrastructure.Persistence.PostgreSQL;
 using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -8,16 +9,8 @@ using Xunit;
 
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
 
-public class ServiceProvidersRepositoryTest
+public class ServiceProvidersRepositoryTest : RepositoryTestBase
 {
-    private static AppDbContext CreateContext()
-    {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        return new AppDbContext(options);
-    }
 
     [Fact]
     public async Task GetByNameAsync_ShouldReturnServiceProvider_WhenExistsAsync()

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/StudentAnswersRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/StudentAnswersRepositoryTest.cs
@@ -1,0 +1,478 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+
+using Eras.Domain.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL.Joins;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using Xunit;
+
+public class StudentAnswersRepositoryTest
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    private static Mock<DbSet<ErasCalculationsByPollEntity>> CreateMockErasCalculations(IEnumerable<ErasCalculationsByPollEntity> Data)
+    {
+        var queryable = new TestAsyncEnumerable<ErasCalculationsByPollEntity>(Data);
+        var dbSet = new Mock<DbSet<ErasCalculationsByPollEntity>>();
+
+        dbSet
+            .As<IAsyncEnumerable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.GetAsyncEnumerator(
+                It.IsAny<CancellationToken>()))
+            .Returns(() => queryable.GetAsyncEnumerator());
+
+        dbSet
+            .As<IQueryable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.Provider)
+            .Returns(((IQueryable<ErasCalculationsByPollEntity>)queryable).Provider);
+
+        dbSet
+            .As<IQueryable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.Expression)
+            .Returns(((IQueryable<ErasCalculationsByPollEntity>)queryable).Expression);
+
+        dbSet
+            .As<IQueryable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.ElementType)
+            .Returns(((IQueryable<ErasCalculationsByPollEntity>)queryable).ElementType);
+
+        dbSet
+            .As<IQueryable<ErasCalculationsByPollEntity>>()
+            .Setup(X => X.GetEnumerator())
+            .Returns(() => queryable.AsEnumerable().GetEnumerator());
+        return dbSet;
+    }
+
+    private static List<ErasCalculationsByPollEntity> CreateErasCalculations()
+    {
+        return [
+            new ErasCalculationsByPollEntity
+            {
+                StudentId = 1,
+                PollId = 10,
+                Question = "Question 1",
+                Position = 1,
+                ComponentName = "Component 1",
+                AnswerText = "Yes",
+                AnswerRisk = 2,
+                PollUuid = "10",
+                CohortName = "Cohort A",
+                StudentEmail = "A@mail.com",
+                StudentName = "Anne"
+            },
+            new ErasCalculationsByPollEntity
+            {
+                StudentId = 1,
+                PollId = 10,
+                Question = "Question 2",
+                Position = 2,
+                ComponentName = "Component 2",
+                AnswerText = "No",
+                AnswerRisk = 3,
+                PollUuid = "10",
+                CohortName = "Cohort A",
+                StudentEmail = "A@mail.com",
+                StudentName = "Anne"
+            }
+        ];
+    }
+
+    [Fact]
+    public async Task GetStudentAnswersPagedAsync_ShouldReturnStudentAnswersAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var calculations = CreateErasCalculations();
+        var calculationsDbSet = CreateMockErasCalculations(calculations);
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+        await context.SaveChangesAsync();
+
+        var repository = new StudentAnswersRepository(context);
+
+        // Act
+        var result = await repository.GetStudentAnswersPagedAsync(StudentId: 1, PollId: 10, Page: 1, PageSize: 10);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count);
+        Assert.Equal(2, result.Items.Count);
+
+        Assert.Equal("Question 1", result.Items[0].Variable);
+        Assert.Equal(1, result.Items[0].Position);
+        Assert.Equal("Component 1", result.Items[0].Component);
+        Assert.Equal("Yes", result.Items[0].Answer);
+        Assert.Equal(2, result.Items[0].Score);
+
+        Assert.Equal("Question 2", result.Items[1].Variable);
+        Assert.Equal(2, result.Items[1].Position);
+        Assert.Equal("Component 2", result.Items[1].Component);
+        Assert.Equal("No", result.Items[1].Answer);
+        Assert.Equal(3, result.Items[1].Score);
+    }
+
+    [Fact]
+    public async Task GetStudentAnswersPagedAsync_ShouldReturnEmpty_WhenStudentHasNoAnswersAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var calculations = CreateErasCalculations();
+        var calculationsDbSet = CreateMockErasCalculations(calculations);
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+        await context.SaveChangesAsync();
+
+        var repository = new StudentAnswersRepository(context);
+
+        // Act
+        var result = await repository.GetStudentAnswersPagedAsync(StudentId: 999, PollId: 10, Page: 1, PageSize: 10);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(0, result.Count);
+        Assert.Empty(result.Items);
+    }
+
+    [Fact]
+    public async Task GetStudentAnswersPagedAsync_ShouldReturnEmpty_WhenPollDoesNotMatchAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var calculations = CreateErasCalculations();
+        var calculationsDbSet = CreateMockErasCalculations(calculations);
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+        await context.SaveChangesAsync();
+
+        var repository = new StudentAnswersRepository(context);
+
+        // Act
+        var result = await repository.GetStudentAnswersPagedAsync(StudentId: 1, PollId: 999, Page: 1, PageSize: 10);
+
+        // Assert
+        Assert.Equal(0, result.Count);
+        Assert.Empty(result.Items);
+    }
+
+    [Fact]
+    public async Task GetStudentAnswersPagedAsync_ShouldReturnDistinctQuestionsAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var calculations = CreateErasCalculations();
+        var calculationsDbSet = CreateMockErasCalculations(calculations);
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+        await context.SaveChangesAsync();
+
+        var repository = new StudentAnswersRepository(context);
+
+        // Act
+        var result = await repository.GetStudentAnswersPagedAsync(StudentId: 1, PollId: 10, Page: 1, PageSize: 10);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Equal(2, result.Items.Count);
+    }
+
+    [Fact]
+    public async Task GetStudentAnswersPagedAsync_ShouldOrderByPositionAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var calculations = CreateErasCalculations();
+        var calculationsDbSet = CreateMockErasCalculations(calculations);
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+        await context.SaveChangesAsync();
+
+        var repository = new StudentAnswersRepository(context);
+
+        // Act
+        var result = await repository.GetStudentAnswersPagedAsync(StudentId: 1,PollId: 10, Page: 1, PageSize: 10);
+ 
+        // Assert
+        Assert.Equal(2, result.Items.Count);
+
+        Assert.Equal(1, result.Items[0].Position);
+        Assert.Equal(2, result.Items[1].Position);
+    }
+
+    [Fact]
+    public async Task GetStudentAnswersPagedAsync_ShouldApplyPageSizeAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var calculations = CreateErasCalculations();
+        var calculationsDbSet = CreateMockErasCalculations(calculations);
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+        await context.SaveChangesAsync();
+
+        var repository = new StudentAnswersRepository(context);
+
+        // Act
+        var result = await repository.GetStudentAnswersPagedAsync(StudentId: 1, PollId: 10, Page: 1, PageSize: 2);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Equal(2, result.Items.Count);
+
+        Assert.Equal("Question 1", result.Items[0].Variable);
+        Assert.Equal("Question 2", result.Items[1].Variable);
+    }
+
+    [Fact]
+    public async Task GetStudentAnswersPagedAsync_ShouldReturnEmpty_WhenPageIsBeyondResultsAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var calculations = CreateErasCalculations();
+        var calculationsDbSet = CreateMockErasCalculations(calculations);
+        context.ErasCalculationsByPoll = calculationsDbSet.Object;
+        await context.SaveChangesAsync();
+
+        var repository = new StudentAnswersRepository(context);
+
+        // Act
+        var result = await repository.GetStudentAnswersPagedAsync(StudentId: 1, PollId: 10, Page: 2,PageSize: 10);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Empty(result.Items);
+    }
+
+    [Fact]
+    public async Task GetStudentAnswersAsync_ShouldReturnMatchingAnswersAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var component = new ComponentEntity
+        {
+            Id = 1,
+            Name = "Component 1"
+        };
+
+        var variable = new VariableEntity
+        {
+            Id = 10,
+            Name = "Variable 1",
+            ComponentId = 1,
+            Component = component
+        };
+
+        var student = new StudentEntity
+        {
+            Id = 1,
+            Name = "Student 1",
+            Uuid = "student-1",
+            Email = "st@mail.com"
+        };
+
+        var pollInstance = new PollInstanceEntity
+        {
+            Id = 100,
+            StudentId = 1,
+            Student = student
+        };
+
+        var pollVariable = new PollVariableJoin
+        {
+            Id = 200,
+            PollId = 10,
+            VariableId = 10,
+            Variable = variable
+        };
+
+        context.Components.Add(component);
+        context.Variables.Add(variable);
+        context.Students.Add(student);
+        context.PollInstances.Add(pollInstance);
+        context.PollVariables.Add(pollVariable);
+
+        context.Answers.Add(new AnswerEntity
+        {
+            Id = 1,
+            PollInstanceId = 100,
+            PollVariableId = 200,
+            AnswerText = "Yes",
+            RiskLevel = 2
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new StudentAnswersRepository(context);
+
+        // Act
+        var result = await repository.GetStudentAnswersAsync(StudentId: 1, PollId: 10);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("Variable 1", result[0].Variable);
+        Assert.Equal(200, result[0].Position);
+        Assert.Equal("Component 1", result[0].Component);
+        Assert.Equal("Yes", result[0].Answer);
+        Assert.Equal(2, result[0].Score);
+    }
+
+    [Fact]
+    public async Task GetStudentAnswersAsync_ShouldReturnEmpty_WhenStudentDoesNotMatchAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        context.Answers.Add(new AnswerEntity
+        {
+            Id = 1,
+            PollInstanceId = 100,
+            PollVariableId = 200,
+            AnswerText = "Yes"
+        });
+
+        context.PollInstances.Add(new PollInstanceEntity
+        {
+            Id = 100,
+            StudentId = 1
+        });
+
+        context.PollVariables.Add(new PollVariableJoin
+        {
+            Id = 200,
+            PollId = 10,
+            VariableId = 20
+        });
+
+        context.Variables.Add(new VariableEntity
+        {
+            Id = 20,
+            Name = "Variable"
+        });
+
+        context.Components.Add(new ComponentEntity
+        {
+            Id = 1,
+            Name = "Component"
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new StudentAnswersRepository(context);
+
+        // Act
+        var result = await repository.GetStudentAnswersAsync(StudentId: 999, PollId: 10);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetStudentAnswersAsync_ShouldReturnEmpty_WhenPollDoesNotMatchAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        context.PollInstances.Add(new PollInstanceEntity
+        {
+            Id = 100,
+            StudentId = 1
+        });
+
+        context.PollVariables.Add(new PollVariableJoin
+        {
+            Id = 200,
+            PollId = 10,
+            VariableId = 20
+        });
+
+        context.Variables.Add(new VariableEntity
+        {
+            Id = 20,
+            Name = "Variable"
+        });
+
+        context.Components.Add(new ComponentEntity
+        {
+            Id = 1,
+            Name = "Component"
+        });
+
+        context.Answers.Add(new AnswerEntity
+        {
+            Id = 1,
+            PollInstanceId = 100,
+            PollVariableId = 200,
+            AnswerText = "Yes"
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new StudentAnswersRepository(context);
+
+        // Act
+        var result = await repository.GetStudentAnswersAsync(StudentId: 1, PollId: 999);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetStudentAnswersAsync_ShouldReturnEmpty_WhenNoAnswersExistAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var repository = new StudentAnswersRepository(context);
+
+        // Act
+        var result = await repository.GetStudentAnswersAsync(StudentId: 1, PollId: 10);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ShouldThrowNotImplementedExceptionAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var repository = new StudentAnswersRepository(context);
+
+        var entity = new StudentAnswer
+        {
+            Variable = "Variable",
+            Position = 1,
+            Component = "Component",
+            Answer = "Answer",
+            Score = 1
+        };
+
+        // Assert
+        await Assert.ThrowsAsync<NotImplementedException>(
+            () => repository.UpdateAsync(entity));
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/StudentAnswersRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/StudentAnswersRepositoryTest.cs
@@ -19,16 +19,8 @@ using Moq;
 
 using Xunit;
 
-public class StudentAnswersRepositoryTest
+public class StudentAnswersRepositoryTest : RepositoryTestBase
 {
-    private static AppDbContext CreateContext()
-    {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        return new AppDbContext(options);
-    }
 
     private static Mock<DbSet<ErasCalculationsByPollEntity>> CreateMockErasCalculations(IEnumerable<ErasCalculationsByPollEntity> Data)
     {

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/StudentCohortRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/StudentCohortRepositoryTest.cs
@@ -1,0 +1,502 @@
+﻿using Eras.Application.Utils;
+using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL.Joins;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Xunit;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+
+public class StudentCohortRepositoryTest
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    [Fact]
+    public async Task GetByCohortIdAndStudentIdAsync_ShouldReturnStudent_WhenExistsAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var student = new StudentEntity
+        {
+            Id = 1,
+            Uuid = "student-uuid",
+            Email = "stu@mail.com",
+            Name = "Student 1"
+        };
+
+        context.Students.Add(student);
+
+        context.StudentCohorts.Add(new StudentCohortJoin
+        {
+            StudentId = 1,
+            CohortId = 10,
+            Student = student
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new StudentCohortRepository(context);
+
+        // Act
+        var result = await repository.GetByCohortIdAndStudentIdAsync(
+            CohortId: 10,
+            StudentId: 1);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Id);
+        Assert.Equal("student-uuid", result.Uuid);
+        Assert.Equal("Student 1", result.Name);
+    }
+
+    [Fact]
+    public async Task GetByCohortIdAndStudentIdAsync_ShouldReturnNull_WhenStudentDoesNotExistAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        context.StudentCohorts.Add(new StudentCohortJoin
+        {
+            StudentId = 1,
+            CohortId = 10
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new StudentCohortRepository(context);
+
+        // Act
+        var result = await repository.GetByCohortIdAndStudentIdAsync(
+            CohortId: 10,
+            StudentId: 999);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByCohortIdAndStudentIdAsync_ShouldReturnNull_WhenCohortDoesNotMatchAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var student = new StudentEntity
+        {
+            Id = 1,
+            Uuid = "student-uuid",
+            Email = "stu@mail.com",
+            Name = "Student 1"
+        };
+
+        context.Students.Add(student);
+
+        context.StudentCohorts.Add(new StudentCohortJoin
+        {
+            StudentId = 1,
+            CohortId = 10,
+            Student = student
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new StudentCohortRepository(context);
+
+        // Act
+        var result = await repository.GetByCohortIdAndStudentIdAsync(
+            CohortId: 999,
+            StudentId: 1);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetAllStudentsByCohortIdAsync_ShouldReturnStudentsAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var student1 = new StudentEntity
+        {
+            Id = 1,
+            Uuid = "student-1",
+            Email = "stu@mail.com",
+            Name = "Student 1",
+        };
+
+        var student2 = new StudentEntity
+        {
+            Id = 2,
+            Uuid = "student-2",
+            Email = "stu@mail.com",
+            Name = "Student 2",
+        };
+
+        context.Students.AddRange(student1, student2);
+
+        context.StudentCohorts.AddRange(
+            new StudentCohortJoin
+            {
+                StudentId = 1,
+                CohortId = 10,
+                Student = student1
+            },
+            new StudentCohortJoin
+            {
+                StudentId = 2,
+                CohortId = 10,
+                Student = student2
+            });
+
+        await context.SaveChangesAsync();
+
+        var repository = new StudentCohortRepository(context);
+
+        // Act
+        var result = await repository.GetAllStudentsByCohortIdAsync(10);
+
+        // Assert
+        Assert.NotNull(result);
+
+        var students = result.ToList();
+
+        Assert.Equal(2, students.Count);
+        Assert.Contains(students, S => S.Id == 1);
+        Assert.Contains(students, S => S.Id == 2);
+    }
+
+    [Fact]
+    public async Task GetAllStudentsByCohortIdAsync_ShouldReturnOnlyStudentsFromRequestedCohortAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var student1 = new StudentEntity
+        {
+            Id = 1,
+            Uuid = "student-1",
+            Name = "Student 1",
+            Email = "stu@mail.com"
+        };
+
+        var student2 = new StudentEntity
+        {
+            Id = 2,
+            Uuid = "student-2",
+            Name = "Student 2",
+            Email = "stu@mail.com"
+        };
+
+        context.Students.AddRange(student1, student2);
+
+        context.StudentCohorts.AddRange(
+            new StudentCohortJoin
+            {
+                StudentId = 1,
+                CohortId = 10,
+                Student = student1
+            },
+            new StudentCohortJoin
+            {
+                StudentId = 2,
+                CohortId = 20,
+                Student = student2
+            });
+
+        await context.SaveChangesAsync();
+
+        var repository = new StudentCohortRepository(context);
+
+        // Act
+        var result = await repository.GetAllStudentsByCohortIdAsync(10);
+
+        // Assert
+        var students = result!.ToList();
+
+        Assert.Single(students);
+        Assert.Equal(1, students[0].Id);
+    }
+
+    [Fact]
+    public async Task GetAllStudentsByCohortIdAsync_ShouldReturnEmpty_WhenCohortHasNoStudentsAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        context.StudentCohorts.Add(new StudentCohortJoin
+        {
+            StudentId = 1,
+            CohortId = 10
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new StudentCohortRepository(context);
+
+        // Act
+        var result = await repository.GetAllStudentsByCohortIdAsync(999);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetCohortsSummaryAsync_ShouldReturnStudentAndCohortSummaryAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var cohort = new CohortEntity
+        {
+            Id = 10,
+            Name = "Cohort 1",
+            CourseCode = "123"
+        };
+
+        var student = new StudentEntity
+        {
+            Id = 1,
+            Uuid = "student-uuid",
+            Name = "Student 1",
+            Email = "stu@mail.com"
+        };
+
+        var pollInstance = new PollInstanceEntity
+        {
+            Id = 100,
+            StudentId = 1,
+            Student = student,
+            FinishedAt = new DateTime(2026, 1, 15)
+        };
+
+        var pollVariable = new PollVariableJoin
+        {
+            Id = 200,
+            PollId = 50,
+            VariableId = 300
+        };
+
+        var answer1 = new AnswerEntity
+        {
+            Id = 1,
+            PollInstanceId = 100,
+            PollVariableId = 200,
+            RiskLevel = 2,
+            PollVariable = pollVariable
+        };
+
+        var answer2 = new AnswerEntity
+        {
+            Id = 2,
+            PollInstanceId = 100,
+            PollVariableId = 200,
+            RiskLevel = 4,
+            PollVariable = pollVariable
+        };
+
+        pollInstance.Answers = new List<AnswerEntity>
+        {
+            answer1,
+            answer2
+        };
+
+        student.PollInstances = new List<PollInstanceEntity>
+        {
+            pollInstance
+        };
+
+        context.Cohorts.Add(cohort);
+        context.Students.Add(student);
+        context.PollInstances.Add(pollInstance);
+        context.PollVariables.Add(pollVariable);
+        context.Answers.AddRange(answer1, answer2);
+
+        context.StudentCohorts.Add(new StudentCohortJoin
+        {
+            StudentId = 1,
+            CohortId = 10,
+            Student = student,
+            Cohort = cohort
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new StudentCohortRepository(context);
+
+        var pagination = new Pagination
+        {
+            Page = 0,
+            PageSize = 10
+        };
+
+        // Act
+        var result = await repository.GetCohortsSummaryAsync(pagination);
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.Equal(1, result.StudentCount);
+        Assert.Equal(1, result.CohortCount);
+
+        var summary = result.Summary.ToList();
+
+        Assert.Single(summary);
+
+        Assert.Equal("student-uuid", summary[0].StudentUuid);
+        Assert.Equal("Student 1", summary[0].StudentName);
+        Assert.Equal(10, summary[0].CohortId);
+        Assert.Equal("Cohort 1", summary[0].CohortName);
+
+        // (2 + 4) / 2 = 3
+        Assert.Equal(3, summary[0].PollinstancesAverage);
+
+        Assert.Equal(1, summary[0].PollinstancesCount);
+    }
+
+    [Fact]
+    public async Task GetCohortsSummaryAsync_ShouldReturnZeroPollInstances_WhenStudentHasNoPollInstancesAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var cohort = new CohortEntity
+        {
+            Id = 10,
+            Name = "Cohort 1",
+            CourseCode = "123"
+        };
+
+        var student = new StudentEntity
+        {
+            Id = 1,
+            Uuid = "student-uuid",
+            Name = "Student 1",
+            Email = "stu@mail.com"
+        };
+
+        context.Cohorts.Add(cohort);
+        context.Students.Add(student);
+
+        context.StudentCohorts.Add(new StudentCohortJoin
+        {
+            StudentId = 1,
+            CohortId = 10,
+            Student = student,
+            Cohort = cohort
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new StudentCohortRepository(context);
+
+        var pagination = new Pagination
+        {
+            Page = 1,
+            PageSize = 10
+        };
+
+        // Act
+        var result = await repository.GetCohortsSummaryAsync(pagination);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(1, result.StudentCount);
+        Assert.Equal(1, result.CohortCount);
+        Assert.Empty(result.Summary);
+    }
+
+    [Fact]
+    public async Task GetCohortsSummaryAsync_ShouldIgnorePollInstanceOutsideDateRangeAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var cohort = new CohortEntity
+        {
+            Id = 10,
+            Name = "Cohort 1",
+            CourseCode = "123"
+        };
+
+        var student = new StudentEntity
+        {
+            Id = 1,
+            Uuid = "student-uuid",
+            Name = "Student 1",
+            Email = "stu@mail.com"
+        };
+
+        var pollInstance = new PollInstanceEntity
+        {
+            Id = 100,
+            StudentId = 1,
+            Student = student,
+            FinishedAt = new DateTime(2025, 1, 1)
+        };
+
+        context.Cohorts.Add(cohort);
+        context.Students.Add(student);
+        context.PollInstances.Add(pollInstance);
+
+        context.StudentCohorts.Add(new StudentCohortJoin
+        {
+            StudentId = 1,
+            CohortId = 10,
+            Student = student,
+            Cohort = cohort
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new StudentCohortRepository(context);
+
+        var pagination = new Pagination
+        {
+            Page = 1,
+            PageSize = 10
+        };
+
+        // Act
+        var result = await repository.GetCohortsSummaryAsync(
+            pagination,
+            startDate: new DateTime(2026, 1, 1),
+            endDate: new DateTime(2026, 12, 31));
+
+        // Assert
+        Assert.Equal(1, result.StudentCount);
+        Assert.Equal(1, result.CohortCount);
+        Assert.Empty(result.Summary);
+    }
+
+    [Fact]
+    public async Task GetCohortsSummaryAsync_ShouldReturnEmptySummary_WhenNoStudentsExistAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var repository = new StudentCohortRepository(context);
+
+        var pagination = new Pagination { Page = 1, PageSize = 10 };
+
+        // Act
+        var result = await repository.GetCohortsSummaryAsync(pagination);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(0, result.StudentCount);
+        Assert.Equal(0, result.CohortCount);
+        Assert.Empty(result.Summary);
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/StudentCohortRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/StudentCohortRepositoryTest.cs
@@ -3,6 +3,7 @@ using Eras.Infrastructure.Persistence.PostgreSQL;
 using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Joins;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -10,16 +11,8 @@ using Xunit;
 
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
 
-public class StudentCohortRepositoryTest
+public class StudentCohortRepositoryTest : RepositoryTestBase
 {
-    private static AppDbContext CreateContext()
-    {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        return new AppDbContext(options);
-    }
 
     [Fact]
     public async Task GetByCohortIdAndStudentIdAsync_ShouldReturnStudent_WhenExistsAsync()

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/StudentDetailRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/StudentDetailRepositoryTest.cs
@@ -2,6 +2,7 @@
 using Eras.Infrastructure.Persistence.PostgreSQL;
 using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -9,17 +10,8 @@ using Xunit;
 
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
 
-public class StudentDetailRepositoryTest
+public class StudentDetailRepositoryTest : RepositoryTestBase
 {
-    private static AppDbContext CreateContext()
-    {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        return new AppDbContext(options);
-    }
-
     [Fact]
     public async Task GetByStudentId_ShouldReturnStudentDetail_WhenExistsAsync()
     {

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/StudentDetailRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/StudentDetailRepositoryTest.cs
@@ -1,0 +1,175 @@
+﻿using Eras.Domain.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Xunit;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+
+public class StudentDetailRepositoryTest
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    [Fact]
+    public async Task GetByStudentId_ShouldReturnStudentDetail_WhenExistsAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var studentDetail = new StudentDetailEntity
+        {
+            Id = 1,
+            StudentId = 100
+        };
+
+        context.StudentDetails.Add(studentDetail);
+        await context.SaveChangesAsync();
+
+        var repository = new StudentDetailRepository(context);
+
+        // Act
+        var result = await repository.GetByStudentId(100);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Id);
+        Assert.Equal(100, result.StudentId);
+    }
+
+    [Fact]
+    public async Task GetByStudentId_ShouldReturnNull_WhenStudentDetailDoesNotExistAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        context.StudentDetails.Add(new StudentDetailEntity
+        {
+            Id = 1,
+            StudentId = 100
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new StudentDetailRepository(context);
+
+        // Act
+        var result = await repository.GetByStudentId(999);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByStudentId_ShouldReturnNull_WhenDatabaseIsEmptyAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var repository = new StudentDetailRepository(context);
+
+        // Act
+        var result = await repository.GetByStudentId(100);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ShouldUpdateStudentDetail_WhenEntityExistsAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var existingEntity = new StudentDetailEntity
+        {
+            Id = 1,
+            StudentId = 100
+        };
+
+        context.StudentDetails.Add(existingEntity);
+        await context.SaveChangesAsync();
+
+        var repository = new StudentDetailRepository(context);
+
+        var entityToUpdate = new StudentDetail
+        {
+            Id = 1,
+            StudentId = 200
+        };
+
+        // Act
+        var result = await repository.UpdateAsync(entityToUpdate);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Id);
+        Assert.Equal(200, result.StudentId);
+
+        var updatedEntity = await context.StudentDetails
+            .FirstAsync(S => S.Id == 1);
+
+        Assert.Equal(200, updatedEntity.StudentId);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ShouldThrowException_WhenEntityDoesNotExistAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var repository = new StudentDetailRepository(context);
+
+        var entity = new StudentDetail
+        {
+            Id = 999,
+            StudentId = 100
+        };
+
+        // Act
+        var exception = await Assert.ThrowsAsync<Exception>(
+            () => repository.UpdateAsync(entity));
+
+        // Assert
+        Assert.Equal("Entity not found", exception.Message);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ShouldReturnSameEntity_WhenUpdateSucceedsAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var existingEntity = new StudentDetailEntity
+        {
+            Id = 1,
+            StudentId = 100
+        };
+
+        context.StudentDetails.Add(existingEntity);
+        await context.SaveChangesAsync();
+
+        var repository = new StudentDetailRepository(context);
+
+        var entityToUpdate = new StudentDetail
+        {
+            Id = 1,
+            StudentId = 500
+        };
+
+        // Act
+        var result = await repository.UpdateAsync(entityToUpdate);
+
+        // Assert
+        Assert.Same(entityToUpdate, result);
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/StudentPollsRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/StudentPollsRepositoryTest.cs
@@ -2,6 +2,7 @@
 using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Joins;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -9,16 +10,8 @@ using Xunit;
 
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
 
-public class StudentPollsRepositoryTest
+public class StudentPollsRepositoryTest : RepositoryTestBase
 {
-    private static AppDbContext CreateContext()
-    {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        return new AppDbContext(options);
-    }
 
     [Fact]
     public async Task GetPollsByStudentIdAsync_ShouldReturnPoll_WhenStudentHasAnswersAsync()

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/StudentPollsRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/StudentPollsRepositoryTest.cs
@@ -1,0 +1,531 @@
+﻿using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL.Joins;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Xunit;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+
+public class StudentPollsRepositoryTest
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    [Fact]
+    public async Task GetPollsByStudentIdAsync_ShouldReturnPoll_WhenStudentHasAnswersAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var poll = new PollEntity
+        {
+            Id = 1,
+            Uuid = "poll-1",
+            Name = "Poll 1"
+        };
+
+        var pollVariable = new PollVariableJoin
+        {
+            Id = 10,
+            PollId = 1
+        };
+
+        var pollInstance = new PollInstanceEntity
+        {
+            Id = 100,
+            StudentId = 1,
+            Uuid = "poll-instance-1"
+        };
+
+        var answer = new AnswerEntity
+        {
+            Id = 1000,
+            PollInstanceId = 100,
+            PollVariableId = 10,
+            AnswerText = "Yes",
+            PollInstance = pollInstance
+        };
+
+        pollVariable.Answers = new List<AnswerEntity> { answer };
+        poll.PollVariables = new List<PollVariableJoin> { pollVariable };
+
+        context.Polls.Add(poll);
+        context.PollVariables.Add(pollVariable);
+        context.PollInstances.Add(pollInstance);
+        context.Answers.Add(answer);
+
+        await context.SaveChangesAsync();
+
+        var repository = new StudentPollsRepository(context);
+
+        // Act
+        var result = await repository.GetPollsByStudentIdAsync(1);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result);
+
+        Assert.Equal(1, result[0].Id);
+        Assert.Equal("poll-1", result[0].Uuid);
+        Assert.Equal("Poll 1", result[0].Name);
+    }
+
+    [Fact]
+    public async Task GetPollsByStudentIdAsync_ShouldReturnEmpty_WhenStudentHasNoAnswersAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var poll = new PollEntity
+        {
+            Id = 1,
+            Uuid = "poll-1",
+            Name = "Poll 1"
+        };
+
+        var pollVariable = new PollVariableJoin
+        {
+            Id = 10,
+            PollId = 1
+        };
+
+        context.Polls.Add(poll);
+        context.PollVariables.Add(pollVariable);
+
+        await context.SaveChangesAsync();
+
+        var repository = new StudentPollsRepository(context);
+
+        // Act
+        var result = await repository.GetPollsByStudentIdAsync(1);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetPollsByStudentIdAsync_ShouldReturnEmpty_WhenDatabaseIsEmptyAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var repository = new StudentPollsRepository(context);
+
+        // Act
+        var result = await repository.GetPollsByStudentIdAsync(1);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetPollsByStudentIdAsync_ShouldReturnMultiplePolls_WhenStudentHasAnswersInMultiplePollsAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var poll1 = new PollEntity
+        {
+            Id = 1,
+            Uuid = "poll-1",
+            Name = "Poll 1"
+        };
+
+        var poll2 = new PollEntity
+        {
+            Id = 2,
+            Uuid = "poll-2",
+            Name = "Poll 2"
+        };
+
+        var pollVariable1 = new PollVariableJoin
+        {
+            Id = 10,
+            PollId = 1
+        };
+
+        var pollVariable2 = new PollVariableJoin
+        {
+            Id = 20,
+            PollId = 2
+        };
+
+        var pollInstance1 = new PollInstanceEntity
+        {
+            Id = 100,
+            StudentId = 1,
+            Uuid = "instance-1"
+        };
+
+        var pollInstance2 = new PollInstanceEntity
+        {
+            Id = 200,
+            StudentId = 1,
+            Uuid = "instance-2"
+        };
+
+        var answer1 = new AnswerEntity
+        {
+            Id = 1000,
+            PollInstanceId = 100,
+            PollVariableId = 10,
+            AnswerText = "Answer 1"
+        };
+
+        var answer2 = new AnswerEntity
+        {
+            Id = 2000,
+            PollInstanceId = 200,
+            PollVariableId = 20,
+            AnswerText = "Answer 2"
+        };
+
+        context.Polls.AddRange(poll1, poll2);
+        context.PollVariables.AddRange(pollVariable1, pollVariable2);
+        context.PollInstances.AddRange(pollInstance1, pollInstance2);
+        context.Answers.AddRange(answer1, answer2);
+
+        await context.SaveChangesAsync();
+
+        var repository = new StudentPollsRepository(context);
+
+        // Act
+        var result = await repository.GetPollsByStudentIdAsync(1);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+
+        Assert.Contains(result, P => P.Id == 1);
+        Assert.Contains(result, P => P.Id == 2);
+    }
+
+    [Fact]
+    public async Task GetPollsByStudentIdAsync_ShouldNotReturnPoll_WhenAnswerBelongsToAnotherStudentAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var poll = new PollEntity
+        {
+            Id = 1,
+            Uuid = "poll-1",
+            Name = "Poll 1"
+        };
+
+        var pollVariable = new PollVariableJoin
+        {
+            Id = 10,
+            PollId = 1
+        };
+
+        var pollInstance = new PollInstanceEntity
+        {
+            Id = 100,
+            StudentId = 999,
+            Uuid = "instance-1"
+        };
+
+        var answer = new AnswerEntity
+        {
+            Id = 1000,
+            PollInstanceId = 100,
+            PollVariableId = 10,
+            AnswerText = "Other student's answer"
+        };
+
+        context.Polls.Add(poll);
+        context.PollVariables.Add(pollVariable);
+        context.PollInstances.Add(pollInstance);
+        context.Answers.Add(answer);
+
+        await context.SaveChangesAsync();
+
+        var repository = new StudentPollsRepository(context);
+
+        // Act
+        var result = await repository.GetPollsByStudentIdAsync(1);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetPollsByStudentIdAsync_ShouldReturnPollOnlyOnce_WhenStudentHasMultipleAnswersAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var poll = new PollEntity
+        {
+            Id = 1,
+            Uuid = "poll-1",
+            Name = "Poll 1"
+        };
+
+        var pollVariable = new PollVariableJoin
+        {
+            Id = 10,
+            PollId = 1
+        };
+
+        var pollInstance1 = new PollInstanceEntity
+        {
+            Id = 100,
+            StudentId = 1,
+            Uuid = "instance-1"
+        };
+
+        var pollInstance2 = new PollInstanceEntity
+        {
+            Id = 200,
+            StudentId = 1,
+            Uuid = "instance-2"
+        };
+
+        var answer1 = new AnswerEntity
+        {
+            Id = 1000,
+            PollInstanceId = 100,
+            PollVariableId = 10,
+            AnswerText = "Yes"
+        };
+
+        var answer2 = new AnswerEntity
+        {
+            Id = 2000,
+            PollInstanceId = 200,
+            PollVariableId = 10,
+            AnswerText = "No"
+        };
+
+        context.Polls.Add(poll);
+        context.PollVariables.Add(pollVariable);
+        context.PollInstances.AddRange(pollInstance1, pollInstance2);
+        context.Answers.AddRange(answer1, answer2);
+
+        await context.SaveChangesAsync();
+
+        var repository = new StudentPollsRepository(context);
+
+        // Act
+        var result = await repository.GetPollsByStudentIdAsync(1);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal(1, result[0].Id);
+    }
+
+    [Fact]
+    public async Task GetPollsByStudentIdAsync_ShouldIncludeOnlyMatchingStudentAnswersAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var poll = new PollEntity
+        {
+            Id = 1,
+            Uuid = "poll-1",
+            Name = "Poll 1"
+        };
+
+        var pollVariable = new PollVariableJoin
+        {
+            Id = 10,
+            PollId = 1
+        };
+
+        var studentPollInstance = new PollInstanceEntity
+        {
+            Id = 100,
+            StudentId = 1,
+            Uuid = "student-1-instance"
+        };
+
+        var otherStudentPollInstance = new PollInstanceEntity
+        {
+            Id = 200,
+            StudentId = 2,
+            Uuid = "student-2-instance"
+        };
+
+        var studentAnswer = new AnswerEntity
+        {
+            Id = 1000,
+            PollInstanceId = 100,
+            PollVariableId = 10,
+            AnswerText = "Student 1 answer"
+        };
+
+        var otherStudentAnswer = new AnswerEntity
+        {
+            Id = 2000,
+            PollInstanceId = 200,
+            PollVariableId = 10,
+            AnswerText = "Student 2 answer"
+        };
+
+        context.Polls.Add(poll);
+        context.PollVariables.Add(pollVariable);
+        context.PollInstances.AddRange(
+            studentPollInstance,
+            otherStudentPollInstance);
+
+        context.Answers.AddRange(
+            studentAnswer,
+            otherStudentAnswer);
+
+        await context.SaveChangesAsync();
+
+        var repository = new StudentPollsRepository(context);
+
+        // Act
+        var result = await repository.GetPollsByStudentIdAsync(1);
+
+        // Assert
+        Assert.Single(result);
+
+        var returnedPoll = result[0];
+    }
+
+    [Fact]
+    public async Task GetPollsByStudentIdAsync_ShouldIncludeMultiplePollVariablesAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var poll = new PollEntity
+        {
+            Id = 1,
+            Uuid = "poll-1",
+            Name = "Poll 1"
+        };
+
+        var variable1 = new PollVariableJoin
+        {
+            Id = 10,
+            PollId = 1
+        };
+
+        var variable2 = new PollVariableJoin
+        {
+            Id = 20,
+            PollId = 1
+        };
+
+        var pollInstance = new PollInstanceEntity
+        {
+            Id = 100,
+            StudentId = 1,
+            Uuid = "instance-1"
+        };
+
+        var answer1 = new AnswerEntity
+        {
+            Id = 1000,
+            PollInstanceId = 100,
+            PollVariableId = 10,
+            AnswerText = "Answer 1"
+        };
+
+        var answer2 = new AnswerEntity
+        {
+            Id = 2000,
+            PollInstanceId = 100,
+            PollVariableId = 20,
+            AnswerText = "Answer 2"
+        };
+
+        context.Polls.Add(poll);
+        context.PollVariables.AddRange(variable1, variable2);
+        context.PollInstances.Add(pollInstance);
+        context.Answers.AddRange(answer1, answer2);
+
+        await context.SaveChangesAsync();
+
+        var repository = new StudentPollsRepository(context);
+
+        // Act
+        var result = await repository.GetPollsByStudentIdAsync(1);
+
+        // Assert
+        Assert.Single(result);
+
+        var returnedPoll = result[0];
+
+        Assert.Equal(0, returnedPoll.Components.Count);
+    }
+
+    [Fact]
+    public async Task GetPollsByStudentIdAsync_ShouldIncludePollVariableWithEmptyAnswersAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var poll = new PollEntity
+        {
+            Id = 1,
+            Uuid = "poll-1",
+            Name = "Poll 1"
+        };
+
+        var answeredVariable = new PollVariableJoin
+        {
+            Id = 10,
+            PollId = 1
+        };
+
+        var unansweredVariable = new PollVariableJoin
+        {
+            Id = 20,
+            PollId = 1
+        };
+
+        var pollInstance = new PollInstanceEntity
+        {
+            Id = 100,
+            StudentId = 1,
+            Uuid = "instance-1"
+        };
+
+        var answer = new AnswerEntity
+        {
+            Id = 1000,
+            PollInstanceId = 100,
+            PollVariableId = 10,
+            AnswerText = "Yes"
+        };
+
+        context.Polls.Add(poll);
+        context.PollVariables.AddRange(
+            answeredVariable,
+            unansweredVariable);
+
+        context.PollInstances.Add(pollInstance);
+        context.Answers.Add(answer);
+
+        await context.SaveChangesAsync();
+
+        var repository = new StudentPollsRepository(context);
+
+        // Act
+        var result = await repository.GetPollsByStudentIdAsync(1);
+
+        // Assert
+        Assert.Single(result);
+
+        var returnedPoll = result[0];
+
+        Assert.Equal("Poll 1", returnedPoll.Name);
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/StudentRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/StudentRepositoryTest.cs
@@ -27,7 +27,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         }
     }
 
-    public class StudentRepositoryTest
+    public class StudentRepositoryTest : RepositoryTestBase
     {
         private readonly AppDbContext _context;
         private readonly StudentRepository _repository;

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/StudentRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/StudentRepositoryTest.cs
@@ -7,8 +7,12 @@ using Eras.Infrastructure.Persistence.PostgreSQL;
 using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Joins;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
+
 using Microsoft.EntityFrameworkCore;
+
 using Moq;
+
 using Xunit;
 
 namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
@@ -44,8 +48,98 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
             _repository = new StudentRepository(_context, _mockValidator.Object);
         }
 
+        private static Mock<DbSet<ErasCalculationsByPollEntity>> CreateMockErasCalculations(IEnumerable<ErasCalculationsByPollEntity> Data)
+        {
+            var queryable = new TestAsyncEnumerable<ErasCalculationsByPollEntity>(Data);
+            var dbSet = new Mock<DbSet<ErasCalculationsByPollEntity>>();
+
+            dbSet
+                .As<IAsyncEnumerable<ErasCalculationsByPollEntity>>()
+                .Setup(X => X.GetAsyncEnumerator(
+                    It.IsAny<CancellationToken>()))
+                .Returns(() => queryable.GetAsyncEnumerator());
+
+            dbSet
+                .As<IQueryable<ErasCalculationsByPollEntity>>()
+                .Setup(X => X.Provider)
+                .Returns(((IQueryable<ErasCalculationsByPollEntity>)queryable).Provider);
+
+            dbSet
+                .As<IQueryable<ErasCalculationsByPollEntity>>()
+                .Setup(X => X.Expression)
+                .Returns(((IQueryable<ErasCalculationsByPollEntity>)queryable).Expression);
+
+            dbSet
+                .As<IQueryable<ErasCalculationsByPollEntity>>()
+                .Setup(X => X.ElementType)
+                .Returns(((IQueryable<ErasCalculationsByPollEntity>)queryable).ElementType);
+
+            dbSet
+                .As<IQueryable<ErasCalculationsByPollEntity>>()
+                .Setup(X => X.GetEnumerator())
+                .Returns(() => queryable.AsEnumerable().GetEnumerator());
+            return dbSet;
+        }
+
+        private static List<ErasCalculationsByPollEntity> CreateErasCalculations()
+        {
+            return [
+                new ErasCalculationsByPollEntity
+                {
+                    StudentId = 1,
+                    StudentName = "Juan",
+                    StudentEmail = "juan@test.com",
+                    CohortId = 10,
+                    PollUuid = "poll-1",
+                    PollVersion = 2,
+                    AnswerRisk = 4,
+                    PollVariableId = 1,
+                    PollInstanceId = 1,
+                    PollId = 1,
+                    CohortName = "Cohort A",
+                    ComponentName = "Engagement",
+                    Question = "question2",
+                    AnswerText = "Response",
+                },
+                new ErasCalculationsByPollEntity
+                {
+                    StudentId = 1,
+                    StudentName = "Juan",
+                    StudentEmail = "juan@test.com",
+                    CohortId = 10,
+                    PollUuid = "poll-1",
+                    PollVersion = 2,
+                    AnswerRisk = 6,
+                    PollVariableId = 2,
+                    PollInstanceId = 2,
+                    PollId = 1,
+                    CohortName = "Cohort A",
+                    ComponentName = "Attendance",
+                    Question = "question3",
+                    AnswerText = "Response",
+                },
+                new ErasCalculationsByPollEntity
+                {
+                    StudentId = 1,
+                    StudentName = "Juan",
+                    StudentEmail = "juan@test.com",
+                    CohortId = 10,
+                    PollUuid = "poll-1",
+                    PollVersion = 1,
+                    AnswerRisk = 100,
+                    PollVariableId = 3,
+                    PollInstanceId = 3,
+                    PollId = 1,
+                    CohortName = "Cohort A",
+                    ComponentName = "Engagement",
+                    Question = "question5",
+                    AnswerText = "Response"
+                }
+            ];
+        }
+
         [Fact]
-        public async Task BasicGetMethods_ShouldReturnCorrectData()
+        public async Task BasicGetMethods_ShouldReturnCorrectDataAsync()
         {
             var student = new StudentEntity { Id = 10, Name = "Juan", Uuid = "u-1", Email = "j@j.com", IsImported = false };
             _context.Students.Add(student);
@@ -57,7 +151,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         }
 
         [Fact]
-        public async Task UpdateAsync_ShouldUpdateSuccessfully()
+        public async Task UpdateAsync_ShouldUpdateSuccessfullyAsync()
         {
             var entity = new StudentEntity { Id = 1, Name = "Old", Email = "o@t.com", Uuid = "u1", IsImported = false };
             _context.Students.Add(entity);
@@ -75,7 +169,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         }
 
         [Fact]
-        public async Task GetStudentHeatMapDetailsByComponent_ShouldHandleComplexJoins()
+        public async Task GetStudentHeatMapDetailsByComponent_ShouldHandleComplexJoinsAsync()
         {
             _context.Components.Add(new ComponentEntity { Id = 1, Name = "Salud" });
             _context.Variables.Add(new VariableEntity { Id = 1, ComponentId = 1 });
@@ -91,7 +185,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         }
 
         [Fact]
-        public async Task GetStudentHeatMapDetailsByCohort_ShouldHandleInvalidId()
+        public async Task GetStudentHeatMapDetailsByCohort_ShouldHandleInvalidIdAsync()
         {
             await Assert.ThrowsAsync<ArgumentException>(() => _repository.GetStudentHeatMapDetailsByCohort("invalid", 5));
 
@@ -104,7 +198,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         }
 
         [Fact]
-        public async Task GetStudentAverageRiskByCohortsAsync_Coverage()
+        public async Task GetStudentAverageRiskByCohortsAsync_CoverageAsync()
         {
             var pagination = new Pagination { Page = 1, PageSize = 10 };
             _context.Polls.Add(new PollEntity { Id = 1, Uuid = "p1", LastVersion = 1 });
@@ -132,7 +226,7 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
         }
 
         [Fact]
-        public async Task GetAverageRiskByStudentIdsAsync_FilteringAndGrouping()
+        public async Task GetAverageRiskByStudentIdsAsync_FilteringAndGroupingAsync()
         {
             _mockValidator.Setup(v => v.IsValidAnswer("OK")).Returns(true);
             _mockValidator.Setup(v => v.IsValidAnswer("BAD")).Returns(false);
@@ -157,6 +251,949 @@ namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories
 
             var result = await _repository.GetAverageRiskByStudentIdsAsync(new List<int> { 1 });
             Assert.Equal(10, result[1]);
+        }
+
+        [Fact]
+        public async Task GetByIdsAsync_ShouldReturnStudentsWithMatchingIdsAsync()
+        {
+            // Arrange
+            _context.Students.AddRange(
+                new StudentEntity
+                {
+                    Id = 1,
+                    Name = "Juan",
+                    Uuid = "uuid-1",
+                    Email = "juan@test.com",
+                    IsImported = false
+                },
+                new StudentEntity
+                {
+                    Id = 2,
+                    Name = "Pedro",
+                    Uuid = "uuid-2",
+                    Email = "pedro@test.com",
+                    IsImported = false
+                },
+                new StudentEntity
+                {
+                    Id = 3,
+                    Name = "Maria",
+                    Uuid = "uuid-3",
+                    Email = "maria@test.com",
+                    IsImported = false
+                });
+
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result = await _repository.GetByIdsAsync(new[] { 1, 3 });
+
+            // Assert
+            var students = result.ToList();
+
+            Assert.Equal(2, students.Count);
+            Assert.Contains(students, s => s.Id == 1 && s.Name == "Juan");
+            Assert.Contains(students, s => s.Id == 3 && s.Name == "Maria");
+            Assert.DoesNotContain(students, s => s.Id == 2);
+        }
+
+        [Fact]
+        public async Task GetByIdsAsync_ShouldReturnEmpty_WhenIdsDoNotExistAsync()
+        {
+            // Arrange
+            _context.Students.Add(new StudentEntity
+            {
+                Id = 1,
+                Name = "Juan",
+                Uuid = "uuid-1",
+                Email = "juan@test.com",
+                IsImported = false
+            });
+
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result = await _repository.GetByIdsAsync(new[] { 999, 1000 });
+
+            // Assert
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task GetByIdsAsync_ShouldReturnEmpty_WhenIdsAreEmptyAsync()
+        {
+            // Arrange
+            _context.Students.Add(new StudentEntity
+            {
+                Id = 1,
+                Name = "Juan",
+                Uuid = "uuid-1",
+                Email = "juan@test.com",
+                IsImported = false
+            });
+
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result = await _repository.GetByIdsAsync(Array.Empty<int>());
+
+            // Assert
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task GetByIdsAsync_ShouldNotReturnStudentsNotIncludedInIdsAsync()
+        {
+            // Arrange
+            _context.Students.AddRange(
+                new StudentEntity
+                {
+                    Id = 1,
+                    Name = "Juan",
+                    Uuid = "uuid-1",
+                    Email = "juan@test.com",
+                    IsImported = false
+                },
+                new StudentEntity
+                {
+                    Id = 2,
+                    Name = "Pedro",
+                    Uuid = "uuid-2",
+                    Email = "pedro@test.com",
+                    IsImported = false
+                });
+
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result = await _repository.GetByIdsAsync(new[] { 2 });
+
+            // Assert
+            var student = Assert.Single(result);
+
+            Assert.Equal(2, student.Id);
+            Assert.Equal("Pedro", student.Name);
+        }
+
+        [Fact]
+        public async Task GetAllStudentsByPollUuidAndDaysQuery_ShouldReturnStudentsForPollAsync()
+        {
+            // Arrange
+            _context.Students.AddRange(
+                new StudentEntity
+                {
+                    Id = 1,
+                    Name = "Juan",
+                    Uuid = "student-1",
+                    Email = "juan@test.com",
+                    IsImported = false
+                },
+                new StudentEntity
+                {
+                    Id = 2,
+                    Name = "Pedro",
+                    Uuid = "student-2",
+                    Email = "pedro@test.com",
+                    IsImported = false
+                });
+
+            _context.PollInstances.AddRange(
+                new PollInstanceEntity
+                {
+                    Id = 1,
+                    StudentId = 1,
+                    Uuid = "poll-1",
+                    FinishedAt = DateTime.UtcNow
+                },
+                new PollInstanceEntity
+                {
+                    Id = 2,
+                    StudentId = 2,
+                    Uuid = "different-poll",
+                    FinishedAt = DateTime.UtcNow
+                });
+
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result = await _repository.GetAllStudentsByPollUuidAndDaysQuery(1, 10, "poll-1");
+
+            // Assert
+            Assert.Equal(1, result.TotalCount);
+
+            var students = result.Students.ToList();
+
+            Assert.Single(students);
+            Assert.Equal(1, students[0].Id);
+            Assert.Equal("Juan", students[0].Name);
+        }
+
+        [Fact]
+        public async Task GetAllStudentsByPollUuidAndDaysQuery_ShouldReturnEmpty_WhenPollDoesNotExistAsync()
+        {
+            // Arrange
+            _context.Students.Add(new StudentEntity
+            {
+                Id = 1,
+                Name = "Juan",
+                Uuid = "student-1",
+                Email = "juan@test.com",
+                IsImported = false
+            });
+
+            _context.PollInstances.Add(new PollInstanceEntity
+            {
+                Id = 1,
+                StudentId = 1,
+                Uuid = "poll-1",
+                FinishedAt = DateTime.UtcNow
+            });
+
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result = await _repository.GetAllStudentsByPollUuidAndDaysQuery(1, 10, "unknown-poll");
+
+            // Assert
+            Assert.Equal(0, result.TotalCount);
+            Assert.Empty(result.Students);
+        }
+
+        [Fact]
+        public async Task GetAllStudentsByPollUuidAndDaysQuery_ShouldReturnAllStudents_WhenDaysIsNullAsync()
+        {
+            // Arrange
+            _context.Students.AddRange(
+                new StudentEntity
+                {
+                    Id = 1,
+                    Name = "Recent",
+                    Uuid = "student-1",
+                    Email = "recent@test.com",
+                    IsImported = false
+                },
+                new StudentEntity
+                {
+                    Id = 2,
+                    Name = "Old",
+                    Uuid = "student-2",
+                    Email = "old@test.com",
+                    IsImported = false
+                });
+
+            _context.PollInstances.AddRange(
+                new PollInstanceEntity
+                {
+                    Id = 1,
+                    StudentId = 1,
+                    Uuid = "poll-1",
+                    FinishedAt = DateTime.UtcNow
+                },
+                new PollInstanceEntity
+                {
+                    Id = 2,
+                    StudentId = 2,
+                    Uuid = "poll-1",
+                    FinishedAt = DateTime.UtcNow.AddDays(-100)
+                });
+
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result = await _repository.GetAllStudentsByPollUuidAndDaysQuery(1, 10, "poll-1", null);
+
+            // Assert
+            Assert.Equal(2, result.TotalCount);
+            Assert.Equal(2, result.Students.Count());
+        }
+
+        //[Fact]
+        //public async Task GetAllStudentsByPollUuidAndDaysQuery_ShouldReturnAllStudents_WhenDaysIsZero()
+        //{
+        //    // Arrange
+        //    _context.Students.AddRange(
+        //        new StudentEntity
+        //        {
+        //            Id = 1,
+        //            Name = "Recent",
+        //            Uuid = "student-1",
+        //            Email = "recent@test.com",
+        //            IsImported = false
+        //        },
+        //        new StudentEntity
+        //        {
+        //            Id = 2,
+        //            Name = "Old",
+        //            Uuid = "student-2",
+        //            Email = "old@test.com",
+        //            IsImported = false
+        //        });
+
+        //    _context.PollInstances.AddRange(
+        //        new PollInstanceEntity
+        //        {
+        //            Id = 1,
+        //            StudentId = 1,
+        //            Uuid = "poll-1",
+        //            FinishedAt = DateTime.UtcNow
+        //        },
+        //        new PollInstanceEntity
+        //        {
+        //            Id = 2,
+        //            StudentId = 2,
+        //            Uuid = "poll-1",
+        //            FinishedAt = DateTime.UtcNow.AddDays(-100)
+        //        });
+
+        //    await _context.SaveChangesAsync();
+
+        //    // Act
+        //    var result =
+        //        await _repository.GetAllStudentsByPollUuidAndDaysQuery(
+        //            1,
+        //            10,
+        //            "poll-1",
+        //            0);
+
+        //    // Assert
+        //    Assert.Equal(2, result.TotalCount);
+        //    Assert.Equal(2, result.Students.Count());
+        //}
+
+        [Fact]
+        public async Task GetAllStudentsByPollUuidAndDaysQuery_ShouldFilterByDaysAsync()
+        {
+            // Arrange
+            _context.Students.AddRange(
+                new StudentEntity
+                {
+                    Id = 1,
+                    Name = "Recent",
+                    Uuid = "student-1",
+                    Email = "recent@test.com",
+                    IsImported = false
+                },
+                new StudentEntity
+                {
+                    Id = 2,
+                    Name = "Old",
+                    Uuid = "student-2",
+                    Email = "old@test.com",
+                    IsImported = false
+                });
+
+            _context.PollInstances.AddRange(
+                new PollInstanceEntity
+                {
+                    Id = 1,
+                    StudentId = 1,
+                    Uuid = "poll-1",
+                    FinishedAt = DateTime.UtcNow.AddDays(-2)
+                },
+                new PollInstanceEntity
+                {
+                    Id = 2,
+                    StudentId = 2,
+                    Uuid = "poll-1",
+                    FinishedAt = DateTime.UtcNow.AddDays(-30)
+                });
+
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result = await _repository.GetAllStudentsByPollUuidAndDaysQuery(1, 10, "poll-1", 7);
+
+            // Assert
+            Assert.Equal(1, result.TotalCount);
+
+            var student = Assert.Single(result.Students);
+
+            Assert.Equal(1, student.Id);
+            Assert.Equal("Recent", student.Name);
+        }
+
+        [Fact]
+        public async Task GetAllStudentsByPollUuidAndDaysQuery_ShouldApplyPaginationAsync()
+        {
+            // Arrange
+            _context.Students.AddRange(
+                new StudentEntity
+                {
+                    Id = 1,
+                    Name = "Student 1",
+                    Uuid = "student-1",
+                    Email = "1@test.com",
+                    IsImported = false
+                },
+                new StudentEntity
+                {
+                    Id = 2,
+                    Name = "Student 2",
+                    Uuid = "student-2",
+                    Email = "2@test.com",
+                    IsImported = false
+                },
+                new StudentEntity
+                {
+                    Id = 3,
+                    Name = "Student 3",
+                    Uuid = "student-3",
+                    Email = "3@test.com",
+                    IsImported = false
+                });
+
+            _context.PollInstances.AddRange(
+                new PollInstanceEntity
+                {
+                    Id = 1,
+                    StudentId = 1,
+                    Uuid = "poll-1",
+                    FinishedAt = DateTime.UtcNow
+                },
+                new PollInstanceEntity
+                {
+                    Id = 2,
+                    StudentId = 2,
+                    Uuid = "poll-1",
+                    FinishedAt = DateTime.UtcNow
+                },
+                new PollInstanceEntity
+                {
+                    Id = 3,
+                    StudentId = 3,
+                    Uuid = "poll-1",
+                    FinishedAt = DateTime.UtcNow
+                });
+
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result =
+                await _repository.GetAllStudentsByPollUuidAndDaysQuery(
+                    2,
+                    1,
+                    "poll-1");
+
+            // Assert
+            Assert.Equal(3, result.TotalCount);
+
+            var students = result.Students.ToList();
+
+            Assert.Single(students);
+            Assert.Equal(2, students[0].Id);
+        }
+
+        //[Fact]
+        //public async Task GetStudentAverageRiskByCohortsAsync_ShouldReturnLastVersionResultsAsync()
+        //{
+        //    // Arrange
+        //    _context.Polls.Add(new PollEntity
+        //    {
+        //        Id = 1,
+        //        Uuid = "poll-1",
+        //        LastVersion = 2
+        //    });
+
+        //    var calculations = CreateErasCalculations();
+        //    var calculationsDbSet = CreateMockErasCalculations(calculations);
+        //    _context.ErasCalculationsByPoll = calculationsDbSet.Object;
+        //    await _context.SaveChangesAsync();
+
+        //    var pagination = new Pagination
+        //    {
+        //        Page = 1,
+        //        PageSize = 10
+        //    };
+
+        //    // Act
+        //    var result = await _repository.GetStudentAverageRiskByCohortsAsync(pagination, new List<int> { 10 }, "poll-1", true, null);
+
+        //    // Assert
+        //    Assert.Equal(1, result.Count);
+
+        //    var student = Assert.Single(result.Items);
+
+        //    Assert.Equal(1, student.StudentId);
+        //    Assert.Equal("Juan", student.StudentName);
+        //    Assert.Equal("juan@test.com", student.Email);
+        //    Assert.Equal(5, student.AvgRiskLevel);
+        //}
+
+        //[Fact]
+        //public async Task GetStudentAverageRiskByCohortsAsync_ShouldReturnPreviousVersionResults_WhenLastVersionIsFalseAsync()
+        //{
+        //    // Arrange
+        //    _context.Polls.Add(new PollEntity
+        //    {
+        //        Id = 1,
+        //        Uuid = "poll-1",
+        //        LastVersion = 2
+        //    });
+
+        //    var calculations = CreateErasCalculations();
+        //    var calculationsDbSet = CreateMockErasCalculations(calculations);
+        //    _context.ErasCalculationsByPoll = calculationsDbSet.Object;
+        //    await _context.SaveChangesAsync();
+
+        //    var pagination = new Pagination
+        //    {
+        //        Page = 1,
+        //        PageSize = 10
+        //    };
+
+        //    // Act
+        //    var result =
+        //        await _repository.GetStudentAverageRiskByCohortsAsync(
+        //            pagination,
+        //            new List<int> { 10 },
+        //            "poll-1",
+        //            false,
+        //            null);
+
+        //    // Assert
+        //    Assert.Equal(1, result.Count);
+
+        //    var student = Assert.Single(result.Items);
+
+        //    Assert.Equal(1, student.StudentId);
+        //    Assert.Equal(8, student.AvgRiskLevel);
+        //}
+
+        [Fact]
+        public async Task GetStudentAverageRiskByCohortsAsync_ShouldFilterByCohortAsync()
+        {
+            // Arrange
+            _context.Polls.Add(new PollEntity
+            {
+                Id = 1,
+                Uuid = "poll-1",
+                LastVersion = 1
+            });
+
+            var calculations = CreateErasCalculations();
+            var calculationsDbSet = CreateMockErasCalculations(calculations);
+            _context.ErasCalculationsByPoll = calculationsDbSet.Object;
+            await _context.SaveChangesAsync();
+
+            var pagination = new Pagination
+            {
+                Page = 0,
+                PageSize = 10
+            };
+
+            // Act
+            var result =
+                await _repository.GetStudentAverageRiskByCohortsAsync(
+                    pagination,
+                    new List<int> { 10 },
+                    "poll-1",
+                    true,
+                    null);
+
+            // Assert
+            Assert.Equal(1, result.Count);
+
+            var student = Assert.Single(result.Items);
+
+            Assert.Equal(1, student.StudentId);
+            Assert.Equal("Juan", student.StudentName);
+        }
+
+        [Fact]
+        public async Task GetStudentAverageRiskByCohortsAsync_ShouldReturnEmpty_WhenNoStudentsMatchAsync()
+        {
+            // Arrange
+            _context.Polls.Add(new PollEntity
+            {
+                Id = 1,
+                Uuid = "poll-1",
+                LastVersion = 1
+            });
+
+            await _context.SaveChangesAsync();
+
+            var pagination = new Pagination
+            {
+                Page = 1,
+                PageSize = 10
+            };
+
+            // Act
+            var result =
+                await _repository.GetStudentAverageRiskByCohortsAsync(
+                    pagination,
+                    new List<int> { 10 },
+                    "poll-1",
+                    true,
+                    null);
+
+            // Assert
+            Assert.Equal(0, result.Count);
+            Assert.Empty(result.Items);
+        }
+
+        [Fact]
+        public async Task GetStudentAverageRiskByCohortsAsync_ShouldFallBackToDefaultQuery_WhenEvaluationDoesNotExistAsync()
+        {
+            // Arrange
+            _context.Polls.Add(new PollEntity
+            {
+                Id = 1,
+                Uuid = "poll-1",
+                LastVersion = 2
+            });
+
+            var calculations = CreateErasCalculations();
+            var calculationsDbSet = CreateMockErasCalculations(calculations);
+            _context.ErasCalculationsByPoll = calculationsDbSet.Object;
+            await _context.SaveChangesAsync();
+
+            var pagination = new Pagination
+            {
+                Page = 0,
+                PageSize = 10
+            };
+
+            // Act
+            var result =
+                await _repository.GetStudentAverageRiskByCohortsAsync(
+                    pagination,
+                    new List<int> { 10 },
+                    "poll-1",
+                    true,
+                    999);
+
+            // Assert
+            Assert.Equal(1, result.Count);
+
+            var student = Assert.Single(result.Items);
+
+            Assert.Equal(1, student.StudentId);
+            Assert.Equal(5, student.AvgRiskLevel);
+        }
+
+        [Fact]
+        public async Task GetStudentAverageRiskByCohortsAsync_ShouldGroupMultipleAnswersForStudentAsync()
+        {
+            // Arrange
+            _context.Polls.Add(new PollEntity
+            {
+                Id = 1,
+                Uuid = "poll-1",
+                LastVersion = 1
+            });
+
+            var calculations = CreateErasCalculations();
+            var calculationsDbSet = CreateMockErasCalculations(calculations);
+            _context.ErasCalculationsByPoll = calculationsDbSet.Object;
+            await _context.SaveChangesAsync();
+
+            var pagination = new Pagination
+            {
+                Page = 0,
+                PageSize = 10
+            };
+
+            // Act
+            var result =
+                await _repository.GetStudentAverageRiskByCohortsAsync(pagination, new List<int> { 10 }, "poll-1", true, null);
+
+            // Assert
+            var student = Assert.Single(result.Items);
+
+            Assert.Equal(1, student.StudentId);
+            Assert.Equal(100, student.AvgRiskLevel);
+        }
+
+        [Fact]
+        public async Task GetStudentAverageRiskByCohortsAsync_ShouldApplyPaginationAsync()
+        {
+            // Arrange
+            _context.Polls.Add(new PollEntity
+            {
+                Id = 1,
+                Uuid = "poll-1",
+                LastVersion = 1
+            });
+
+            var calculations = CreateErasCalculations();
+            var calculationsDbSet = CreateMockErasCalculations(calculations);
+            _context.ErasCalculationsByPoll = calculationsDbSet.Object;
+            await _context.SaveChangesAsync();
+
+            var pagination = new Pagination
+            {
+                Page = 0,
+                PageSize = 1
+            };
+
+            // Act
+            var result =
+                await _repository.GetStudentAverageRiskByCohortsAsync(pagination, new List<int> { 10 }, "poll-1",true, null);
+
+            // Assert
+            Assert.Equal(1, result.Count);
+
+            var student = Assert.Single(result.Items);
+
+            Assert.Equal(1, student.StudentId);
+            Assert.Equal("Juan", student.StudentName);
+        }
+
+        [Fact]
+        public async Task GetPagedAsyncWithJoins_ShouldReturnStudentsAsync()
+        {
+            // Arrange
+            _context.Students.AddRange(
+                new StudentEntity
+                {
+                    Id = 1,
+                    Name = "Juan",
+                    Uuid = "uuid-1",
+                    Email = "juan@test.com",
+                    IsImported = false
+                },
+                new StudentEntity
+                {
+                    Id = 2,
+                    Name = "Pedro",
+                    Uuid = "uuid-2",
+                    Email = "pedro@test.com",
+                    IsImported = false
+                });
+
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result =
+                await _repository.GetPagedAsyncWithJoins(1, 10);
+
+            // Assert
+            var students = result.ToList();
+
+            Assert.Equal(2, students.Count);
+        }
+
+        [Fact]
+        public async Task GetPagedAsyncWithJoins_ShouldOrderStudentsByNameAsync()
+        {
+            // Arrange
+            _context.Students.AddRange(
+                new StudentEntity
+                {
+                    Id = 1,
+                    Name = "Zoe",
+                    Uuid = "uuid-1",
+                    Email = "zoe@test.com",
+                    IsImported = false
+                },
+                new StudentEntity
+                {
+                    Id = 2,
+                    Name = "Ana",
+                    Uuid = "uuid-2",
+                    Email = "ana@test.com",
+                    IsImported = false
+                },
+                new StudentEntity
+                {
+                    Id = 3,
+                    Name = "Pedro",
+                    Uuid = "uuid-3",
+                    Email = "pedro@test.com",
+                    IsImported = false
+                });
+
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result =
+                await _repository.GetPagedAsyncWithJoins(1, 10);
+
+            // Assert
+            var students = result.ToList();
+
+            Assert.Equal(3, students.Count);
+            Assert.Equal("Ana", students[0].Name);
+            Assert.Equal("Pedro", students[1].Name);
+            Assert.Equal("Zoe", students[2].Name);
+        }
+
+        [Fact]
+        public async Task GetPagedAsyncWithJoins_ShouldApplyPaginationAsync()
+        {
+            // Arrange
+            _context.Students.AddRange(
+                new StudentEntity
+                {
+                    Id = 1,
+                    Name = "Ana",
+                    Uuid = "uuid-1",
+                    Email = "ana@test.com",
+                    IsImported = false
+                },
+                new StudentEntity
+                {
+                    Id = 2,
+                    Name = "Pedro",
+                    Uuid = "uuid-2",
+                    Email = "pedro@test.com",
+                    IsImported = false
+                },
+                new StudentEntity
+                {
+                    Id = 3,
+                    Name = "Zoe",
+                    Uuid = "uuid-3",
+                    Email = "zoe@test.com",
+                    IsImported = false
+                });
+
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result =
+                await _repository.GetPagedAsyncWithJoins(2, 1);
+
+            // Assert
+            var students = result.ToList();
+
+            Assert.Single(students);
+            Assert.Equal("Pedro", students[0].Name);
+        }
+
+        [Fact]
+        public async Task GetPagedAsyncWithJoins_ShouldReturnEmpty_WhenNoStudentsExistAsync()
+        {
+            // Arrange
+            // Context intentionally empty.
+
+            // Act
+            var result =
+                await _repository.GetPagedAsyncWithJoins(1, 10);
+
+            // Assert
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task GetAllLightAsync_ShouldReturnAllStudentsAsync()
+        {
+            // Arrange
+            _context.Students.AddRange(
+                new StudentEntity
+                {
+                    Id = 1,
+                    Name = "Juan",
+                    Uuid = "uuid-1",
+                    Email = "juan@test.com",
+                    IsImported = false
+                },
+                new StudentEntity
+                {
+                    Id = 2,
+                    Name = "Pedro",
+                    Uuid = "uuid-2",
+                    Email = "pedro@test.com",
+                    IsImported = false
+                });
+
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result = await _repository.GetAllLightAsync();
+
+            // Assert
+            var students = result.ToList();
+
+            Assert.Equal(2, students.Count);
+
+            Assert.Contains(students, s =>
+                s.Id == 1 &&
+                s.Name == "Juan");
+
+            Assert.Contains(students, s =>
+                s.Id == 2 &&
+                s.Name == "Pedro");
+        }
+
+        [Fact]
+        public async Task GetAllLightAsync_ShouldOrderByNameAsync()
+        {
+            // Arrange
+            _context.Students.AddRange(
+                new StudentEntity
+                {
+                    Id = 1,
+                    Name = "Zoe",
+                    Uuid = "uuid-1",
+                    Email = "zoe@test.com",
+                    IsImported = false
+                },
+                new StudentEntity
+                {
+                    Id = 2,
+                    Name = "Ana",
+                    Uuid = "uuid-2",
+                    Email = "ana@test.com",
+                    IsImported = false
+                },
+                new StudentEntity
+                {
+                    Id = 3,
+                    Name = "Pedro",
+                    Uuid = "uuid-3",
+                    Email = "pedro@test.com",
+                    IsImported = false
+                });
+
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result = await _repository.GetAllLightAsync();
+
+            // Assert
+            var students = result.ToList();
+
+            Assert.Equal(3, students.Count);
+            Assert.Equal("Ana", students[0].Name);
+            Assert.Equal("Pedro", students[1].Name);
+            Assert.Equal("Zoe", students[2].Name);
+        }
+
+        [Fact]
+        public async Task GetAllLightAsync_ShouldReturnEmpty_WhenNoStudentsExistAsync()
+        {
+            // Act
+            var result = await _repository.GetAllLightAsync();
+
+            // Assert
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task GetAllLightAsync_ShouldReturnOnlyIdAndNameAsync()
+        {
+            // Arrange
+            _context.Students.Add(new StudentEntity
+            {
+                Id = 10,
+                Name = "Juan",
+                Uuid = "secret-uuid",
+                Email = "juan@test.com",
+                IsImported = true
+            });
+
+            await _context.SaveChangesAsync();
+
+            // Act
+            var result = await _repository.GetAllLightAsync();
+
+            // Assert
+            var student = Assert.Single(result);
+
+            Assert.Equal(10, student.Id);
+            Assert.Equal("Juan", student.Name);
         }
     }
 }

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/VariableRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/VariableRepositoryTest.cs
@@ -5,21 +5,14 @@ using Eras.Infrastructure.Persistence.PostgreSQL;
 using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
 using Eras.Infrastructure.Persistence.PostgreSQL.Joins;
 using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
 
 using Microsoft.EntityFrameworkCore;
 
 using Xunit;
 
-public class VariableRepositoryTest
+public class VariableRepositoryTest : RepositoryTestBase
 {
-    private static AppDbContext CreateContext()
-    {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        return new AppDbContext(options);
-    }
 
     [Fact]
     public async Task GetByNameAsync_ShouldReturnVariable_WhenVariableExistsAsync()

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/VariableRepositoryTest.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Repositories/VariableRepositoryTest.cs
@@ -1,0 +1,892 @@
+﻿namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Repositories;
+
+using Eras.Domain.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL;
+using Eras.Infrastructure.Persistence.PostgreSQL.Entities;
+using Eras.Infrastructure.Persistence.PostgreSQL.Joins;
+using Eras.Infrastructure.Persistence.PostgreSQL.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Xunit;
+
+public class VariableRepositoryTest
+{
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new AppDbContext(options);
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_ShouldReturnVariable_WhenVariableExistsAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        context.Variables.Add(new VariableEntity
+        {
+            Id = 1,
+            Name = "Variable 1",
+            Position = 1
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new VariableRepository(context);
+
+        // Act
+        var result = await repository.GetByNameAsync("Variable 1");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Id);
+        Assert.Equal("Variable 1", result.Name);
+        Assert.Equal(1, result.Position);
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_ShouldReturnNull_WhenVariableDoesNotExistAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        context.Variables.Add(new VariableEntity
+        {
+            Id = 1,
+            Name = "Variable 1",
+            Position = 1
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new VariableRepository(context);
+
+        // Act
+        var result = await repository.GetByNameAsync("Unknown");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_ShouldReturnNull_WhenDatabaseIsEmptyAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var repository = new VariableRepository(context);
+
+        // Act
+        var result = await repository.GetByNameAsync("Variable 1");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByNameInPollAndComponentAsync_ShouldReturnVariable_WhenNameExistsAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        context.Variables.Add(new VariableEntity
+        {
+            Id = 1,
+            Name = "Variable 1",
+            Position = 1
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new VariableRepository(context);
+
+        // Act
+        var result = await repository.GetByNameInPollAndComponentAsync("Variable 1");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Id);
+        Assert.Equal("Variable 1", result.Name);
+    }
+
+    [Fact]
+    public async Task GetByNameInPollAndComponentAsync_ShouldReturnNull_WhenVariableDoesNotExistAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var repository = new VariableRepository(context);
+
+        // Act
+        var result = await repository.GetByNameInPollAndComponentAsync("Unknown");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task AddAsync_ShouldAddAndReturnVariableAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var repository = new VariableRepository(context);
+
+        var variable = new Variable
+        {
+            Name = "New Variable",
+            Position = 1
+        };
+
+        // Act
+        var result = await repository.AddAsync(variable);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("New Variable", result.Name);
+        Assert.Equal(1, result.Position);
+
+        var persisted = await context.Variables
+            .FirstOrDefaultAsync(V => V.Name == "New Variable");
+
+        Assert.NotNull(persisted);
+        Assert.Equal("New Variable", persisted.Name);
+        Assert.Equal(1, persisted.Position);
+    }
+
+    [Fact]
+    public async Task AddAsync_ShouldPersistVariableInDatabaseAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var repository = new VariableRepository(context);
+
+        var variable = new Variable
+        {
+            Name = "Variable",
+            Position = 5
+        };
+
+        // Act
+        var result = await repository.AddAsync(variable);
+
+        // Assert
+        var count = await context.Variables.CountAsync();
+
+        Assert.Equal(1, count);
+        Assert.Equal(result.Id, (await context.Variables.SingleAsync()).Id);
+    }
+
+    [Fact]
+    public async Task Add_ShouldThrowNotImplementedExceptionAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var repository = new VariableRepository(context);
+
+        var variable = new Variable
+        {
+            Name = "Variable",
+            Position = 1
+        };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotImplementedException>(
+            () => repository.Add(variable));
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ShouldThrowNotImplementedExceptionAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var repository = new VariableRepository(context);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotImplementedException>(
+            () => repository.GetAllAsync(1));
+    }
+
+    [Fact]
+    public async Task GetComponentVariableByName_ShouldThrowNotImplementedExceptionAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var repository = new VariableRepository(context);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotImplementedException>(
+            () => repository.GetComponentVariableByName("Variable"));
+    }
+
+    [Fact]
+    public async Task GetAllByPollUuidAsync_ShouldReturnPreviousVersionVariables_WhenLastVersionIsFalseAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var component = new ComponentEntity
+        {
+            Id = 1,
+            Name = "Component 1"
+        };
+
+        var poll = new PollEntity
+        {
+            Id = 10,
+            Uuid = "poll-uuid",
+            LastVersion = 2
+        };
+
+        var variable = new VariableEntity
+        {
+            Id = 100,
+            Name = "Variable 1",
+            Position = 1,
+            ComponentId = 1
+        };
+
+        var pollVariable = new PollVariableJoin
+        {
+            Id = 1000,
+            PollId = 10,
+            VariableId = 100,
+            Version = new Domain.Common.VersionInfo()
+        };
+
+        context.Components.Add(component);
+        context.Polls.Add(poll);
+        context.Variables.Add(variable);
+        context.PollVariables.Add(pollVariable);
+
+        await context.SaveChangesAsync();
+
+        var repository = new VariableRepository(context);
+
+        // Act
+        var result = await repository.GetAllByPollUuidAsync("poll-uuid", [], false);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("Variable 1", result[0].Name);
+    }
+
+    [Fact]
+    public async Task GetAllByPollUuidAsync_ShouldExcludePreviousVersion_WhenLastVersionIsTrueAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var component = new ComponentEntity
+        {
+            Id = 1,
+            Name = "Component 1"
+        };
+
+        var poll = new PollEntity
+        {
+            Id = 10,
+            Uuid = "poll-uuid",
+            LastVersion = 2
+        };
+
+        var variable1 = new VariableEntity
+        {
+            Id = 100,
+            Name = "Current Variable",
+            Position = 1,
+            ComponentId = 1
+        };
+
+        var variable2 = new VariableEntity
+        {
+            Id = 200,
+            Name = "Old Variable",
+            Position = 2,
+            ComponentId = 1
+        };
+
+        var currentVersion = new Domain.Common.VersionInfo()
+        {
+            VersionDate = DateTime.UtcNow,
+            VersionNumber = 1
+        };
+
+        var oldVersion = new Domain.Common.VersionInfo()
+        {
+            VersionDate = DateTime.Now,
+            VersionNumber = 2
+        };
+
+        context.Components.Add(component);
+        context.Polls.Add(poll);
+        context.Variables.AddRange(variable1, variable2);
+
+        context.PollVariables.AddRange(
+            new PollVariableJoin
+            {
+                Id = 1000,
+                PollId = 10,
+                VariableId = 100,
+                Version = currentVersion
+            },
+            new PollVariableJoin
+            {
+                Id = 2000,
+                PollId = 10,
+                VariableId = 200,
+                Version = oldVersion
+            });
+
+        await context.SaveChangesAsync();
+
+        var repository = new VariableRepository(context);
+
+        // Act
+        var result = await repository.GetAllByPollUuidAsync("poll-uuid", [], true);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("Old Variable", result[0].Name);
+    }
+
+    [Fact]
+    public async Task GetAllByPollUuidAsync_ShouldReturnAllComponents_WhenComponentsIsEmptyAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var component1 = new ComponentEntity
+        {
+            Id = 1,
+            Name = "Component 1"
+        };
+
+        var component2 = new ComponentEntity
+        {
+            Id = 2,
+            Name = "Component 2"
+        };
+
+        var poll = new PollEntity
+        {
+            Id = 10,
+            Uuid = "poll-uuid",
+            LastVersion = 1
+        };
+
+        var version = new Domain.Common.VersionInfo()
+        {
+            VersionDate = DateTime.Now,
+            VersionNumber = 1
+        };
+
+        var variable1 = new VariableEntity
+        {
+            Id = 100,
+            Name = "Variable 1",
+            Position = 2,
+            ComponentId = 1
+        };
+
+        var variable2 = new VariableEntity
+        {
+            Id = 200,
+            Name = "Variable 2",
+            Position = 1,
+            ComponentId = 2
+        };
+
+        context.Components.AddRange(component1, component2);
+        context.Polls.Add(poll);
+        context.Variables.AddRange(variable1, variable2);
+
+        context.PollVariables.AddRange(
+            new PollVariableJoin
+            {
+                Id = 1000,
+                PollId = 10,
+                VariableId = 100,
+                Version = version
+            },
+            new PollVariableJoin
+            {
+                Id = 2000,
+                PollId = 10,
+                VariableId = 200,
+                Version = version
+            });
+
+        await context.SaveChangesAsync();
+
+        var repository = new VariableRepository(context);
+
+        // Act
+        var result = await repository.GetAllByPollUuidAsync("poll-uuid", [], true);
+
+        // Assert
+        Assert.Single(result);
+
+        // Also verifies OrderBy(Position)
+        Assert.Equal("Variable 2", result[0].Name);
+    }
+
+    [Fact]
+    public async Task GetAllByPollUuidAsync_ShouldReturnEmpty_WhenPollUuidDoesNotExistAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var repository = new VariableRepository(context);
+
+        // Act
+        var result = await repository.GetAllByPollUuidAsync("unknown-poll", [], true);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetAllByPollUuidAsync_ShouldReturnEmpty_WhenNoVariablesMatchVersionAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var component = new ComponentEntity
+        {
+            Id = 1,
+            Name = "Component"
+        };
+
+        var poll = new PollEntity
+        {
+            Id = 10,
+            Uuid = "poll-uuid",
+            LastVersion = 2
+        };
+
+        var variable = new VariableEntity
+        {
+            Id = 100,
+            Name = "Variable",
+            Position = 1,
+            ComponentId = 1
+        };
+
+        var oldVersion = new Domain.Common.VersionInfo()
+        {
+            VersionDate = DateTime.Now,
+            VersionNumber = 1
+        };
+
+        context.Components.Add(component);
+        context.Polls.Add(poll);
+        context.Variables.Add(variable);
+
+        context.PollVariables.Add(new PollVariableJoin
+        {
+            Id = 1000,
+            PollId = 10,
+            VariableId = 100,
+            Version = oldVersion
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new VariableRepository(context);
+
+        // Act
+        var result = await repository.GetAllByPollUuidAsync("poll-uuid", [], true);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetByNameAndPollIdAsync_ShouldReturnVariable_WhenNameAndPollMatchAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var variable = new VariableEntity
+        {
+            Id = 1,
+            Name = "Variable 1",
+            Position = 1
+        };
+
+        var pollVariable = new PollVariableJoin
+        {
+            Id = 10,
+            PollId = 100,
+            VariableId = 1
+        };
+
+        context.Variables.Add(variable);
+        context.PollVariables.Add(pollVariable);
+
+        await context.SaveChangesAsync();
+
+        var repository = new VariableRepository(context);
+
+        // Act
+        var result = await repository.GetByNameAndPollIdAsync("Variable 1", 100);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Id);
+        Assert.Equal("Variable 1", result.Name);
+    }
+
+    [Fact]
+    public async Task GetByNameAndPollIdAsync_ShouldReturnNull_WhenPollDoesNotMatchAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var variable = new VariableEntity
+        {
+            Id = 1,
+            Name = "Variable 1",
+            Position = 1
+        };
+
+        context.Variables.Add(variable);
+
+        context.PollVariables.Add(new PollVariableJoin
+        {
+            Id = 10,
+            PollId = 100,
+            VariableId = 1
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new VariableRepository(context);
+
+        // Act
+        var result = await repository.GetByNameAndPollIdAsync("Variable 1", 999);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByNameAndPollIdAsync_ShouldReturnNull_WhenNameDoesNotMatchAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var variable = new VariableEntity
+        {
+            Id = 1,
+            Name = "Variable 1",
+            Position = 1
+        };
+
+        context.Variables.Add(variable);
+
+        context.PollVariables.Add(new PollVariableJoin
+        {
+            Id = 10,
+            PollId = 100,
+            VariableId = 1
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new VariableRepository(context);
+
+        // Act
+        var result = await repository.GetByNameAndPollIdAsync("Unknown", 100);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetAllWithNameAndPollIdAsync_ShouldReturnVariablesWithPollIdsAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var variable1 = new VariableEntity
+        {
+            Id = 1,
+            Name = "Variable 1",
+            Position = 1
+        };
+
+        var variable2 = new VariableEntity
+        {
+            Id = 2,
+            Name = "Variable 2",
+            Position = 2
+        };
+
+        context.Variables.AddRange(variable1, variable2);
+
+        context.PollVariables.AddRange(
+            new PollVariableJoin
+            {
+                Id = 10,
+                PollId = 100,
+                VariableId = 1
+            },
+            new PollVariableJoin
+            {
+                Id = 20,
+                PollId = 200,
+                VariableId = 2
+            });
+
+        await context.SaveChangesAsync();
+
+        var repository = new VariableRepository(context);
+
+        // Act
+        var result = await repository.GetAllWithNameAndPollIdAsync();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+
+        var result1 = result.Single(V => V.Id == 1);
+        var result2 = result.Single(V => V.Id == 2);
+
+        Assert.Equal("Variable 1", result1.Name);
+        Assert.Equal(100, result1.IdPoll);
+
+        Assert.Equal("Variable 2", result2.Name);
+        Assert.Equal(200, result2.IdPoll);
+    }
+
+    [Fact]
+    public async Task GetAllWithNameAndPollIdAsync_ShouldReturnEmpty_WhenNoPollVariablesExistAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        context.Variables.Add(new VariableEntity
+        {
+            Id = 1,
+            Name = "Variable 1",
+            Position = 1
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new VariableRepository(context);
+
+        // Act
+        var result = await repository.GetAllWithNameAndPollIdAsync();
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetByPollIdAsync_ShouldReturnVariablesForPollAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var variable1 = new VariableEntity
+        {
+            Id = 1,
+            Name = "Variable 1",
+            Position = 2
+        };
+
+        var variable2 = new VariableEntity
+        {
+            Id = 2,
+            Name = "Variable 2",
+            Position = 1
+        };
+
+        var variable3 = new VariableEntity
+        {
+            Id = 3,
+            Name = "Variable 3",
+            Position = 3
+        };
+
+        context.Variables.AddRange(
+            variable1,
+            variable2,
+            variable3);
+
+        context.PollVariables.AddRange(
+            new PollVariableJoin
+            {
+                Id = 10,
+                PollId = 100,
+                VariableId = 1
+            },
+            new PollVariableJoin
+            {
+                Id = 20,
+                PollId = 100,
+                VariableId = 2
+            },
+            new PollVariableJoin
+            {
+                Id = 30,
+                PollId = 200,
+                VariableId = 3
+            });
+
+        await context.SaveChangesAsync();
+
+        var repository = new VariableRepository(context);
+
+        // Act
+        var result = await repository.GetByPollIdAsync(100);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+
+        Assert.Contains(result, V =>
+            V.Id == 1 &&
+            V.Name == "Variable 1" &&
+            V.Position == 2 &&
+            V.IdPoll == 100);
+
+        Assert.Contains(result, V =>
+            V.Id == 2 &&
+            V.Name == "Variable 2" &&
+            V.Position == 1 &&
+            V.IdPoll == 100);
+
+        Assert.DoesNotContain(result, V => V.Id == 3);
+    }
+
+    [Fact]
+    public async Task GetByPollIdAsync_ShouldReturnEmpty_WhenPollHasNoVariablesAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        context.Variables.Add(new VariableEntity
+        {
+            Id = 1,
+            Name = "Variable 1",
+            Position = 1
+        });
+
+        context.PollVariables.Add(new PollVariableJoin
+        {
+            Id = 10,
+            PollId = 200,
+            VariableId = 1
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new VariableRepository(context);
+
+        // Act
+        var result = await repository.GetByPollIdAsync(100);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetByNameAndPositionAsync_ShouldReturnVariable_WhenNameAndPositionMatchAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        context.Variables.Add(new VariableEntity
+        {
+            Id = 1,
+            Name = "Variable 1",
+            Position = 5
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new VariableRepository(context);
+
+        // Act
+        var result = await repository.GetByNameAndPositionAsync("Variable 1", 5);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Id);
+        Assert.Equal("Variable 1", result.Name);
+        Assert.Equal(5, result.Position);
+    }
+
+    [Fact]
+    public async Task GetByNameAndPositionAsync_ShouldReturnNull_WhenPositionDoesNotMatchAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        context.Variables.Add(new VariableEntity
+        {
+            Id = 1,
+            Name = "Variable 1",
+            Position = 5
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new VariableRepository(context);
+
+        // Act
+        var result = await repository.GetByNameAndPositionAsync("Variable 1", 10);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByNameAndPositionAsync_ShouldReturnNull_WhenNameDoesNotMatchAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        context.Variables.Add(new VariableEntity
+        {
+            Id = 1,
+            Name = "Variable 1",
+            Position = 5
+        });
+
+        await context.SaveChangesAsync();
+
+        var repository = new VariableRepository(context);
+
+        // Act
+        var result = await repository.GetByNameAndPositionAsync("Unknown", 5);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByNameAndPositionAsync_ShouldReturnNull_WhenDatabaseIsEmptyAsync()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        var repository = new VariableRepository(context);
+
+        // Act
+        var result = await repository.GetByNameAndPositionAsync("Variable", 1);
+
+        // Assert
+        Assert.Null(result);
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Utils/RepositoryTestBase.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Utils/RepositoryTestBase.cs
@@ -1,0 +1,17 @@
+﻿using Eras.Infrastructure.Persistence.PostgreSQL;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
+
+public abstract class RepositoryTestBase
+{
+    protected static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new AppDbContext(options);
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Utils/TestAsyncEnumerable.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Utils/TestAsyncEnumerable.cs
@@ -1,0 +1,16 @@
+﻿using System.Linq.Expressions;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
+
+public class TestAsyncEnumerable<T>: EnumerableQuery<T>, IAsyncEnumerable<T>, IQueryable<T>
+{
+    public TestAsyncEnumerable(IEnumerable<T> Enumerable) : base(Enumerable) { }
+
+    public TestAsyncEnumerable(Expression Expression): base(Expression){}
+
+    public IAsyncEnumerator<T> GetAsyncEnumerator(
+        CancellationToken CancellationToken = default)
+        => new TestAsyncEnumerator<T>(this.AsEnumerable().GetEnumerator());
+
+    IQueryProvider IQueryable.Provider => new TestAsyncQueryProvider<T>(this);
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Utils/TestAsyncEnumerator.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Utils/TestAsyncEnumerator.cs
@@ -1,0 +1,20 @@
+﻿namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
+public class TestAsyncEnumerator<T> : IAsyncEnumerator<T>
+{
+    private readonly IEnumerator<T> _inner;
+
+    public TestAsyncEnumerator(IEnumerator<T> Inner)
+    {
+        _inner = Inner;
+    }
+
+    public T Current => _inner.Current;
+
+    public ValueTask<bool> MoveNextAsync() => new(_inner.MoveNext());
+
+    public ValueTask DisposeAsync()
+    {
+        _inner.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Utils/TestAsyncQueryProvider.cs
+++ b/test/Eras.Infrastructure.Tests/Persistence/PostgreSQL/Utils/TestAsyncQueryProvider.cs
@@ -1,0 +1,49 @@
+﻿
+using System.Linq.Expressions;
+
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace Eras.Infrastructure.Tests.Persistence.PostgreSQL.Utils;
+
+public class TestAsyncQueryProvider<TEntity> : IAsyncQueryProvider
+{
+    private readonly IQueryProvider _inner;
+    public TestAsyncQueryProvider(IQueryProvider Inner)
+    {
+        _inner = Inner;
+    }
+
+    public IQueryable CreateQuery(Expression Expression) => new TestAsyncEnumerable<TEntity>(Expression);
+
+    public IQueryable<TElement> CreateQuery<TElement>(Expression Expression) => new TestAsyncEnumerable<TElement>(Expression);
+
+    public object? Execute(Expression Expression) => _inner.Execute(Expression);
+
+    public TResult Execute<TResult>(Expression Expression) => _inner.Execute<TResult>(Expression);
+
+    public TResult ExecuteAsync<TResult>(
+    Expression Expression,
+    CancellationToken CancellationToken = default)
+    {
+        var resultType = typeof(TResult).GetGenericArguments()[0];
+
+        var executeMethod = typeof(IQueryProvider)
+            .GetMethods()
+            .Single(Method =>
+                Method.Name == nameof(IQueryProvider.Execute) &&
+                Method.IsGenericMethod &&
+                Method.GetParameters().Length == 1);
+
+        var executionResult = executeMethod
+            .MakeGenericMethod(resultType)
+            .Invoke(_inner, new object[] { Expression });
+
+        var taskResult = typeof(Task)
+            .GetMethod(nameof(Task.FromResult))!
+            .MakeGenericMethod(resultType)
+            .Invoke(null, new[] { executionResult });
+
+        return (TResult)taskResult!;
+    }
+
+}


### PR DESCRIPTION
## Description

The layer "Infrastructure" has an increment in code coverage.
Added unit tests for repositories:
- AnswerRepository
- AssessmentRepository
- BaseRepository<T> (It did not reach 70% code coverage on both sides)
- BaseRepository<T1, T2> (It did not reach 70% code coverage on both sides)
- CohortRepository
- ComponentRepository
- ComponentsAvgRepository
- ConfigurationsRepository
- ErasEvaluationDetailsViewRepository	
- EvaluationPollRepository
- EvaluationRepository
- FeatureFlagRepository
- HeatMapRepository	
- ImportJobItemRepository (It did not reach 70% code coverage on both sides)
- ImportJobRepository (It did not reach 70% code coverage on both sides)
- JUServiceRepository
- PollCohortRepository
- PollInstanceRepository
- PollRepository
- PollVariableRepository
- ProfessionalRepository
- ServiceProvidersRepository
- StudentAnswersRepository	
- StudentCohortRepository
- StudentDetailRepository
- StudentPollsRepository	
- StudentRepository
- VariableRepository

If you want the code coverage for the implemented unit tests filter by using "repository":
<img width="1696" height="292" alt="image" src="https://github.com/user-attachments/assets/cb49c068-7ae8-46ef-a3d7-82b88a9ac279" />

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation Improvements
- [x] Others: unit tests

## Checklist

- [ ] Have the requirements been met?
- [ ] Is the code easy to read?
- [ ] Do unit tests pass?
- [ ] Is the code formatted correctly?

## C# Checklist

- [ ] Does this code make correct use of asynchronous programming constructs, including proper use of await and Task.WhenAll including CancellationTokens?
- [ ] Does the code handle exceptions correctly
- [ ] Is the code subject to concurrency issues? Are shared objects properly protected?
- [ ] There are no complex long boolean expressions (i.e; x = isMatched ? shouldMatch ? doesMatch ? blahBlahBlah).
- [ ] There are no negatively named booleans (i.e; notMatchshould be isMatch and the logical negation operator (!) should be used.
- [ ] Are internal vs private vs public classes and methods used the right way?

## Related Issues

#474 